### PR TITLE
fix: correct TOTAL_RULES_PER_CATEGORY counts (layout 9→8, handoff-risk 3→4)

### DIFF
--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -73,12 +73,12 @@ const SEVERITY_DENSITY_WEIGHT: Record<Severity, number> = {
  * Must be updated when rules are added/removed from a category.
  */
 const TOTAL_RULES_PER_CATEGORY: Record<Category, number> = {
-  layout: 9,
+  layout: 8,
   token: 7,
   component: 3,
   naming: 5,
   "ai-readability": 5,
-  "handoff-risk": 3,
+  "handoff-risk": 4,
 };
 
 /**


### PR DESCRIPTION
## Summary
- `deep-nesting` rule is defined in `layout/index.ts` but has `category: "handoff-risk"`
- `TOTAL_RULES_PER_CATEGORY.layout` was 9, should be 8
- `TOTAL_RULES_PER_CATEGORY["handoff-risk"]` was 3, should be 4

Phase 0 of #79 — git blame 추적성 확보를 위해 선행 커밋으로 분리.

## Test plan
- [x] `pnpm test:run` — 636 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted scoring calculation constants to improve the accuracy of category scores and diversity measurements in evaluation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->