### PR TITLE
fix: map actualImpact to Difficulty enum in orchestrator

### DIFF
--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -19,6 +19,24 @@ import {
 import type { CalibrationEvidenceEntry, DiscoveryEvidenceEntry } from "./evidence-collector.js";
 
 /**
+ * Normalize Converter's actualImpact (none/low/medium/high) to Difficulty enum (easy/moderate/hard/failed).
+ * Falls back to "moderate" for unknown values.
+ */
+function normalizeActualImpact(impact: string): string {
+  const mapping: Record<string, string> = {
+    none: "easy",
+    low: "easy",
+    easy: "easy",
+    medium: "moderate",
+    moderate: "moderate",
+    high: "hard",
+    hard: "hard",
+    failed: "failed",
+  };
+  return mapping[impact] ?? "moderate";
+}
+
+/**
  * Patterns that indicate environment/tooling noise rather than design issues.
  * Used to filter out non-actionable entries from discovery evidence.
  */
@@ -239,7 +257,7 @@ export function runCalibrationEvaluate(
       ruleRelatedStruggles: assessment.map(a => ({
         ruleId: a.ruleId,
         description: a.description,
-        actualImpact: a.actualImpact === "none" ? "easy" : a.actualImpact === "low" ? "easy" : a.actualImpact === "medium" ? "moderate" : a.actualImpact === "high" ? "hard" : a.actualImpact,
+        actualImpact: normalizeActualImpact(a.actualImpact),
       })),
       uncoveredStruggles: struggles,
     }];


### PR DESCRIPTION
## Summary
Converter's `ruleImpactAssessment` uses `none/low/medium/high` but evaluation agent expects `easy/moderate/hard/failed`. Missing mapping caused crash (`Cannot read properties of undefined reading 'min'`).

- `none` → `easy`
- `low` → `easy`  
- `medium` → `moderate`
- `high` → `hard`

Found during calibrate-night run (#89).

## Test plan
- [x] 590 tests pass
- [x] E2E verified: calibrate-evaluate now produces proposals correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of impact levels used during calibration evaluations: various synonyms and edge values now map consistently to standardized difficulty levels (e.g., none/low/easy → easy; medium/moderate → moderate; high/hard → hard; failed remains failed), reducing misclassification and improving downstream consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->