### PR TITLE
refactor: codify calibration tier and difficulty thresholds

### DIFF
--- a/.claude/agents/calibration/converter.md
+++ b/.claude/agents/calibration/converter.md
@@ -62,13 +62,13 @@ Read and follow `.claude/skills/design-to-code/PROMPT.md` for all code generatio
    ```
    This saves `figma.png`, `code.png`, and `diff.png` into the run directory.
    Replace `:` with `-` in the nodeId for the URL.
-5. Use similarity to determine overall difficulty:
+5. Use similarity to determine overall difficulty (thresholds defined in `src/agents/orchestrator.ts` → `SIMILARITY_DIFFICULTY_THRESHOLDS`):
 
    | Similarity | Difficulty |
    |-----------|-----------|
    | 90%+ | easy |
-   | 70-90% | moderate |
-   | 50-70% | hard |
+   | 70-89% | moderate |
+   | 50-69% | hard |
    | <50% | failed |
 
 6. **MANDATORY — Rule Impact Assessment**: For EVERY rule ID in `nodeIssueSummaries[].flaggedRuleIds`, assess its actual impact on conversion. Read the analysis JSON, collect all unique `flaggedRuleIds`, and for each one write an entry in `ruleImpactAssessment`. This array MUST NOT be empty if there are flagged rules.

--- a/.claude/commands/calibrate-loop-deep.md
+++ b/.claude/commands/calibrate-loop-deep.md
@@ -33,26 +33,21 @@ npx canicode calibrate-analyze "$ARGUMENTS" --run-dir $RUN_DIR
 
 Read `$RUN_DIR/analysis.json`. If `issueCount` is 0, stop here.
 
-Check the grade from `scoreReport.overall.grade` and `scoreReport.overall.percentage` and branch into 3 tiers:
+Read the `calibrationTier` field from `analysis.json`. The CLI determines the tier based on grade percentage. Branch accordingly:
 
-- **A or higher (percentage >= 90)**: Full pipeline — proceed to Step 2 (Converter + visual-compare + Gap Analysis)
-- **B to B+ (percentage 68-89)**: Converter + visual-compare, but **skip Step 3 (Gap Analysis)**.
-- **Below B (percentage < 68)**: Skip Steps 2-3 entirely. Jump to Step 4 (Evaluation).
+- **`"full"`**: Full pipeline — proceed to Step 2 (Converter + visual-compare + Gap Analysis)
+- **`"visual-only"`**: Converter + visual-compare, but **skip Step 3 (Gap Analysis)**. Gap analysis on diff images is only meaningful at high similarity.
+
+**Always run the Converter** regardless of tier. Low-scoring designs need score validation the most.
 
 Append to `$RUN_DIR/activity.jsonl`:
 ```json
-{"step":"Analysis","timestamp":"<ISO8601>","result":"nodes=<N> issues=<N> grade=<X> (<N>%) tier=<full|visual-only|skip>","durationMs":<ms>}
+{"step":"Analysis","timestamp":"<ISO8601>","result":"nodes=<N> issues=<N> grade=<X> (<N>%) tier=<calibrationTier>","durationMs":<ms>}
 ```
 
-If skipping visual-compare entirely (< 68%), also append:
+If tier is `"visual-only"`, append after Converter completes:
 ```json
