### PR TITLE
refactor: parse debate.json with Zod schema (#32)

### DIFF
--- a/src/agents/run-directory.ts
+++ b/src/agents/run-directory.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync } from "node:fs";
 import { resolve, join, basename } from "node:path";
+import { z } from "zod";
 
 const CALIBRATION_DIR = "logs/calibration";
 const RULE_DISCOVERY_DIR = "logs/rule-discovery";
@@ -157,49 +158,61 @@ export function moveFixtureToDone(fixturePath: string, fixturesDir: string = DEF
   return dest;
 }
 
-// --- Debate result parsing ---
+// --- Debate result parsing (Zod-validated) ---
 
-export interface DebateDecision {
-  ruleId: string;
-  decision: string;
-  before?: number | undefined;
-  after?: number | undefined;
-  reason?: string | undefined;
-}
+const DebateDecisionSchema = z.object({
+  ruleId: z.string(),
+  decision: z.string(),
+  before: z.number().optional(),
+  after: z.number().optional(),
+  reason: z.string().optional(),
+}).passthrough();
 
-export interface DebateResult {
-  critic: {
-    summary: string;
-    reviews: Array<{
-      ruleId: string;
-      decision: string;
-      reason?: string | undefined;
-      revised?: number | undefined;
-    }>;
-  } | null;
-  arbitrator: {
-    summary: string;
-    decisions: DebateDecision[];
-    newRuleProposals?: unknown[];
-  } | null;
-  skipped?: string | undefined;
-}
+const CriticSchema = z.object({
+  summary: z.string(),
+  reviews: z.array(z.object({
+    ruleId: z.string(),
+    decision: z.string(),
+    reason: z.string().optional(),
+    revised: z.number().optional(),
+  }).passthrough()),
+}).passthrough();
+
+const ArbitratorSchema = z.object({
+  summary: z.string(),
+  decisions: z.array(DebateDecisionSchema),
+  newRuleProposals: z.array(z.unknown()).optional(),
+}).passthrough();
+
+const DebateResultSchema = z.object({
+  critic: CriticSchema.nullable().default(null),
+  arbitrator: ArbitratorSchema.nullable().default(null),
+  skipped: z.string().optional(),
+}).passthrough();
+
+/** A single decision from the Arbitrator in debate.json. */
+export type DebateDecision = z.infer<typeof DebateDecisionSchema>;
+
+/** Parsed debate.json structure from a calibration run. */
+export type DebateResult = z.infer<typeof DebateResultSchema>;
 
 /**
  * Parse a debate.json file from a run directory.
- * Returns null if the file doesn't exist or is malformed.
+ * Validates with Zod schema — returns null if file is missing or malformed.
  */
 export function parseDebateResult(runDir: string): DebateResult | null {
   const debatePath = join(runDir, "debate.json");
   if (!existsSync(debatePath)) return null;
   try {
-    const raw = JSON.parse(readFileSync(debatePath, "utf-8")) as Record<string, unknown>;
-    return {
-      critic: raw["critic"] as DebateResult["critic"] ?? null,
-      arbitrator: raw["arbitrator"] as DebateResult["arbitrator"] ?? null,
-      ...(typeof raw["skipped"] === "string" ? { skipped: raw["skipped"] } : {}),
-    };
-  } catch {
+    const raw: unknown = JSON.parse(readFileSync(debatePath, "utf-8"));
+    const result = DebateResultSchema.safeParse(raw);
+    if (!result.success) {
+      console.debug(`[parseDebateResult] invalid debate.json in ${runDir}:`, result.error.issues);
+      return null;
+    }
+    return result.data;
+  } catch (err) {
+    console.debug(`[parseDebateResult] failed to read debate.json in ${runDir}:`, err);
     return null;
   }
 }
@@ -210,8 +223,12 @@ export function parseDebateResult(runDir: string): DebateResult | null {
 export function extractAppliedRuleIds(debate: DebateResult): string[] {
   if (!debate.arbitrator) return [];
   return debate.arbitrator.decisions
-    .filter((d) => d.decision === "applied" || d.decision === "revised")
-    .map((d) => d.ruleId);
+    .filter((d) => {
+      const dec = d.decision.trim().toLowerCase();
+      return dec === "applied" || dec === "revised";
+    })
+    .map((d) => d.ruleId.trim())
+    .filter((id) => id.length > 0);
 }
 
 /**
@@ -225,7 +242,10 @@ export function isConverged(runDir: string): boolean {
   if (debate.skipped) return true; // zero proposals = converged
   if (!debate.arbitrator) return false;
   const decisions = debate.arbitrator.decisions;
-  const applied = decisions.filter((d) => d.decision === "applied" || d.decision === "revised").length;
-  const rejected = decisions.filter((d) => d.decision === "rejected").length;
+  const applied = decisions.filter((d) => {
+    const dec = d.decision.trim().toLowerCase();
+    return dec === "applied" || dec === "revised";
+  }).length;
+  const rejected = decisions.filter((d) => d.decision.trim().toLowerCase() === "rejected").length;
   return applied === 0 && rejected === 0;
 }


### PR DESCRIPTION
## Summary

debate.json 파싱을 ad-hoc type cast에서 Zod 스키마 기반으로 교체.

### 변경

- `DebateResultSchema`, `ArbitratorSchema`, `CriticSchema`, `DebateDecisionSchema` 추가
- `parseDebateResult`가 `safeParse`로 전체 shape 검증
- 실패 시 debug 로그 + null 반환
- `DebateDecision`/`DebateResult` 타입을 `z.infer`로 도출
- `.passthrough()`로 에이전트 출력의 추가 필드 허용

### 효과

- malformed nested shape가 파싱 시점에 걸림 (기존: 하위 코드까지 흘러감)
- `isDecisionRecord` 같은 런타임 가드 불필요
- 에러 원인 추적 용이 (Zod issues 로그)

## Test plan

- [x] `pnpm test:run` — 302 tests passed
- [x] `pnpm lint` — clean

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)