### PR TITLE
fix: catch transformFileNodesResponse error in web app

### DIFF
--- a/app/web/src/index.html
+++ b/app/web/src/index.html
@@ -329,12 +329,12 @@
       } catch (e) { setLoading(false); showError('Network error', 'Could not reach Figma API.'); return; }
 
       setLoading(true, 'Analyzing...');
-      var analysisFile = nodeId
-        ? CanICode.transformFileNodesResponse(fileKey, response)
-        : CanICode.transformFigmaResponse(fileKey, response);
-      var options = nodeId ? { targetNodeId: nodeId } : {};
-      var result, scores;
+      var analysisFile, options, result, scores;
       try {
+        analysisFile = nodeId
+          ? CanICode.transformFileNodesResponse(fileKey, response)
+          : CanICode.transformFigmaResponse(fileKey, response);
+        options = nodeId ? { targetNodeId: nodeId } : {};
         result = CanICode.analyzeFile(analysisFile, options);
         scores = CanICode.calculateScores(result);
       } catch (e) { setLoading(false); showError('Analysis error', e.message); window._trackError && window._trackError(e, { context: 'analysis' }); window._trackEvent && window._trackEvent('cic_analysis_failed', { error: e.message }); return; }

--- a/src/core/adapters/figma-transformer.ts
+++ b/src/core/adapters/figma-transformer.ts
@@ -239,7 +239,11 @@ export function transformFileNodesResponse(
 ): AnalysisFile {
   const entries = Object.values(response.nodes);
   const first = entries[0];
-  if (!first) throw new Error("No nodes returned from Figma API");
+  if (!first)
+    throw new Error(
+      "No nodes returned from Figma API — the node-id in the URL may be invalid or deleted. " +
+        "Try selecting the frame in Figma and copying the link again."
+    );
 
   return {
     fileKey,


### PR DESCRIPTION
## Summary

- `transformFileNodesResponse` was called outside the try/catch in `runAnalysis()`, so when the Figma API returned no nodes (invalid/deleted node-id):
  - No error message appeared in UI — only `Uncaught (in promise) Error` in console
  - Loading spinner kept spinning forever (`setLoading(false)` never reached)
- Moved the transform call inside the existing try/catch so errors display via `showError()`
- Improved error message to guide users: "node-id may be invalid or deleted — try re-copying the link"

## Scope

- **Affected**: Web app (GitHub Pages) only
- **Not affected**: CLI, MCP — errors propagate normally in Node.js runtime

## Test plan

- [x] `pnpm test:run` — 622 tests pass
- [x] `pnpm lint` — clean
- [ ] Open web app → enter a Figma URL with an invalid node-id → verify error message appears in UI

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging when Figma frame links are invalid or reference deleted nodes, with clearer guidance directing users to re-copy the frame link directly from Figma for successful resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->