### PR TITLE
fix: Claude PostToolUse hooks schema (.claude/settings.json)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,8 +3,18 @@
     "PostToolUse": [
       {
         "matcher": "Edit|Write",
-        "filePattern": "src/core/rules/**",
-        "command": "npx tsx scripts/sync-rule-docs.ts"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx scripts/sync-rule-docs.ts",
+            "if": "Edit(**/src/core/rules/**)"
+          },
+          {
+            "type": "command",
+            "command": "npx tsx scripts/sync-rule-docs.ts",
+            "if": "Write(**/src/core/rules/**)"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary

Updates project `.claude/settings.json` so `PostToolUse` matches the [Claude Code hooks schema](https://code.claude.com/docs/en/hooks): each matcher group must include a `hooks` array of handlers (`type: "command"`, `command`, optional `if`).

## Changes

- Replace invalid top-level `command` / `filePattern` with nested `hooks` entries.
- Scope sync with `if` permission patterns for `Edit` / `Write` under `**/src/core/rules/**`.

## Why

Without the nested `hooks` array, Claude Code reported: `hooks: Expected array, but received undefined`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration to improve command execution efficiency for rule documentation synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->