### PR TITLE
fix: resolve CanICode.parseFigmaUrl undefined error on web app

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,6 +1,7 @@
 // Browser entry point — exports analysis functions for client-side use
 // All imports here must be pure functions with no Node.js dependencies
 
+export { version as VERSION } from "../package.json";
 export { analyzeFile } from "./core/engine/rule-engine.js";
 export type { AnalysisResult, AnalysisIssue, RuleEngineOptions } from "./core/engine/rule-engine.js";
 export { calculateScores, formatScoreSummary, getCategoryLabel, getSeverityLabel, gradeToClassName } from "./core/engine/scoring.js";

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -2,7 +2,7 @@ import type { Category } from "../contracts/category.js";
 import { CATEGORIES } from "../contracts/category.js";
 import type { Severity } from "../contracts/severity.js";
 import type { AnalysisResult } from "./rule-engine.js";
-import { VERSION } from "../../index.js";
+import { version as VERSION } from "../../../package.json";
 
 /**
  * Score breakdown for a single category


### PR DESCRIPTION
## Summary

- `scoring.ts`가 `VERSION`을 `src/index.ts`에서 임포트하면서, Node.js 전용 모듈(`fs`, `path`, `os`, `crypto`)이 브라우저 IIFE 번들에 포함됨
- 번들 실행 시 `path`, `os$1` 등 정의되지 않은 전역 변수를 참조하여 `CanICode` 네임스페이스 전체가 `undefined`가 됨
- `VERSION` 임포트를 `package.json`에서 직접 읽도록 변경하여 Node.js 의존성 제거

## Root Cause

```
scoring.ts → import { VERSION } from "../../index.js"
  → src/index.ts re-exports everything
    → core/engine/config-store.ts (node:fs, node:crypto, node:os, node:path)
    → core/engine/loader.ts (node:fs, node:path)
    → core/engine/visual-compare.ts (node:fs, node:path)
    → agents/index.js ...
```

Bundle footer before: `})({},null,path,null,null,os$1);` — `path` and `os$1` are undefined in browser → ReferenceError → `CanICode = undefined`

Bundle footer after: `})({});` — no external dependencies

## Test plan

- [x] `pnpm build:web` — no Node.js module warnings
- [x] `pnpm build` — main build passes
- [x] `pnpm test:run` — 232 tests pass
- [ ] Open web app and verify Figma URL parsing works

https://claude.ai/code/session_01Myz9SrpE3RjuS2AndXUQmN