### PR TITLE
docs: document MCP limitations for responsive and instance internals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,16 +82,24 @@ app/                          # Browser runtime
 
 | Feature | CLI (REST API) | MCP (Figma MCP) |
 |---------|:-:|:-:|
-| Node structure | ✅ Full tree | ✅ XML metadata |
+| Node structure | ✅ Full tree | ⚠️ XML metadata (instance internals collapsed) |
 | Style values | ✅ Raw Figma JSON | ✅ React+Tailwind code |
 | Component metadata (name, desc) | ✅ | ❌ |
 | Component master trees | ✅ `componentDefinitions` | ❌ |
+| Instance internals | ✅ Full subtree | ❌ `<instance ... />` collapsed |
+| Responsive behavior | ✅ Inherent (root-only width fix) | ⚠️ Depends on LLM post-processing |
 | Annotations (dev mode) | ❌ private beta | ✅ `data-annotations` |
 | Screenshots | ✅ via API | ✅ `get_screenshot` |
 | FIGMA_TOKEN required | ✅ | ❌ |
 
+**Known MCP limitations:**
+- `get_metadata` returns collapsed `<symbol ... />` for COMPONENT nodes and `<instance ... />` for INSTANCE nodes — internal children are not expanded, so component/instance subtree analysis is incomplete
+- MCP-generated code embeds hardcoded widths (e.g., `w-[375px]`) in child elements, requiring LLM post-processing to remove ALL fixed widths for responsive behavior
+- CLI/design-tree path is inherently responsive — only the ROOT element's fixed width needs to be removed
+
 **When to use which:**
 - Accurate component analysis (style overrides, missing-component) → **CLI with FIGMA_TOKEN**
+- Responsive design-to-code with minimal fixup → **CLI with FIGMA_TOKEN** (design-tree path)
 - Quick structure/style check, annotation-aware workflows → **MCP**
 - Offline/CI analysis → **CLI with saved fixtures**
 

