### PR TITLE
feat: ablation pilot for OAT sensitivity analysis (Step 0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.80.0",
     "@figma/rest-api-spec": "^0.36.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "cac": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.80.0
+        version: 0.80.0(zod@4.3.6)
       '@figma/rest-api-spec':
         specifier: ^0.36.0
         version: 0.36.0
@@ -56,6 +59,19 @@ importers:
         version: 4.1.0(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0)(esbuild@0.27.4)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
+
+  '@anthropic-ai/sdk@0.80.0':
+    resolution: {integrity: sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -838,6 +854,10 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -1202,6 +1222,9 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -1360,6 +1383,14 @@ packages:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
+
+  '@anthropic-ai/sdk@0.80.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
+  '@babel/runtime@7.29.2': {}
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -1995,6 +2026,11 @@ snapshots:
 
   joycon@3.1.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -2350,6 +2386,8 @@ snapshots:
   toidentifier@1.0.1: {}
 
   tree-kill@1.2.2: {}
+
+  ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/src/agents/ablation/ablation-runner.ts
+++ b/src/agents/ablation/ablation-runner.ts
@@ -1,0 +1,116 @@
+/**
+ * Ablation runner: calls the Anthropic API with extended thinking
+ * to convert a design tree into HTML, measuring thinking tokens as a signal
+ * for implementation difficulty.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+
+/** Result from a single ablation conversion run. */
+export interface AblationRunResult {
+  /** Number of tokens used in the thinking/reasoning step. */
+  thinkingTokens: number;
+  /** Number of tokens in the output (HTML). */
+  outputTokens: number;
+  /** The generated HTML code. */
+  html: string;
+}
+
+/** Options for the ablation runner. */
+export interface AblationRunnerOptions {
+  /** Budget for extended thinking tokens. Default: 10000. */
+  budgetTokens?: number;
+  /** Max output tokens for the response. Default: 16000. */
+  maxTokens?: number;
+}
+
+const MODEL = "claude-sonnet-4-6" as const;
+const DEFAULT_BUDGET_TOKENS = 10000;
+const DEFAULT_MAX_TOKENS = 16000;
+
+/**
+ * Build the converter prompt for design-to-HTML conversion.
+ * This is a focused, minimal prompt that asks the model to convert
+ * a design tree into a single HTML file.
+ */
+function buildConverterPrompt(designTree: string): string {
+  return `You are a frontend developer. Convert the following design tree into a single, self-contained HTML file.
+
+Requirements:
+- Output ONLY the HTML code, nothing else. No markdown fences, no explanations.
+- Use inline CSS styles (no external stylesheets).
+- Match every dimension, color, font, spacing, and layout property exactly as specified.
+- Each node in the design tree maps to one HTML element.
+- Use semantic HTML where appropriate (div, section, h1-h6, p, span, etc.).
+- For images ([IMAGE] or url(...)), use a colored placeholder div with the same dimensions.
+- Include a reset style: * { margin: 0; padding: 0; box-sizing: border-box; }
+
+Design Tree:
+${designTree}`;
+}
+
+/**
+ * Run a single ablation conversion using the Anthropic API with extended thinking.
+ *
+ * Uses claude-sonnet-4-6 with extended thinking enabled to measure:
+ * - thinkingTokens: how much reasoning the model needed
+ * - outputTokens: how much code was generated
+ * - html: the actual generated HTML
+ *
+ * Temperature is controlled by extended thinking (deterministic reasoning).
+ */
+export async function runAblation(
+  designTree: string,
+  options?: AblationRunnerOptions,
+): Promise<AblationRunResult> {
+  const budgetTokens = options?.budgetTokens ?? DEFAULT_BUDGET_TOKENS;
+  const maxTokens = options?.maxTokens ?? DEFAULT_MAX_TOKENS;
+
+  const client = new Anthropic();
+
+  const response = await client.messages.create({
+    model: MODEL,
+    max_tokens: maxTokens,
+    thinking: {
+      type: "enabled",
+      budget_tokens: budgetTokens,
+    },
+    messages: [
+      {
+        role: "user",
+        content: buildConverterPrompt(designTree),
+      },
+    ],
+  });
+
+  // Extract thinking tokens from usage
+  const usage = response.usage as unknown as Record<string, unknown>;
+  const thinkingTokens = usage["thinking_tokens"];
+  const outputTokens = response.usage.output_tokens;
+
+  // Extract HTML from response content blocks
+  let html = "";
+  for (const block of response.content) {
+    if (block.type === "text") {
+      html += block.text;
+    }
+  }
+
+  // Clean up: remove markdown fences if the model wraps the output
+  html = html.trim();
+  if (html.startsWith("```html")) {
+    html = html.slice(7);
+  } else if (html.startsWith("```")) {
+    html = html.slice(3);
+  }
+  if (html.endsWith("```")) {
+    html = html.slice(0, -3);
+  }
+  html = html.trim();
+
+  return {
+    thinkingTokens: typeof thinkingTokens === "number" ? thinkingTokens : 0,
+    outputTokens,
+    html,
+  };
+}

--- a/src/agents/ablation/design-tree-stripper.test.ts
+++ b/src/agents/ablation/design-tree-stripper.test.ts
@@ -1,0 +1,213 @@
+import { stripForRule, PILOT_RULE_IDS } from "./design-tree-stripper.js";
+
+// Sample design tree for testing
+const SAMPLE_TREE = `# Design Tree
+# Root: 375px x 812px
+# Each node shows: name (TYPE, WxH) followed by CSS-like styles
+# Reproduce this tree as HTML. Each node = one HTML element.
+# Every style value is from Figma data — use exactly as shown.
+
+Hero Section (FRAME, 375x812)
+  style: display: flex; flex-direction: column; row-gap: 32px; padding: 24px 16px 24px 16px; background: #FFFFFF
+  Navigation Bar (FRAME, 343x48)
+    style: display: flex; flex-direction: row; column-gap: 12px; justify-content: space-between; align-items: center
+    Logo (INSTANCE, 120x40) [component: BrandLogo]
+      style: background-image: [IMAGE]
+    Menu Button (INSTANCE, 40x40) [component: IconButton]
+      style: border-radius: 8px; background: #F5F5F5
+  Title (TEXT, 311x48)
+    style: font-family: "Inter"; font-weight: 700; font-size: 48px; color: #2C2C2C; text: "Welcome Home"
+  Card Container (FRAME, 343x200)
+    style: display: flex; flex-direction: column; row-gap: 16px; padding: 16px 16px 16px 16px; border-radius: 12px; background: #F9F9F9
+    Card Title (TEXT, 311x24)
+      style: font-family: "Inter"; font-weight: 600; font-size: 20px; color: #333333; text: "Featured"
+    Card Body (TEXT, 311x72)
+      style: font-family: "Inter"; font-weight: 400; font-size: 14px; line-height: 24px; color: #666666; text: "This is the card body text"`;
+
+describe("stripForRule", () => {
+  describe("no-auto-layout", () => {
+    it("removes layout properties from style lines", () => {
+      const result = stripForRule(SAMPLE_TREE, "no-auto-layout");
+
+      expect(result).not.toContain("display: flex");
+      expect(result).not.toContain("flex-direction:");
+      expect(result).not.toContain("row-gap:");
+      expect(result).not.toContain("column-gap:");
+      expect(result).not.toContain("justify-content:");
+      expect(result).not.toContain("align-items:");
+    });
+
+    it("preserves non-layout style properties", () => {
+      const result = stripForRule(SAMPLE_TREE, "no-auto-layout");
+
+      expect(result).toContain("padding: 24px 16px 24px 16px");
+      expect(result).toContain("background: #FFFFFF");
+      expect(result).toContain("border-radius: 12px");
+      expect(result).toContain('font-family: "Inter"');
+      expect(result).toContain("font-weight: 700");
+      expect(result).toContain("color: #2C2C2C");
+    });
+
+    it("preserves node headers and comment lines", () => {
+      const result = stripForRule(SAMPLE_TREE, "no-auto-layout");
+
+      expect(result).toContain("# Design Tree");
+      expect(result).toContain("Hero Section (FRAME, 375x812)");
+      expect(result).toContain("Navigation Bar (FRAME, 343x48)");
+      expect(result).toContain("Title (TEXT, 311x48)");
+    });
+
+    it("omits style line entirely when all properties are layout-only", () => {
+      const layoutOnlyTree = `Root (FRAME, 100x100)
+  style: display: flex; flex-direction: row; column-gap: 8px`;
+
+      const result = stripForRule(layoutOnlyTree, "no-auto-layout");
+
+      expect(result).toBe("Root (FRAME, 100x100)");
+    });
+
+    it("handles grid layout properties", () => {
+      const gridTree = `Container (FRAME, 600x400)
+  style: display: grid; grid-template-columns: 1fr 1fr; gap: 16px; padding: 8px 8px 8px 8px`;
+
+      const result = stripForRule(gridTree, "no-auto-layout");
+
+      expect(result).not.toContain("display: grid");
+      expect(result).not.toContain("grid-template-columns:");
+      expect(result).not.toContain("gap:");
+      expect(result).toContain("padding: 8px 8px 8px 8px");
+    });
+  });
+
+  describe("missing-component", () => {
+    it("removes [component: ...] annotations from node headers", () => {
+      const result = stripForRule(SAMPLE_TREE, "missing-component");
+
+      expect(result).not.toContain("[component: BrandLogo]");
+      expect(result).not.toContain("[component: IconButton]");
+      expect(result).not.toContain("[component:");
+    });
+
+    it("preserves node names and types after removing component annotations", () => {
+      const result = stripForRule(SAMPLE_TREE, "missing-component");
+
+      expect(result).toContain("Logo (INSTANCE, 120x40)");
+      expect(result).toContain("Menu Button (INSTANCE, 40x40)");
+    });
+
+    it("preserves all style properties", () => {
+      const result = stripForRule(SAMPLE_TREE, "missing-component");
+
+      expect(result).toContain("display: flex");
+      expect(result).toContain("flex-direction: column");
+      expect(result).toContain('font-family: "Inter"');
+    });
+
+    it("handles design trees with no component annotations", () => {
+      const noComponents = `Root (FRAME, 100x100)
+  style: background: #FFF
+  Child (TEXT, 80x20)
+    style: text: "Hello"`;
+
+      const result = stripForRule(noComponents, "missing-component");
+
+      expect(result).toBe(noComponents);
+    });
+  });
+
+  describe("default-name", () => {
+    it("replaces meaningful names with generic names based on type", () => {
+      const result = stripForRule(SAMPLE_TREE, "default-name");
+
+      // Original meaningful names should not appear as node names
+      expect(result).not.toContain("Hero Section (FRAME");
+      expect(result).not.toContain("Navigation Bar (FRAME");
+      expect(result).not.toContain("Logo (INSTANCE");
+      expect(result).not.toContain("Title (TEXT");
+      expect(result).not.toContain("Card Container (FRAME");
+    });
+
+    it("uses correct type-based generic names", () => {
+      const result = stripForRule(SAMPLE_TREE, "default-name");
+
+      // Should contain Frame N, Text N, Instance N patterns
+      expect(result).toMatch(/Frame \d+ \(FRAME,/);
+      expect(result).toMatch(/Text \d+ \(TEXT,/);
+      expect(result).toMatch(/Instance \d+ \(INSTANCE,/);
+    });
+
+    it("assigns incrementing numbers per type", () => {
+      const result = stripForRule(SAMPLE_TREE, "default-name");
+      const lines = result.split("\n");
+
+      // Find all FRAME-typed nodes
+      const frameLines = lines.filter((l) => l.match(/Frame \d+ \(FRAME,/));
+      expect(frameLines.length).toBeGreaterThan(1);
+
+      // Numbers should increment
+      const numbers = frameLines.map((l) => {
+        const m = l.match(/Frame (\d+)/);
+        return m ? parseInt(m[1]!, 10) : 0;
+      });
+      for (let i = 1; i < numbers.length; i++) {
+        expect(numbers[i]).toBeGreaterThan(numbers[i - 1]!);
+      }
+    });
+
+    it("preserves comment lines unchanged", () => {
+      const result = stripForRule(SAMPLE_TREE, "default-name");
+
+      expect(result).toContain("# Design Tree");
+      expect(result).toContain("# Root: 375px x 812px");
+    });
+
+    it("preserves style lines unchanged", () => {
+      const result = stripForRule(SAMPLE_TREE, "default-name");
+
+      expect(result).toContain("display: flex; flex-direction: column");
+      expect(result).toContain('font-family: "Inter"');
+      expect(result).toContain('text: "Welcome Home"');
+    });
+
+    it("preserves dimensions and type info", () => {
+      const result = stripForRule(SAMPLE_TREE, "default-name");
+
+      expect(result).toContain("(FRAME, 375x812)");
+      expect(result).toContain("(TEXT, 311x48)");
+      expect(result).toContain("(INSTANCE, 120x40)");
+    });
+
+    it("preserves component annotations", () => {
+      const result = stripForRule(SAMPLE_TREE, "default-name");
+
+      expect(result).toContain("[component: BrandLogo]");
+      expect(result).toContain("[component: IconButton]");
+    });
+  });
+
+  describe("unsupported rules", () => {
+    it("throws error for non-pilot rules", () => {
+      expect(() => stripForRule(SAMPLE_TREE, "raw-color")).toThrow(
+        "Stripping not implemented for rule: raw-color"
+      );
+    });
+  });
+
+  describe("PILOT_RULE_IDS", () => {
+    it("contains exactly the 3 pilot rules", () => {
+      expect(PILOT_RULE_IDS).toEqual([
+        "no-auto-layout",
+        "missing-component",
+        "default-name",
+      ]);
+    });
+
+    it("all pilot rules have working strip implementations", () => {
+      for (const ruleId of PILOT_RULE_IDS) {
+        const result = stripForRule(SAMPLE_TREE, ruleId);
+        expect(typeof result).toBe("string");
+        expect(result.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/agents/ablation/design-tree-stripper.ts
+++ b/src/agents/ablation/design-tree-stripper.ts
@@ -1,0 +1,165 @@
+/**
+ * Design tree stripper for ablation testing.
+ * Removes rule-specific information from a text-based design tree
+ * to measure how much harder AI implementation becomes without that info.
+ */
+
+import type { RuleId } from "../../core/contracts/rule.js";
+
+/** Pilot rule IDs supported for stripping. */
+export const PILOT_RULE_IDS = [
+  "no-auto-layout",
+  "missing-component",
+  "default-name",
+] as const satisfies readonly RuleId[];
+
+export type PilotRuleId = (typeof PILOT_RULE_IDS)[number];
+
+/**
+ * Strip rule-specific information from a design tree text.
+ * Returns a modified design tree with the target rule's information removed.
+ *
+ * Currently supports pilot rules only:
+ * - `no-auto-layout`: removes layout properties (display, flex-direction, gap, align-items, justify-content)
+ * - `missing-component`: removes [component: ...] annotations
+ * - `default-name`: replaces meaningful node names with generic "Frame 1", "Group 2", etc.
+ */
+export function stripForRule(designTree: string, ruleId: RuleId): string {
+  switch (ruleId) {
+    case "no-auto-layout":
+      return stripAutoLayout(designTree);
+    case "missing-component":
+      return stripComponents(designTree);
+    case "default-name":
+      return stripNames(designTree);
+    default:
+      throw new Error(`Stripping not implemented for rule: ${ruleId}`);
+  }
+}
+
+/**
+ * Strip auto-layout properties from the design tree.
+ * Removes: display, flex-direction, flex-wrap, row-gap, column-gap,
+ * justify-content, align-items, align-content, display: grid and grid properties.
+ */
+function stripAutoLayout(designTree: string): string {
+  const lines = designTree.split("\n");
+  const result: string[] = [];
+
+  for (const line of lines) {
+    // Check if this is a style line
+    const styleMatch = line.match(/^(\s*)style:\s*(.+)$/);
+    if (!styleMatch) {
+      result.push(line);
+      continue;
+    }
+
+    const indent = styleMatch[1] ?? "";
+    const styleContent = styleMatch[2] ?? "";
+
+    // Parse semicolon-separated CSS properties
+    const properties = styleContent.split(";").map((p) => p.trim());
+
+    // Layout-related property prefixes to remove
+    const layoutPrefixes = [
+      "display:",
+      "flex-direction:",
+      "flex-wrap:",
+      "row-gap:",
+      "column-gap:",
+      "gap:",
+      "justify-content:",
+      "align-items:",
+      "align-content:",
+      "grid-template-columns:",
+      "grid-template-rows:",
+    ];
+
+    const filtered = properties.filter((prop) => {
+      if (!prop) return false;
+      return !layoutPrefixes.some((prefix) => prop.startsWith(prefix));
+    });
+
+    if (filtered.length > 0) {
+      result.push(`${indent}style: ${filtered.join("; ")}`);
+    }
+    // If no properties remain, omit the entire style line
+  }
+
+  return result.join("\n");
+}
+
+/**
+ * Strip component annotations from the design tree.
+ * Removes: [component: ...] annotations from node headers.
+ */
+function stripComponents(designTree: string): string {
+  // Remove [component: ...] annotations from node header lines
+  return designTree.replace(/ \[component: [^\]]+\]/g, "");
+}
+
+/**
+ * Strip meaningful names from the design tree, replacing with generic names.
+ * Replaces node names with "Frame 1", "Group 2", "Text 3", etc. based on node type.
+ */
+function stripNames(designTree: string): string {
+  const lines = designTree.split("\n");
+  const result: string[] = [];
+
+  // Counter per type for unique generic names
+  const typeCounters = new Map<string, number>();
+
+  for (const line of lines) {
+    // Skip comment lines (headers)
+    if (line.startsWith("#")) {
+      result.push(line);
+      continue;
+    }
+
+    // Match node header lines: indentation + name (TYPE, WxH) [optional component annotation]
+    const nodeMatch = line.match(/^(\s*)(.+?)\s+\((\w+),\s*(\S+)\)(.*)$/);
+    if (!nodeMatch) {
+      result.push(line);
+      continue;
+    }
+
+    const indent = nodeMatch[1] ?? "";
+    const nodeType = nodeMatch[3] ?? "FRAME";
+    const dimensions = nodeMatch[4] ?? "?x?";
+    const suffix = nodeMatch[5] ?? "";
+
+    // Map Figma node types to readable generic names
+    const genericBase = getGenericNameBase(nodeType);
+    const count = (typeCounters.get(nodeType) ?? 0) + 1;
+    typeCounters.set(nodeType, count);
+
+    const genericName = `${genericBase} ${count}`;
+    result.push(`${indent}${genericName} (${nodeType}, ${dimensions})${suffix}`);
+  }
+
+  return result.join("\n");
+}
+
+/** Map Figma node types to readable generic name bases. */
+function getGenericNameBase(nodeType: string): string {
+  const typeMap: Record<string, string> = {
+    FRAME: "Frame",
+    GROUP: "Group",
+    TEXT: "Text",
+    RECTANGLE: "Rectangle",
+    ELLIPSE: "Ellipse",
+    VECTOR: "Vector",
+    INSTANCE: "Instance",
+    COMPONENT: "Component",
+    COMPONENT_SET: "ComponentSet",
+    BOOLEAN_OPERATION: "BooleanOp",
+    LINE: "Line",
+    STAR: "Star",
+    REGULAR_POLYGON: "Polygon",
+    SECTION: "Section",
+    SLICE: "Slice",
+    DOCUMENT: "Document",
+    CANVAS: "Canvas",
+  };
+  return typeMap[nodeType] ?? "Element";
+}

--- a/src/agents/ablation/pilot.ts
+++ b/src/agents/ablation/pilot.ts
@@ -1,0 +1,382 @@
+/**
+ * Ablation pilot orchestrator.
+ * Validates that thinking token increase (deltaT) is a stable signal
+ * by running 3 rules x 2 repetitions + 2 baseline runs = 8 converter runs per fixture.
+ *
+ * Usage: npx tsx src/agents/ablation/pilot.ts <fixture-dir>
+ */
+
+import { existsSync, mkdirSync, writeFileSync, readFileSync, copyFileSync } from "node:fs";
+import { resolve, join, basename } from "node:path";
+import { loadFile } from "../../core/engine/loader.js";
+import { generateDesignTree } from "../../core/engine/design-tree.js";
+import { renderCodeScreenshot } from "../../core/engine/visual-compare.js";
+import { compareScreenshots } from "../../core/engine/visual-compare-helpers.js";
+import { stripForRule, PILOT_RULE_IDS } from "./design-tree-stripper.js";
+import { runAblation } from "./ablation-runner.js";
+import { buildHtmlWrapper } from "../code-renderer.js";
+
+// --- Types ---
+
+interface RepResult {
+  thinkingTokens: number;
+  outputTokens: number;
+  visualSimilarity: number;
+}
+
+interface AblationResult {
+  reps: RepResult[];
+  avgDeltaT: number;
+  avgDeltaV: number;
+  deltaT_cv: number;
+  deltaV_cv: number;
+}
+
+interface PilotResults {
+  fixture: string;
+  timestamp: string;
+  repetitions: number;
+  baseline: {
+    reps: RepResult[];
+  };
+  ablations: Record<string, AblationResult>;
+  validation: {
+    deltaT_stable: boolean;
+    deltaV_direction_correct: boolean;
+    strip_clean: boolean;
+    pass: boolean;
+  };
+}
+
+// --- Constants ---
+
+const REPETITIONS = 2;
+const ABLATION_DIR = "logs/ablation";
+const CV_THRESHOLD = 0.30; // Coefficient of variation < 30% = stable
+
+// --- Helpers ---
+
+function getTimestamp(): string {
+  return new Date().toISOString();
+}
+
+function getTimestampSlug(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  const hours = String(now.getHours()).padStart(2, "0");
+  const minutes = String(now.getMinutes()).padStart(2, "0");
+  return `${year}-${month}-${day}-${hours}${minutes}`;
+}
+
+/** Compute coefficient of variation (stddev / mean). Returns 0 if mean is 0. */
+function coefficientOfVariation(values: number[]): number {
+  if (values.length === 0) return 0;
+  const mean = values.reduce((a, b) => a + b, 0) / values.length;
+  if (mean === 0) return 0;
+  const variance = values.reduce((sum, v) => sum + (v - mean) ** 2, 0) / values.length;
+  return Math.sqrt(variance) / Math.abs(mean);
+}
+
+/** Run visual comparison between generated HTML and fixture screenshot. */
+async function measureVisualSimilarity(
+  html: string,
+  fixtureScreenshotPath: string,
+  outputDir: string,
+  repLabel: string,
+): Promise<number> {
+  // Write HTML to a temp file
+  const htmlPath = join(outputDir, `${repLabel}.html`);
+  const wrappedHtml = buildHtmlWrapper(html);
+  writeFileSync(htmlPath, wrappedHtml);
+
+  // Read the fixture screenshot to get dimensions
+  const { PNG } = await import("pngjs");
+  const figmaPng = PNG.sync.read(readFileSync(fixtureScreenshotPath));
+
+  // Assume fixture screenshot is @2x (standard from save-fixture)
+  const exportScale = 2;
+  const logicalW = Math.max(1, Math.round(figmaPng.width / exportScale));
+  const logicalH = Math.max(1, Math.round(figmaPng.height / exportScale));
+
+  // Render code screenshot
+  const codePngPath = join(outputDir, `${repLabel}-code.png`);
+  await renderCodeScreenshot(htmlPath, codePngPath, { width: logicalW, height: logicalH }, exportScale);
+
+  // Copy fixture screenshot for comparison
+  const figmaPngPath = join(outputDir, `${repLabel}-figma.png`);
+  copyFileSync(fixtureScreenshotPath, figmaPngPath);
+
+  // Compare
+  const diffPath = join(outputDir, `${repLabel}-diff.png`);
+  const result = compareScreenshots(figmaPngPath, codePngPath, diffPath);
+
+  return result.similarity;
+}
+
+/** Run one conversion and measure results. */
+async function runOneConversion(
+  designTree: string,
+  fixtureScreenshotPath: string,
+  outputDir: string,
+  repLabel: string,
+): Promise<RepResult> {
+  console.error(`  Running conversion: ${repLabel}...`);
+
+  const ablationResult = await runAblation(designTree);
+
+  // Measure visual similarity (also saves the HTML file)
+  let visualSimilarity = 0;
+  try {
+    visualSimilarity = await measureVisualSimilarity(
+      ablationResult.html,
+      fixtureScreenshotPath,
+      outputDir,
+      repLabel,
+    );
+  } catch (err) {
+    // If visual comparison fails, still save the HTML for inspection
+    const htmlPath = join(outputDir, `${repLabel}.html`);
+    writeFileSync(htmlPath, buildHtmlWrapper(ablationResult.html));
+    console.error(`  Warning: visual comparison failed for ${repLabel}: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  console.error(`  ${repLabel}: thinking=${ablationResult.thinkingTokens}, output=${ablationResult.outputTokens}, similarity=${visualSimilarity}%`);
+
+  return {
+    thinkingTokens: ablationResult.thinkingTokens,
+    outputTokens: ablationResult.outputTokens,
+    visualSimilarity,
+  };
+}
+
+// --- Main orchestrator ---
+
+async function runPilot(fixtureDir: string): Promise<PilotResults> {
+  const resolvedDir = resolve(fixtureDir);
+  const dataPath = join(resolvedDir, "data.json");
+  const screenshotPath = join(resolvedDir, "screenshot.png");
+
+  if (!existsSync(dataPath)) {
+    throw new Error(`Fixture data.json not found: ${dataPath}`);
+  }
+  if (!existsSync(screenshotPath)) {
+    throw new Error(`Fixture screenshot.png not found: ${screenshotPath}`);
+  }
+
+  const fixtureName = basename(resolvedDir);
+  const timestamp = getTimestamp();
+  const timestampSlug = getTimestampSlug();
+
+  // Create run directory
+  const runDir = resolve(ABLATION_DIR, `pilot--${timestampSlug}`);
+  mkdirSync(runDir, { recursive: true });
+
+  console.error(`\nAblation Pilot: ${fixtureName}`);
+  console.error(`Run directory: ${runDir}`);
+  console.error(`Repetitions: ${REPETITIONS}`);
+  console.error(`Rules: ${PILOT_RULE_IDS.join(", ")}\n`);
+
+  // Load fixture and generate design tree
+  console.error("Loading fixture...");
+  const { file } = await loadFile(resolvedDir);
+  const vectorDir = join(resolvedDir, "vectors");
+  const treeOptions = existsSync(vectorDir) ? { vectorDir } : {};
+  const designTree = generateDesignTree(file, treeOptions);
+
+  // Save design tree for reference
+  writeFileSync(join(runDir, "design-tree.txt"), designTree);
+
+  // Verify stripping works cleanly for all pilot rules
+  let stripClean = true;
+  for (const ruleId of PILOT_RULE_IDS) {
+    try {
+      const stripped = stripForRule(designTree, ruleId);
+      if (stripped === designTree) {
+        console.error(`  Warning: strip for ${ruleId} had no effect — rule may not be present in this fixture`);
+      }
+      // Save stripped trees for reference
+      const strippedDir = join(runDir, "stripped", ruleId);
+      mkdirSync(strippedDir, { recursive: true });
+      writeFileSync(join(strippedDir, "design-tree.txt"), stripped);
+    } catch (err) {
+      console.error(`  Error: strip failed for ${ruleId}: ${err instanceof Error ? err.message : String(err)}`);
+      stripClean = false;
+    }
+  }
+
+  // --- Run baseline ---
+  console.error("\n--- Baseline runs ---");
+  const baselineDir = join(runDir, "baseline");
+  mkdirSync(baselineDir, { recursive: true });
+  const baselineReps: RepResult[] = [];
+
+  for (let rep = 1; rep <= REPETITIONS; rep++) {
+    const result = await runOneConversion(
+      designTree,
+      screenshotPath,
+      baselineDir,
+      `rep-${rep}`,
+    );
+    baselineReps.push(result);
+  }
+
+  // --- Run ablations for each pilot rule ---
+  const ablations: Record<string, AblationResult> = {};
+
+  for (const ruleId of PILOT_RULE_IDS) {
+    console.error(`\n--- Ablation: ${ruleId} ---`);
+    const ruleDir = join(runDir, "stripped", ruleId);
+    mkdirSync(ruleDir, { recursive: true });
+
+    const strippedTree = stripForRule(designTree, ruleId);
+    const ruleReps: RepResult[] = [];
+
+    for (let rep = 1; rep <= REPETITIONS; rep++) {
+      const result = await runOneConversion(
+        strippedTree,
+        screenshotPath,
+        ruleDir,
+        `rep-${rep}`,
+      );
+      ruleReps.push(result);
+    }
+
+    // Compute deltas relative to baseline
+    const avgBaselineT = baselineReps.reduce((s, r) => s + r.thinkingTokens, 0) / baselineReps.length;
+    const avgBaselineV = baselineReps.reduce((s, r) => s + r.visualSimilarity, 0) / baselineReps.length;
+    const avgRuleT = ruleReps.reduce((s, r) => s + r.thinkingTokens, 0) / ruleReps.length;
+    const avgRuleV = ruleReps.reduce((s, r) => s + r.visualSimilarity, 0) / ruleReps.length;
+
+    const avgDeltaT = avgRuleT - avgBaselineT;
+    const avgDeltaV = avgRuleV - avgBaselineV;
+
+    // Per-rep deltas for CV calculation
+    const deltaTs = ruleReps.map((r) => r.thinkingTokens - avgBaselineT);
+    const deltaVs = ruleReps.map((r) => r.visualSimilarity - avgBaselineV);
+
+    ablations[ruleId] = {
+      reps: ruleReps,
+      avgDeltaT: Math.round(avgDeltaT),
+      avgDeltaV: Math.round(avgDeltaV * 10) / 10,
+      deltaT_cv: Math.round(coefficientOfVariation(deltaTs) * 100) / 100,
+      deltaV_cv: Math.round(coefficientOfVariation(deltaVs) * 100) / 100,
+    };
+  }
+
+  // --- Validation ---
+  const deltaTStable = Object.values(ablations).every(
+    (a) => a.deltaT_cv < CV_THRESHOLD,
+  );
+  // deltaV should be negative (worse similarity when info is stripped)
+  const deltaVDirectionCorrect = Object.values(ablations).every(
+    (a) => a.avgDeltaV <= 0,
+  );
+
+  const validation = {
+    deltaT_stable: deltaTStable,
+    deltaV_direction_correct: deltaVDirectionCorrect,
+    strip_clean: stripClean,
+    pass: deltaTStable && deltaVDirectionCorrect && stripClean,
+  };
+
+  const results: PilotResults = {
+    fixture: fixtureName,
+    timestamp,
+    repetitions: REPETITIONS,
+    baseline: { reps: baselineReps },
+    ablations,
+    validation,
+  };
+
+  // Save results
+  writeFileSync(join(runDir, "results.json"), JSON.stringify(results, null, 2));
+
+  // Generate summary
+  const summary = generateSummary(results);
+  writeFileSync(join(runDir, "summary.md"), summary);
+
+  console.error("\n" + summary);
+  console.error(`\nResults saved to: ${runDir}`);
+
+  return results;
+}
+
+/** Generate a human-readable summary of pilot results. */
+function generateSummary(results: PilotResults): string {
+  const lines: string[] = [];
+
+  lines.push(`# Ablation Pilot Results`);
+  lines.push(``);
+  lines.push(`- **Fixture**: ${results.fixture}`);
+  lines.push(`- **Timestamp**: ${results.timestamp}`);
+  lines.push(`- **Repetitions**: ${results.repetitions}`);
+  lines.push(``);
+
+  // Baseline
+  lines.push(`## Baseline`);
+  lines.push(``);
+  lines.push(`| Rep | Thinking Tokens | Output Tokens | Visual Similarity |`);
+  lines.push(`|-----|-----------------|---------------|-------------------|`);
+  for (let i = 0; i < results.baseline.reps.length; i++) {
+    const r = results.baseline.reps[i]!;
+    lines.push(`| ${i + 1} | ${r.thinkingTokens} | ${r.outputTokens} | ${r.visualSimilarity}% |`);
+  }
+  lines.push(``);
+
+  // Ablations
+  lines.push(`## Ablations`);
+  lines.push(``);
+  for (const [ruleId, ablation] of Object.entries(results.ablations)) {
+    lines.push(`### ${ruleId}`);
+    lines.push(``);
+    lines.push(`| Rep | Thinking Tokens | Output Tokens | Visual Similarity |`);
+    lines.push(`|-----|-----------------|---------------|-------------------|`);
+    for (let i = 0; i < ablation.reps.length; i++) {
+      const r = ablation.reps[i]!;
+      lines.push(`| ${i + 1} | ${r.thinkingTokens} | ${r.outputTokens} | ${r.visualSimilarity}% |`);
+    }
+    lines.push(``);
+    lines.push(`- **Avg deltaT**: ${ablation.avgDeltaT} tokens (CV: ${ablation.deltaT_cv})`);
+    lines.push(`- **Avg deltaV**: ${ablation.avgDeltaV}% (CV: ${ablation.deltaV_cv})`);
+    lines.push(``);
+  }
+
+  // Validation
+  lines.push(`## Validation`);
+  lines.push(``);
+  lines.push(`| Check | Result |`);
+  lines.push(`|-------|--------|`);
+  lines.push(`| deltaT run-to-run stability (CV < 30%) | ${results.validation.deltaT_stable ? "PASS" : "FAIL"} |`);
+  lines.push(`| deltaV direction correct (negative) | ${results.validation.deltaV_direction_correct ? "PASS" : "FAIL"} |`);
+  lines.push(`| Strip definitions clean | ${results.validation.strip_clean ? "PASS" : "FAIL"} |`);
+  lines.push(`| **Overall** | **${results.validation.pass ? "PASS" : "FAIL"}** |`);
+  lines.push(``);
+
+  return lines.join("\n");
+}
+
+// --- CLI entry point ---
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || !args[0]) {
+    console.error("Usage: npx tsx src/agents/ablation/pilot.ts <fixture-dir>");
+    console.error("Example: npx tsx src/agents/ablation/pilot.ts fixtures/material3-51954-18254");
+    process.exit(1);
+  }
+
+  const fixtureDir = args[0];
+
+  try {
+    const results = await runPilot(fixtureDir);
+    // Output JSON to stdout for programmatic consumption
+    console.log(JSON.stringify(results, null, 2));
+  } catch (err) {
+    console.error(`\nError: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

Implements Step 0 (pilot validation) of the OAT sensitivity analysis approach from #108.

Before running full ablation on all 29 rules (~$225), this pilot validates that **thinking token delta (ΔT) is a stable, usable signal** with 3 rules × 2 fixtures × 2 reps = 16 converter runs (~$40).

## What's implemented

### 1. Design tree stripper (`src/agents/ablation/design-tree-stripper.ts`)
Removes rule-specific information from text-based design trees:
- **`no-auto-layout`**: strips layout CSS (display, flex-direction, gap, align-items, justify-content)
- **`missing-component`**: strips `[component: ...]` annotations
- **`default-name`**: replaces node names with "Frame 1", "Group 2", etc.

### 2. Ablation runner (`src/agents/ablation/ablation-runner.ts`)
Calls Anthropic API (claude-sonnet-4-6) with extended thinking enabled to:
- Convert design tree to HTML
- Capture `thinkingTokens` and `outputTokens`

### 3. Pilot orchestrator (`src/agents/ablation/pilot.ts`)
CLI-runnable: `npx tsx src/agents/ablation/pilot.ts <fixture-dir>`
- Runs baseline (full design tree) × 2 reps
- Runs ablation (stripped tree) × 2 reps per rule
- Computes ΔT, ΔV, coefficient of variation
- Outputs `results.json` + `summary.md` to `logs/ablation/pilot--<timestamp>/`

## Pass criteria

| Check | Threshold |
|---|---|
| ΔT coefficient of variation | < 30% |
| ΔV direction | negative (stripped → worse visual) |
| Strip clean | no errors |

## Contingency if pilot fails

```
ΔT stable?  → Yes → ΔT + ΔV both used (Step 1)
    ↓ No
ΔV alone valid?  → Yes → ΔV-only OAT + component rules separate
    ↓ No
Strip issue?  → Yes → Switch to perturbation (inject wrong values)
    ↓ No
    → Abandon OAT, manual evaluation (Alternative 2)
```

## Test plan

- [x] 681 tests pass (19 new stripper tests)
- [x] Type check clean

Closes step 0 of #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)