### PR TITLE
fix: set restrictive file permissions on config storing FIGMA_TOKEN

### DIFF
--- a/src/core/engine/config-store.ts
+++ b/src/core/engine/config-store.ts
@@ -15,11 +15,17 @@ interface AireadyConfig {
   deviceId?: string;
 }
 
+function hardenPermissions(path: string, mode: number): void {
+  if (process.platform !== "win32") {
+    chmodSync(path, mode);
+  }
+}
+
 function ensureDir(dir: string): void {
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  chmodSync(dir, 0o700);
+  hardenPermissions(dir, 0o700);
 }
 
 export function readConfig(): AireadyConfig {
@@ -40,7 +46,7 @@ export function writeConfig(config: AireadyConfig): void {
     encoding: "utf-8",
     mode: 0o600,
   });
-  chmodSync(CONFIG_PATH, 0o600);
+  hardenPermissions(CONFIG_PATH, 0o600);
 }
 
 export function getFigmaToken(): string | undefined {
@@ -67,6 +73,7 @@ export function getReportsDir(): string {
 }
 
 export function ensureReportsDir(): void {
+  ensureDir(AIREADY_DIR);
   ensureDir(REPORTS_DIR);
 }
 


### PR DESCRIPTION
## Summary

- `~/.canicode/` 디렉토리 생성 시 `0o700` (소유자만 rwx) 퍼미션 설정
- `config.json` 파일 생성 시 `0o600` (소유자만 rw) 퍼미션 설정
- `FIGMA_TOKEN` 등 민감 정보가 다른 사용자에게 노출되는 보안 취약점 수정

Closes #53

## Changes

`src/core/engine/config-store.ts` — 2줄 변경:
```diff
- mkdirSync(dir, { recursive: true });
+ mkdirSync(dir, { recursive: true, mode: 0o700 });

- writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
+ writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", {
+   encoding: "utf-8",
+   mode: 0o600,
+ });
```

## Test plan

- [x] `pnpm lint` — 타입 체크 통과
- [x] `pnpm test:run` — 27 파일 388 테스트 전체 통과
- [ ] `canicode init --token <test>` 후 `ls -la ~/.canicode/` 및 `ls -la ~/.canicode/config.json`으로 퍼미션 확인

https://claude.ai/code/session_015Rux1jwqHtfmXwZ5MtMf2Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configuration storage now enforces explicit POSIX permissions for created directories and config files.
  * Directories are created with restricted access and file writes apply stricter file permissions to reduce exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->