-{"step":"Converter","timestamp":"<ISO8601>","result":"SKIPPED — grade below B (<percentage>%)","durationMs":0}
-{"step":"Gap Analyzer","timestamp":"<ISO8601>","result":"SKIPPED — no visual-compare data","durationMs":0}
-```
-
-If skipping only Gap Analysis (68-89%), append after Converter completes:
-```json
-{"step":"Gap Analyzer","timestamp":"<ISO8601>","result":"SKIPPED — grade below A (<percentage>%), visual-compare only","durationMs":0}
+{"step":"Gap Analyzer","timestamp":"<ISO8601>","result":"SKIPPED — tier=visual-only, gap analysis skipped","durationMs":0}
 ```
 
 ### Step 2 — Converter

--- a/.claude/commands/calibrate-loop.md
+++ b/.claude/commands/calibrate-loop.md
@@ -33,21 +33,21 @@ npx canicode calibrate-analyze $ARGUMENTS --run-dir $RUN_DIR
 
 Read `$RUN_DIR/analysis.json`. If `issueCount` is 0, stop here.
 
-Check the grade from `scoreReport.overall.grade` and `scoreReport.overall.percentage` and branch into 2 tiers:
+Read the `calibrationTier` field from `analysis.json`. The CLI determines the tier based on grade percentage. Branch accordingly:
 
-- **A or higher (percentage >= 90)**: Full pipeline — proceed to Step 2 (Converter + visual-compare + Gap Analysis)
-- **Below A (percentage < 90)**: Converter + visual-compare, but **skip Step 3 (Gap Analysis)**. Gap analysis on diff images is only meaningful at high similarity.
+- **`"full"`**: Full pipeline — proceed to Step 2 (Converter + visual-compare + Gap Analysis)
+- **`"visual-only"`**: Converter + visual-compare, but **skip Step 3 (Gap Analysis)**. Gap analysis on diff images is only meaningful at high similarity.
 
-**Always run the Converter** regardless of grade. Low-scoring designs need score validation the most — skipping visual-compare on them means we can never verify if their scores are accurate.
+**Always run the Converter** regardless of tier. Low-scoring designs need score validation the most.
 
 Append to `$RUN_DIR/activity.jsonl`:
 ```json
-{"step":"Analysis","timestamp":"<ISO8601>","result":"nodes=<N> issues=<N> grade=<X> (<N>%) tier=<full|visual-only>","durationMs":<ms>}
+{"step":"Analysis","timestamp":"<ISO8601>","result":"nodes=<N> issues=<N> grade=<X> (<N>%) tier=<calibrationTier>","durationMs":<ms>}
 ```
 
-If skipping Gap Analysis (< 90%), append after Converter completes:
+If tier is `"visual-only"`, append after Converter completes:
 ```json
