### PR TITLE
docs: add calibration reference near score description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ canicode analyze "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234"
 
 Each issue is classified: **Blocking** > **Risk** > **Missing Info** > **Suggestion**.
 
-Scores use density + diversity weighting per category, combined into an overall grade (S/A+/A/B+/B/C+/C/D/F).
+Scores use density + diversity weighting per category, combined into an overall grade (S/A+/A/B+/B/C+/C/D/F). Rule scores are calibrated against actual code conversion difficulty — see [Calibration](docs/CALIBRATION.md) for how scores are validated.
 
 ---
 


### PR DESCRIPTION
Link to CALIBRATION.md from the main scoring explanation so readers discover how rule scores are validated against real conversion difficulty.

https://claude.ai/code/session_01FgxFkbDJYzzWSMfQiavtAq