### PR TITLE
feat: use calibrated per-rule scores in final percentage calculation

### DIFF
--- a/src/core/engine/scoring.test.ts
+++ b/src/core/engine/scoring.test.ts
@@ -86,18 +86,34 @@ describe("calculateScores", () => {
     expect(scores.summary.totalIssues).toBe(4);
   });
 
-  it("applies severity density weights (blocking=3.0 > risk=2.0 > missing-info=1.0 > suggestion=0.5)", () => {
-    const blocking = calculateScores(makeResult([
-      makeIssue({ ruleId: "no-auto-layout", category: "structure", severity: "blocking" }),
+  it("uses calculatedScore for density: higher score = more density impact", () => {
+    const heavy = calculateScores(makeResult([
+      makeIssue({ ruleId: "no-auto-layout", category: "structure", severity: "blocking", score: -10 }),
     ], 100));
 
-    const suggestion = calculateScores(makeResult([
-      makeIssue({ ruleId: "numeric-suffix-name", category: "naming", severity: "suggestion" }),
+    const light = calculateScores(makeResult([
+      makeIssue({ ruleId: "unnecessary-node", category: "structure", severity: "suggestion", score: -2 }),
     ], 100));
 
-    expect(blocking.byCategory.structure.densityScore).toBeLessThan(
-      suggestion.byCategory.naming.densityScore
+    expect(heavy.byCategory.structure.densityScore).toBeLessThan(
+      light.byCategory.structure.densityScore
     );
+  });
+
+  it("differentiates rules within the same severity by score", () => {
+    const highScore = calculateScores(makeResult([
+      makeIssue({ ruleId: "no-auto-layout", category: "structure", severity: "blocking", score: -10 }),
+    ], 100));
+
+    const lowScore = calculateScores(makeResult([
+      makeIssue({ ruleId: "absolute-position-in-auto-layout", category: "structure", severity: "blocking", score: -3 }),
+    ], 100));
+
+    expect(highScore.byCategory.structure.densityScore).toBeLessThan(
+      lowScore.byCategory.structure.densityScore
+    );
+    expect(highScore.byCategory.structure.weightedIssueCount).toBe(10);
+    expect(lowScore.byCategory.structure.weightedIssueCount).toBe(3);
   });
 
   it("density score decreases as weighted issue count increases relative to node count", () => {

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -47,26 +47,17 @@ export interface ScoreReport {
 export type Grade = "S" | "A+" | "A" | "B+" | "B" | "C+" | "C" | "D" | "F";
 
 /**
- * Severity weights for density calculation.
+ * Density weighting now uses per-rule `calculatedScore` from the rule engine,
+ * which incorporates both the calibrated rule score and depthWeight.
  *
- * Rationale (initial intuition, pending calibration validation):
- * - blocking (3.0): issues that prevent correct implementation — weighted highest
- * - risk (2.0): implementable now but will break later — significant but less than blocking
- * - missing-info (1.0): forces guessing — baseline weight
- * - suggestion (0.5): nice-to-have improvements — minimal impact on implementation accuracy
+ * Previously, flat severity weights (blocking=3.0, risk=2.0, etc.) were used,
+ * making all rules within the same severity contribute equally and rendering
+ * the per-rule scores in rule-config.ts effectively unused.
  *
- * The 3:2:1:0.5 ratio reflects relative implementation difficulty. A single blocking
- * issue (e.g., missing auto-layout) costs more effort than 3 suggestions combined.
- * These weights are multiplied with issue counts to produce a weighted density score.
- *
- * Status: initial values. To be validated via /calibrate-loop against visual-compare results.
+ * Now: `no-auto-layout` (score: -10, depthWeight: 1.5) at root contributes 15
+ * to density, while `unnecessary-node` (score: -2, no depthWeight) contributes 2.
+ * This makes calibration loop score adjustments flow through to user-facing scores.
  */
-const SEVERITY_DENSITY_WEIGHT: Record<Severity, number> = {
-  blocking: 3.0,
-  risk: 2.0,
-  "missing-info": 1.0,
-  suggestion: 0.5,
-};
 
 /**
  * Total rules per category — used as denominator for diversity scoring.
@@ -181,7 +172,7 @@ export function calculateScores(result: AnalysisResult): ScoreReport {
 
     categoryScores[category].issueCount++;
     categoryScores[category].bySeverity[severity]++;
-    categoryScores[category].weightedIssueCount += SEVERITY_DENSITY_WEIGHT[severity];
+    categoryScores[category].weightedIssueCount += Math.abs(issue.calculatedScore);
     uniqueRulesPerCategory.get(category)!.add(ruleId);
   }
 


### PR DESCRIPTION
## Summary

- Replace flat severity weights with `calculatedScore` from rule engine in density calculation
- Per-rule scores and `depthWeight` from `rule-config.ts` now actually influence user-facing scores
- Calibration loop score adjustments flow through to final percentages

## What was wrong

`calculateScores()` used `SEVERITY_DENSITY_WEIGHT` (blocking=3.0, risk=2.0, missing-info=1.0, suggestion=0.5) for density. This meant:

- All blocking rules contributed **3.0 equally** regardless of their calibrated score
- `no-auto-layout` (score: -10) and `missing-size-constraint` (score: -3) were treated the same
- `depthWeight` was computed into `calculatedScore` but **never consumed** by scoring
- Adjusting scores in `rule-config.ts` via calibration loop had **zero effect** on user-facing scores

## What this fixes

Now `calculateScores()` uses `Math.abs(issue.calculatedScore)` instead of flat severity weights:

| Rule | Before (severity weight) | After (calculatedScore) |
|---|---|---|
| `no-auto-layout` at root (score -10, depthWeight 1.5) | 3.0 | **15** |
| `no-auto-layout` at leaf (score -10, depthWeight 1.0) | 3.0 | **10** |
| `missing-size-constraint` (score -3) | 3.0 | **3** |
| `unnecessary-node` (score -2) | 0.5 | **2** |

## Test plan

- [x] 623 tests pass
- [x] Type check clean
- [ ] Re-run calibration fixtures and compare before/after score distributions

Closes #104

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Scoring calculation now weights issues based on individual impact scores rather than severity classification.
  * Issue density assessment is more precise, reflecting actual impact differences across severity categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->