--- a/src/core/adapters/figma-mcp-adapter.ts
+++ b/src/core/adapters/figma-mcp-adapter.ts
@@ -2,7 +2,11 @@ import type { AnalysisFile, AnalysisNode, AnalysisNodeType } from "../contracts/
 import { parseDesignContextCode, parseCodeHeader, enrichNodeWithStyles } from "./tailwind-parser.js";
 
 /**
- * Map MCP XML tag names to Figma AnalysisNodeType
+ * Map MCP XML tag names to Figma AnalysisNodeType.
+ *
+ * Note: `symbol` and `instance` tags are typically self-closing in get_metadata
+ * output (e.g., `<symbol ... />`, `<instance ... />`), meaning their internal
+ * children are not available through the MCP path.
  */
 const TAG_TYPE_MAP: Record<string, AnalysisNodeType> = {
   canvas: "CANVAS",
@@ -109,7 +113,12 @@ function parseAttributes(attrString: string): Record<string, string> {
 }
 
 /**
- * Convert a parsed XML node to an AnalysisNode
+ * Convert a parsed XML node to an AnalysisNode.
+ *
+ * Note: Self-closing XML tags (e.g., `<instance ... />` or `<symbol ... />`)
+ * will produce AnalysisNodes with no children. This is expected — MCP
+ * get_metadata collapses component/instance internals. These leaf nodes still
+ * carry position, size, and name data useful for structure-level rules.
  */
 function toAnalysisNode(xmlNode: ParsedXmlNode): AnalysisNode {
   const type = TAG_TYPE_MAP[xmlNode.tag] ?? "FRAME";
@@ -142,6 +151,20 @@ function toAnalysisNode(xmlNode: ParsedXmlNode): AnalysisNode {
  *
  * The XML represents a subtree of the Figma file. We wrap it in a
  * DOCUMENT node and fill in minimal file metadata.
+ *
+ * **Known limitations (as of 2026-03):**
+ * - `get_metadata` returns collapsed (self-closing) `<symbol ... />` for COMPONENT
+ *   nodes and `<instance ... />` for some INSTANCE nodes. Internal children are NOT
+ *   expanded, so component/instance subtree analysis is incomplete compared to the
+ *   CLI/REST API path which provides full `componentDefinitions`.
+ * - This parser still produces valid AnalysisFile output for rule analysis (layout,
+ *   spacing, naming, etc.), but rules that depend on instance internals or component
+ *   master trees (e.g., style-override detection, missing-component) will have
+ *   reduced accuracy.
+ * - MCP-generated code (via get_design_context) embeds hardcoded widths in child
+ *   elements, making responsive behavior dependent on LLM post-processing to strip
+ *   fixed widths. The CLI/design-tree path is inherently responsive (only root width
+ *   needs removal).
  */
 export function parseMcpMetadataXml(
   xml: string,
@@ -186,6 +209,17 @@ export function parseMcpMetadataXml(
  * The design context code is React+Tailwind generated for a specific node.
  * We parse Tailwind classes to extract layout, color, spacing, and effect
  * properties, then merge them into matching AnalysisNodes in the tree.
+ *
+ * **Known limitations:**
+ * - Since get_metadata collapses instance/component internals, enrichment can
+ *   only apply styles to nodes that exist in the metadata tree. Child nodes
+ *   inside collapsed instances are never enriched.
+ * - The enrichChildrenFromCode heuristic matches children by name comments in
+ *   the generated code, which is fragile and only works for direct children
+ *   that Figma MCP chose to annotate with comments.
+ * - Despite these limitations, this function provides meaningful style data
+ *   for structure-level analysis (layout, spacing, colors) and is still used
+ *   by the MCP analysis path.
  *
  * @param file - AnalysisFile from parseMcpMetadataXml
  * @param designContextCode - Code string from get_design_context

--- a/src/core/engine/design-data-parser.ts
+++ b/src/core/engine/design-data-parser.ts
@@ -7,7 +7,8 @@ import { transformFigmaResponse } from "../adapters/figma-transformer.js";
  * Parse design data passed directly from Figma MCP or other sources.
  *
  * Accepts:
- * - XML string from Figma MCP get_metadata
+ * - XML string from Figma MCP get_metadata (note: instance/component internals
+ *   are collapsed — see parseMcpMetadataXml for known limitations)
  * - JSON string of an AnalysisFile object
  * - JSON string of a Figma REST API GetFileResponse
  */


### PR DESCRIPTION
## Summary

Document known MCP limitations discovered during ablation experiments. No code deleted — only documentation and comments added.

## Changes

### CLAUDE.md
- Updated MCP vs CLI comparison table: added "Instance internals" and "Responsive behavior" rows
- Added "Known MCP limitations" section documenting:
  - `get_metadata` collapses instance/symbol internals
  - MCP code hardcodes `w-[375px]` in child elements (responsive requires LLM post-processing)
  - CLI/design-tree is inherently responsive (root-only fix)

### src/core/adapters/figma-mcp-adapter.ts
- Added limitation comments to `TAG_TYPE_MAP`, `toAnalysisNode`, `parseMcpMetadataXml`, `enrichWithDesignContext`

### src/core/engine/design-data-parser.ts  
- Added cross-reference note to `parseMcpMetadataXml` limitations

## Decision

Option D from #120: Accept the quality difference between CLI and MCP paths. Don't try to force MCP→design-tree conversion.

| Path | Responsive | Quality |
|---|---|---|
| CLI → design-tree | Root fix only | Gold (94-95%) |
| MCP → direct render | LLM post-processing needed | Good (92-94%) |

Closes #120

## Test plan

- [x] 662 tests pass
- [x] Type check clean
- [x] Documentation only — no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify MCP metadata limitations, including collapsed component/instance nodes and hardcoded fixed widths in generated code.
  * Added guidance on using the CLI design-tree path for responsive design generation with minimal post-processing.
  * Expanded known limitations section with details on metadata handling behavior and enrichment constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->