### PR TITLE
fix: correct PRIVACY.md to match actual telemetry implementation

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -43,7 +43,7 @@ Telemetry uses **pseudonymous identifiers** that vary by channel. These allow us
 
 **What this means:**
 - For CLI/MCP: we can see that "the same device" ran multiple analyses, but we cannot link this to a person, email, or account. Deleting `~/.canicode/config.json` resets the identifier.
-- For Figma Plugin: we can see that "the same hashed ID" used the plugin across sessions. The hash is not reversible to the original Figma user ID.
+- For Figma Plugin: we can see that "the same hashed ID" used the plugin across sessions. FNV-1a is a non-cryptographic hash, but Figma user IDs have sufficient entropy to make practical reversal infeasible.
 - For Web App: all users share the same identifier — we see only aggregate counts.
 
 ## How to Opt Out


### PR DESCRIPTION
## Summary
- PRIVACY.md claimed all telemetry uses `distinctId: "anonymous"` but CLI/MCP use a stable device UUID and Figma Plugin uses a hashed Figma user ID
- Updated "Anonymous Tracking" → "Pseudonymous Tracking" with per-channel breakdown table (CLI, MCP, Plugin, Web App)
- Replaced all "anonymous" language with accurate "pseudonymous" terminology throughout the document

## Why
Code and privacy documentation directly contradicted each other — a trust issue for an open-source project. Adopts Option 3 (per-channel documentation) from #73 to be fully transparent.

## Test plan
- [ ] Verify PRIVACY.md renders correctly on GitHub (table formatting, anchor links)
- [ ] Confirm no other files (README, npm description) reference "anonymous telemetry" that need updating

Closes #73

https://claude.ai/code/session_01BQetjpwUEMxfrnNLresCqq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy policy with enhanced clarity on telemetry and data collection practices
  * Documented platform-specific tracking methods with unique identifiers
  * Strengthened commitments regarding personally identifiable information protection
  * Refined third-party service data handling information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->