### PR TITLE
fix: simplify Figma comment to enriched message only

### DIFF
--- a/app/web/src/index.html
+++ b/app/web/src/index.html
@@ -417,6 +417,7 @@
       var commentBody = '[CanICode] ' + btn.dataset.message;
       btn.disabled = true;
       btn.textContent = 'Sending...';
+      btn.title = '';
       try {
         var res = await fetch('https://api.figma.com/v1/files/' + fileKey + '/comments', {
           method: 'POST',

--- a/src/core/report-html/index.ts
+++ b/src/core/report-html/index.ts
@@ -171,6 +171,7 @@ ${figmaToken ? `  <script>
 
       btn.disabled = true;
       btn.textContent = 'Sending...';
+      btn.title = '';
 
       try {
         const res = await fetch('https://api.figma.com/v1/files/' + fileKey + '/comments', {


### PR DESCRIPTION
## Summary
- Figma 코멘트 본문을 고도화된 violation.message만 보내도록 간소화
- 중복된 why/impact/fix 정적 텍스트 제거 (PR #96에서 message에 이미 수정 방향 포함)
- 에러 핸들링 개선: 403/404/429 구분 + hover시 상세 에러 표시
- 웹앱 + CLI HTML 리포트 양쪽 동일하게 수정

Before:
```
[CanICode] No Auto Layout

Fix: Apply Auto Layout to create clear...
Why: Without Auto Layout, AI must guess...
Impact: Generated code uses hardcoded...

Frame "Card" has no auto-layout...
Node: Page > Card
```

After:
```
[CanICode] No Auto Layout
Frame "Card" has no auto-layout (3 children arranged vertically) — apply VERTICAL auto-layout
Node: Page > Card
```

Closes #98

## Test plan
- [x] `pnpm lint` pass
- [x] `pnpm test:run` — 592 tests pass
- [ ] 웹앱에서 코멘트 버튼 동작 확인 (Figma 토큰 필요)

https://claude.ai/code/session_017n9jQMQWFoEE3Mje7MfgXs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Figma comment submission error handling with HTTP status–specific messages (400/403/404/429 and default). Failed submissions now show "Failed" (no ✗) and display the error text as a tooltip; server responses are appended (truncated) when available.

* **Changes**
  * Comments sent to Figma now contain only the user-facing message (prefixed with a short tag) and exclude diagnostic metadata.
  * Analytics for successful comments no longer include the rule property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->