-{"step":"Gap Analyzer","timestamp":"<ISO8601>","result":"SKIPPED — grade below A (<percentage>%), visual-compare only","durationMs":0}
+{"step":"Gap Analyzer","timestamp":"<ISO8601>","result":"SKIPPED — tier=visual-only, gap analysis skipped","durationMs":0}
 ```
 
 ### Step 2 — Converter

--- a/docs/CALIBRATION.md
+++ b/docs/CALIBRATION.md
@@ -55,14 +55,14 @@ Step 6.5 — Prune Evidence
 
 ### Tiered Approach
 
-Not all fixtures go through the full pipeline. The tier is based on the current grade:
+Not all fixtures go through the full pipeline. The tier is determined by `calibrate-analyze` CLI and output as `calibrationTier` in `analysis.json` (thresholds defined in `src/agents/orchestrator.ts` → `CALIBRATION_TIER_THRESHOLDS`):
 
-| Grade | Pipeline | Rationale |
-|-------|----------|-----------|
-| A+ and above | Full pipeline (Converter + Gap Analysis) | High-quality designs benefit from gap analysis |
-| Below A | Converter + visual-compare only (skip gap analysis) | Low-scoring designs need score validation the most |
+| Tier | Grade | Pipeline | Rationale |
+|------|-------|----------|-----------|
+| `full` | A+ and above (≥90%) | Converter + Gap Analysis | High-quality designs benefit from gap analysis |
+| `visual-only` | Below A (<90%) | Converter + visual-compare only | Low-scoring designs need score validation the most |
 
-**Always run the Converter** regardless of grade. Skipping visual-compare on low-scoring designs means scores can never be validated.
+**Always run the Converter** regardless of tier. Skipping visual-compare on low-scoring designs means scores can never be validated.
 
 ## Agents
 

--- a/src/agents/orchestrator.ts
+++ b/src/agents/orchestrator.ts
@@ -37,6 +37,45 @@ function normalizeActualImpact(impact: string): string {
 }
 
 /**
+ * Calibration tier thresholds (percentage-based).
+ * - "full": Converter + visual-compare + Gap Analysis
+ * - "visual-only": Converter + visual-compare (Gap Analysis skipped)
+ */
+export const CALIBRATION_TIER_THRESHOLDS = {
+  full: 90,       // A or higher
+  visualOnly: 0,  // everything else — always run Converter
+} as const;
+
+export type CalibrationTier = "full" | "visual-only";
+
+/**
+ * Determine calibration tier from analysis percentage.
+ */
+export function determineCalibrationTier(percentage: number): CalibrationTier {
+  if (percentage >= CALIBRATION_TIER_THRESHOLDS.full) return "full";
+  return "visual-only";
+}
+
+/**
+ * Map visual-compare similarity percentage to conversion difficulty.
+ * Used by Converter and Evaluation agents.
+ */
+export const SIMILARITY_DIFFICULTY_THRESHOLDS = {
+  easy: 90,
+  moderate: 70,
+  hard: 50,
+} as const;
+
+export type ConversionDifficulty = "easy" | "moderate" | "hard" | "failed";
+
+export function similarityToDifficulty(similarity: number): ConversionDifficulty {
+  if (similarity >= SIMILARITY_DIFFICULTY_THRESHOLDS.easy) return "easy";
+  if (similarity >= SIMILARITY_DIFFICULTY_THRESHOLDS.moderate) return "moderate";
+  if (similarity >= SIMILARITY_DIFFICULTY_THRESHOLDS.hard) return "hard";
+  return "failed";
+}
+
+/**
  * Patterns that indicate environment/tooling noise rather than design issues.
  * Used to filter out non-actionable entries from discovery evidence.
  */

--- a/src/cli/commands/internal/calibrate-analyze.ts
+++ b/src/cli/commands/internal/calibrate-analyze.ts
@@ -6,6 +6,7 @@ import type { CAC } from "cac";
 import {
   runCalibrationAnalyze,
   filterConversionCandidates,
+  determineCalibrationTier,
 } from "../../../agents/orchestrator.js";
 
 interface CalibrateAnalyzeOptions {
@@ -47,12 +48,16 @@ export function registerCalibrateAnalyze(cli: CAC): void {
           analysisOutput.analysisResult.file.document
         );
 
+        const percentage = analysisOutput.scoreReport.overall.percentage;
+        const calibrationTier = determineCalibrationTier(percentage);
+
         const outputData = {
           fileKey,
           fileName: analysisOutput.analysisResult.file.name,
           analyzedAt: analysisOutput.analysisResult.analyzedAt,
           nodeCount: analysisOutput.analysisResult.nodeCount,
           issueCount: analysisOutput.analysisResult.issues.length,
+          calibrationTier,
           scoreReport: analysisOutput.scoreReport,
           nodeIssueSummaries: filteredSummaries,
           ruleScores,
@@ -71,7 +76,8 @@ export function registerCalibrateAnalyze(cli: CAC): void {
         console.log(`  Nodes: ${outputData.nodeCount}`);
         console.log(`  Issues: ${outputData.issueCount}`);
         console.log(`  Nodes with issues: ${outputData.nodeIssueSummaries.length}`);
-        console.log(`  Grade: ${outputData.scoreReport.overall.grade} (${outputData.scoreReport.overall.percentage}%)`);
+        console.log(`  Grade: ${outputData.scoreReport.overall.grade} (${percentage}%)`);
+        console.log(`  Calibration tier: ${calibrationTier}`);
         console.log(`\nOutput saved: ${outputPath}`);
       } catch (error) {
         console.error(


### PR DESCRIPTION
## Summary
- Tier 결정 로직과 similarity→difficulty 매핑을 프롬프트에서 코드로 이동
- `calibrate-analyze` CLI가 `analysis.json`에 `calibrationTier` 필드 출력
- 프롬프트는 tier를 직접 계산하지 않고 `analysis.json`의 값을 읽음
- `calibrate-loop-deep.md`의 옛 3-tier 로직도 함께 수정 (PR #91 누락분)

Refs #89

## Test plan
- [ ] `pnpm test:run` — 590 tests pass
- [ ] `pnpm lint` — type check pass
- [ ] `pnpm build` — build success
- [ ] Manual: `npx canicode calibrate-analyze fixtures/simple-ds-4333-9262 --run-dir /tmp/test-tier` → analysis.json에 `calibrationTier` 필드 확인

https://claude.ai/code/session_017n9jQMQWFoEE3Mje7MfgXs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calibration system now uses tier-based routing ("full" vs "visual-only") instead of grade-based logic for workflow decisions.
  * CLI calibration output now includes a calibration tier indicator.

* **Documentation**
  * Updated calibration guidance to reflect tier-based routing and updated difficulty thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->