### PR TITLE
docs: refactor README branding and positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ claude mcp add canicode -- npx -y -p canicode canicode-mcp
 | **[Web App](https://let-sunny.github.io/canicode/)** | Quick check, no install |
 | **[Figma Plugin](https://www.figma.com/community/plugin/1617144221046795292/canicode)** | Analyze inside Figma (under review) |
 | **MCP Server** | Claude Code / Cursor / Claude Desktop integration |
-| **[Claude Code Skill](https://github.com/let-sunny/canicode#claude-code-skill)** | Lightweight, no MCP install |
+| **Claude Code Skill** | Lightweight, no MCP install |
 | **CLI** | Full control, CI/CD, offline analysis |
-| **[`canicode implement`](https://github.com/let-sunny/canicode#design-to-code)** | Generate code-ready package (analysis + assets + prompt) |
+| **`canicode implement`** | Generate code-ready package (analysis + assets + prompt) |
 | **[GitHub Action](https://github.com/marketplace/actions/canicode-action)** | PR gate with score threshold |
 
 </details>


### PR DESCRIPTION
## Summary

#72 — README 브랜딩/포지셔닝 리팩터

### Changes
- **Single value proposition**: "Predicts where your Figma design will break when AI implements it"
- **Calibration promoted**: From buried feature to "Why CanICode" core section
- **Badges**: 7 → 3 (npm, CI, Release)
- **Structure**: Why → Getting Started → What It Checks → Installation details
- **Getting Started**: Primary entry (web app + CLI) prominent, channels in expandable section
- **Roadmap removed**: 8 completed phases → Contributing section with fixture sharing CTA
- **Categories updated**: New 5-category table (Structure 9, Token 7, Component 4, Naming 5, Behavior 4)

### Principles from issue
- Hierarchy: existence reason > how it works > where to use it
- One-line test: first two lines should explain what the product does
- Channels are implementation details, not product identity

Closes #72

## Test plan
- [ ] Visual review of rendered README on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated header messaging and removed top-center badges/links
  * Replaced “How It Works” with “Why CanICode”: 29 rules across 5 dimensions and revised calibration description
  * Added “What It Checks” overview (5 categories) and clarified score direction
  * Streamlined Getting Started with “Quickest way”, an “All channels” table, and a CLI vs. MCP comparison
  * Reorganized Installation and Design-to-Code docs; replaced Roadmap with Contributing guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->