### PR TITLE
refactor: structurize mismatch reasoning parsing

### DIFF
--- a/src/agents/contracts/evaluation-agent.ts
+++ b/src/agents/contracts/evaluation-agent.ts
@@ -19,6 +19,8 @@ export const MismatchCaseSchema = z.object({
   currentSeverity: SeveritySchema.optional(),
   actualDifficulty: DifficultySchema,
   reasoning: z.string(),
+  category: z.string().optional(),
+  description: z.string().optional(),
 });
 
 export type MismatchCase = z.infer<typeof MismatchCaseSchema>;

--- a/src/agents/contracts/tuning-agent.ts
+++ b/src/agents/contracts/tuning-agent.ts
@@ -40,6 +40,8 @@ export interface TuningAgentInput {
     currentSeverity?: string | undefined;
     actualDifficulty: string;
     reasoning: string;
+    category?: string | undefined;
+    description?: string | undefined;
   }>;
   ruleScores: Record<string, { score: number; severity: string }>;
   priorEvidence?: CrossRunEvidence;

--- a/src/agents/evaluation-agent.ts
+++ b/src/agents/evaluation-agent.ts
@@ -161,6 +161,8 @@ export function runEvaluationAgent(
         nodePath: record.nodePath,
         actualDifficulty: estimatedDifficulty,
         reasoning: `Uncovered struggle: "${uncovered.description}" (category: ${uncovered.suggestedCategory}, impact: ${estimatedDifficulty}).`,
+        category: uncovered.suggestedCategory,
+        description: uncovered.description,
       });
     }
   }

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -297,10 +297,8 @@ export function runCalibrationEvaluate(
           const isNoise = ENVIRONMENT_NOISE_PATTERNS.some(p => p.test(m.reasoning));
           if (isNoise) continue;
 
-          const categoryMatch = m.reasoning.match(/category:\s*([^,)]+)/);
-          const category = categoryMatch?.[1]?.trim() ?? "unknown";
-          const descMatch = m.reasoning.match(/Uncovered struggle: "([^"]+)"/);
-          const description = descMatch?.[1] ?? m.reasoning;
+          const category = m.category ?? "unknown";
+          const description = m.description ?? m.reasoning;
           discoveryEntries.push({
             description,
             category,

--- a/src/agents/tuning-agent.test.ts
+++ b/src/agents/tuning-agent.test.ts
@@ -111,6 +111,8 @@ describe("runTuningAgent", () => {
           actualDifficulty: "hard",
           reasoning:
             'Uncovered struggle: "inconsistent border radius". category: border-radius',
+          category: "border-radius",
+          description: "inconsistent border radius",
         }),
         makeMismatch({
           type: "missing-rule",
@@ -118,6 +120,8 @@ describe("runTuningAgent", () => {
           actualDifficulty: "hard",
           reasoning:
             'Uncovered struggle: "mixed border radius values". category: border-radius',
+          category: "border-radius",
+          description: "mixed border radius values",
         }),
         makeMismatch({
           type: "missing-rule",
@@ -125,6 +129,8 @@ describe("runTuningAgent", () => {
           actualDifficulty: "moderate",
           reasoning:
             'Uncovered struggle: "no text truncation rule". category: text-overflow',
+          category: "text-overflow",
+          description: "no text truncation rule",
         }),
       ],
       ruleScores: {},

--- a/src/agents/tuning-agent.ts
+++ b/src/agents/tuning-agent.ts
@@ -226,9 +226,7 @@ export function runTuningAgent(
   const missingGrouped = new Map<string, typeof input.mismatches>();
 
   for (const c of missingRuleCases) {
-    // Extract category from reasoning pattern: "category: <value>"
-    const categoryMatch = c.reasoning.match(/category:\s*([^,)]+)/);
-    const category = categoryMatch?.[1]?.trim() ?? "unknown";
+    const category = c.category ?? "unknown";
 
     const existing = missingGrouped.get(category);
     if (existing) {
@@ -241,10 +239,7 @@ export function runTuningAgent(
   for (const [category, cases] of missingGrouped) {
     const difficulties = cases.map((c) => c.actualDifficulty);
     const dominantDifficulty = getDominantDifficulty(difficulties);
-    const descriptions = cases.map((c) => {
-      const descMatch = c.reasoning.match(/Uncovered struggle: "([^"]+)"/);
-      return descMatch?.[1] ?? c.reasoning;
-    });
+    const descriptions = cases.map((c) => c.description ?? c.reasoning);
 
     newRuleProposals.push({
       suggestedId: `new-${category}-rule`,


### PR DESCRIPTION
## Summary
- `MismatchCase` 스키마에 `category`, `description` 구조화 필드 추가
- `evaluation-agent.ts`에서 `missing-rule` 케이스 생성 시 구조화 필드 직접 설정
- `orchestrator.ts`, `tuning-agent.ts`의 정규식 파싱을 구조화 필드 직접 참조로 교체

## Test plan
- [x] `pnpm lint` 타입 체크 통과
- [x] `pnpm test:run` 전체 247개 테스트 통과

Closes #10

https://claude.ai/code/session_01PcNMomwVnU7jVHzupHhysq