### PR TITLE
docs: add PR workflow rules to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,15 @@ pnpm lint           # Type check
 
 - Commit messages: conventional commits (feat, fix, docs, refactor, test, chore)
 
+### PR Workflow
+
+1. Always create PRs as **draft** first — wait for user approval before marking ready
+2. When changes are needed, convert back to **draft** — mark ready again when done
+3. After creating a PR, **subscribe** with `subscribe_pr_activity` to monitor reviews and CI in real-time
+4. After each push, watch for CodeRabbit's first comment — if it contains a rate limit message, wait the specified duration then push an empty commit (`git commit --allow-empty -m "chore: re-trigger review"`) to re-trigger
+5. Address review comments immediately as they arrive
+6. Never merge without **explicit user approval** — always use squash merge and delete the branch after
+
 ## Severity Levels
 
 Rules are classified into 4 severity levels:


### PR DESCRIPTION
## Summary

- Add PR workflow conventions to CLAUDE.md under the Conventions section
- Documents the draft PR lifecycle, CodeRabbit review monitoring, rate limit handling, and merge approval process
- Separated from #100 for cleaner scope

## Changes

New `### PR Workflow` subsection with 6 rules:
1. Draft-first PR creation
2. Draft conversion on changes
3. `subscribe_pr_activity` for real-time monitoring
4. CodeRabbit rate limit handling (empty commit re-trigger)
5. Immediate review comment addressing
6. Squash merge with explicit user approval


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal PR workflow documentation to establish explicit control-flow procedures. New guidelines cover draft PR practices, real-time review and CI monitoring, handling rate-limit messaging with re-trigger options, systematic review comment processing, and explicit approval enforcement before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->