### PR TITLE
fix: remove gauge active state and page-level analysis from plugin (#177)

### DIFF
--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -452,50 +452,6 @@ figma.ui.onmessage = async (msg: { type: string }) => {
     });
   }
 
-  if (msg.type === "analyze-page") {
-    const page = figma.currentPage;
-    const children = page.children;
-
-    if (children.length === 0) {
-      figma.ui.postMessage({
-        type: "error",
-        message: "Current page is empty.",
-      });
-      return;
-    }
-
-    // Wrap page children into a virtual FRAME document node
-    const allChildren: AnalysisNode[] = [];
-    let totalNodes = 0;
-
-    for (const child of children) {
-      totalNodes += countNodes(child as unknown as { children?: readonly unknown[] });
-      allChildren.push(await transformPluginNode(child));
-    }
-
-    const file: AnalysisFile = {
-      fileKey: figma.fileKey ?? "plugin-local",
-      name: page.name,
-      lastModified: new Date().toISOString(),
-      version: "plugin",
-      document: {
-        id: page.id,
-        name: page.name,
-        type: "CANVAS",
-        visible: true,
-        children: allChildren,
-      },
-      components: {},
-      styles: {},
-    };
-
-    figma.ui.postMessage({
-      type: "result",
-      data: file,
-      nodeCount: totalNodes,
-    });
-  }
-
   if (msg.type === "focus-node") {
     const { nodeId } = msg as { type: string; nodeId: string };
     const node = figma.getNodeByIdAsync(nodeId).then((n) => {

--- a/app/figma-plugin/src/ui.template.html
+++ b/app/figma-plugin/src/ui.template.html
@@ -17,7 +17,6 @@
     <!-- Action buttons -->
     <div class="btn-group">
       <button class="btn btn-primary" id="btn-selection" onclick="analyzeSelection()">Analyze Selection</button>
-      <button class="btn" id="btn-page" onclick="analyzePage()">Analyze Page</button>
     </div>
 
     <!-- Error display -->
@@ -26,8 +25,7 @@
     <!-- Empty state -->
     <div id="empty-state" class="empty-state">
       <h2>Ready to analyze</h2>
-      <p>Select a frame, component, or section in Figma, then click <strong>Analyze Selection</strong>.<br>
-      Or click <strong>Analyze Page</strong> to check the entire current page.</p>
+      <p>Select a frame, component, or section in Figma, then click <strong>Analyze Selection</strong>.</p>
     </div>
 
     <!-- Loading -->
@@ -102,11 +100,6 @@
       parent.postMessage({ pluginMessage: { type: 'analyze-selection' } }, '*');
     }
 
-    function analyzePage() {
-      showLoading();
-      parent.postMessage({ pluginMessage: { type: 'analyze-page' } }, '*');
-    }
-
     function showLoading() {
       document.getElementById('empty-state').style.display = 'none';
       document.getElementById('results').className = '';
@@ -114,7 +107,6 @@
       document.getElementById('loading').style.display = 'block';
       document.getElementById('error').style.display = 'none';
       document.getElementById('btn-selection').disabled = true;
-      document.getElementById('btn-page').disabled = true;
     }
 
     function showError(msg) {
@@ -127,7 +119,6 @@
       errEl.textContent = msg;
       errEl.style.display = 'block';
       document.getElementById('btn-selection').disabled = false;
-      document.getElementById('btn-page').disabled = false;
     }
 
     // ---- Render results via shared renderReportBody() ----
@@ -172,8 +163,7 @@
 
       if (msg.type === 'result') {
         document.getElementById('btn-selection').disabled = false;
-        document.getElementById('btn-page').disabled = false;
-
+  
         try {
           var analysisStart = Date.now();
           var file = msg.data;

--- a/app/shared/styles.css
+++ b/app/shared/styles.css
@@ -338,13 +338,6 @@ body {
   text-align: center;
 }
 
-/* ---- Gauge item active highlight ---- */
-.rpt-gauge-item.active {
-  opacity: 1;
-  background: rgba(0,0,0,0.04);
-  border-radius: var(--radius);
-}
-
 /* ---- Score badge ---- */
 .rpt-badge {
   display: inline-flex;

--- a/src/core/report-html/render.ts
+++ b/src/core/report-html/render.ts
@@ -76,9 +76,9 @@ export function renderReportBody(data: ReportData): string {
     <!-- Category Gauges -->
     <section class="card rpt-gauges">
       <div class="rpt-gauges-grid">
-${CATEGORIES.map((cat, i) => {
+${CATEGORIES.map((cat) => {
     const cs = scores.byCategory[cat];
-    return `        <button type="button" class="rpt-gauge-item${i === 0 ? " active" : ""}" data-tab="${cat}">
+    return `        <button type="button" class="rpt-gauge-item" data-tab="${cat}">
           ${renderGaugeSvg(cs.percentage, 100, 7)}
           <span class="rpt-gauge-label">${CATEGORY_LABELS[cat]}</span>
           <span class="rpt-gauge-count">${cs.issueCount} issues</span>
@@ -251,9 +251,6 @@ export function initReportInteractions(container: any): void {
     });
     container.querySelectorAll(".rpt-tab-panel").forEach((p: any) => {
       p.classList.toggle("active", p.dataset.panel === cat);
-    });
-    container.querySelectorAll(".rpt-gauge-item").forEach((g: any) => {
-      g.classList.toggle("active", g.dataset.tab === cat);
     });
     if (scrollTo) {
       const tabList = container.querySelector(".rpt-tab-list");


### PR DESCRIPTION
## Summary
- Remove unnecessary `active` class from gauge items — gauges are category score summaries, not tab navigation
- Remove page-level analysis from Figma plugin — only node selection (frame/section) is supported per Analysis Scope Policy

## Changes
- `render.ts` — remove active class from first gauge item, remove gauge active toggle in interactions
- `styles.css` — remove `.rpt-gauge-item.active` style
- `main.ts` — remove `analyze-page` message handler
- `ui.template.html` — remove "Analyze Page" button, `analyzePage()` function, related disabled toggles

## Test plan
- [x] `pnpm lint` — pass
- [x] `pnpm test:run` — 646 tests pass
- [x] `pnpm build` — CLI/MCP build pass
- [x] `pnpm build:plugin` — Figma plugin build pass
- [x] `pnpm build:web` — Web app build pass
- [x] Visual check: all gauge items render identically (no active highlight)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed "Analyze Page" functionality; "Analyze Selection" is now the only available analysis option.
  * Removed active state visual styling from gauge indicators in reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->