### PR TITLE
fix: separate stdout/stderr in --json mode (#61)

### DIFF
--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -49,6 +49,8 @@ export function registerAnalyze(cli: CAC): void {
     .example("  canicode analyze ./fixtures/my-design --config ./my-config.json")
     .action(async (input: string, options: AnalyzeOptions) => {
       const analysisStart = Date.now();
+      // In --json mode, progress goes to stderr so stdout stays machine-readable
+      const log = options.json ? console.error : console.log;
       trackEvent(EVENTS.ANALYSIS_STARTED, { source: isJsonFile(input) || isFixtureDir(input) ? "fixture" : "figma" });
       try {
         // Check init
@@ -66,7 +68,7 @@ export function registerAnalyze(cli: CAC): void {
               "ANTHROPIC_API_KEY required for --screenshot mode. Set it in .env or environment."
             );
           }
-          console.log("Screenshot comparison mode enabled (coming soon).\n");
+          log("Screenshot comparison mode enabled (coming soon).\n");
         }
 
         // Load file
@@ -82,7 +84,7 @@ export function registerAnalyze(cli: CAC): void {
             const picked = pickRandomScope(file.document);
             if (picked) {
               effectiveNodeId = picked.id;
-              console.log(`\nAuto-scoped to "${picked.name}" (${picked.id}, ${countNodes(picked)} nodes) — file too large (${totalNodes} nodes) for unscoped analysis.`);
+              log(`\nAuto-scoped to "${picked.name}" (${picked.id}, ${countNodes(picked)} nodes) — file too large (${totalNodes} nodes) for unscoped analysis.`);
             } else {
               console.warn(`\nWarning: Could not find a suitable scope in fixture. Analyzing all ${totalNodes} nodes.`);
             }
@@ -101,8 +103,8 @@ export function registerAnalyze(cli: CAC): void {
           console.warn("Tip: Add ?node-id=XXX to analyze a specific section.\n");
         }
 
-        console.log(`\nAnalyzing: ${file.name}`);
-        console.log(`Nodes: ${totalNodes}`);
+        log(`\nAnalyzing: ${file.name}`);
+        log(`Nodes: ${totalNodes}`);
 
         // Build rule configs: start from preset or defaults
         let configs: Record<string, RuleConfig> = options.preset
@@ -118,7 +120,7 @@ export function registerAnalyze(cli: CAC): void {
           configs = mergeConfigs(configs, configFile);
           excludeNodeNames = configFile.excludeNodeNames;
           excludeNodeTypes = configFile.excludeNodeTypes;
-          console.log(`Config loaded: ${options.config}`);
+          log(`Config loaded: ${options.config}`);
         }
 
         // Load and register custom rules
@@ -128,7 +130,7 @@ export function registerAnalyze(cli: CAC): void {
             ruleRegistry.register(rule);
           }
           configs = { ...configs, ...customConfigs };
-          console.log(`Custom rules loaded: ${rules.length} rules from ${options.customRules}`);
+          log(`Custom rules loaded: ${rules.length} rules from ${options.customRules}`);
         }
 
         // Build analysis options
@@ -141,7 +143,7 @@ export function registerAnalyze(cli: CAC): void {
 
         // Run analysis
         const result = analyzeFile(file, analyzeOptions);
-        console.log(`Nodes: ${result.nodeCount} (max depth: ${result.maxDepth})`);
+        log(`Nodes: ${result.nodeCount} (max depth: ${result.maxDepth})`);
 
         // Calculate scores
         const scores = calculateScores(result);
@@ -149,6 +151,10 @@ export function registerAnalyze(cli: CAC): void {
         // JSON output mode
         if (options.json) {
           console.log(JSON.stringify(buildResultJson(file.name, result, scores), null, 2));
+          // Exit with error code if grade is F (CI support)
+          if (scores.overall.grade === "F") {
+            process.exitCode = 1;
+          }
           return;
         }
 

--- a/src/cli/commands/internal/calibrate-gap-report.ts
+++ b/src/cli/commands/internal/calibrate-gap-report.ts
@@ -29,6 +29,8 @@ export function registerCalibrateGapReport(cli: CAC): void {
     })
     .option("--json", "Print JSON summary to stdout")
     .action(async (options: CalibrateGapReportOptions) => {
+      // In --json mode, progress goes to stderr so stdout stays machine-readable
+      const log = options.json ? console.error : console.log;
       try {
         const minRepeat = Math.max(1, parseInt(options.minRepeat ?? "2", 10) || 2);
         const result = generateGapRuleReport({
@@ -52,16 +54,16 @@ export function registerCalibrateGapReport(cli: CAC): void {
             const ts = match[1].replace(/[:.]/g, "-").replace("T", "-").replace("Z", "");
             const backupPath = outPath.replace(/\.md$/, `--${ts}.md`);
             await writeFile(backupPath, existing, "utf-8");
-            console.log(`  Previous report backed up: ${backupPath}`);
+            log(`  Previous report backed up: ${backupPath}`);
           }
         }
 
         await writeFile(outPath, result.markdown, "utf-8");
 
-        console.log("Gap rule review report written.");
-        console.log(`  Runs with gaps: ${result.gapRunCount}`);
-        console.log(`  Runs with snapshots: ${result.runCount}`);
-        console.log(`  Output: ${outPath}`);
+        log("Gap rule review report written.");
+        log(`  Runs with gaps: ${result.gapRunCount}`);
+        log(`  Runs with snapshots: ${result.runCount}`);
+        log(`  Output: ${outPath}`);
 
         if (options.json) {
           console.log(

--- a/src/cli/commands/visual-compare.ts
+++ b/src/cli/commands/visual-compare.ts
@@ -62,7 +62,7 @@ export function registerVisualCompare(cli: CAC): void {
 
         const hasViewportOverride = width !== undefined || height !== undefined;
 
-        console.log("Comparing...");
+        console.error("Comparing...");
         const result = await visualCompare({
           figmaUrl: options.figmaUrl,
           figmaToken: token,


### PR DESCRIPTION
## Summary

- **analyze --json**: Progress messages (`Analyzing:`, `Nodes:`, config/custom-rules loaded) now go to `stderr`, keeping `stdout` as pure JSON
- **analyze --json + grade F**: Fixed exit code being silently skipped — now correctly sets `process.exitCode = 1` (CI support)
- **visual-compare**: "Comparing..." message moved to `stderr` (this command always outputs JSON)
- **calibrate-gap-report --json**: Progress messages routed to `stderr`

## Problem

`--json` mode promised machine-readable output but was broken in 3 ways:

1. `canicode analyze --json | jq .scores` → parse failure (progress messages mixed into stdout)
2. `canicode analyze --json` with grade F → exit code 0 (early return skipped the grade check)
3. `canicode visual-compare` → "Comparing..." prefixed to JSON output

## Test plan

- [x] `pnpm lint` passes (tsc --noEmit)
- [x] `pnpm test:run` passes (427/427 tests)
- [ ] Manual: `canicode analyze fixtures/material3-kit --json 2>/dev/null | jq .scores` parses cleanly
- [ ] Manual: `canicode analyze fixtures/material3-kit --json` shows progress on stderr only

Closes #61

https://claude.ai/code/session_018Y1Y4GuLuyeUEp5vHnuUKu