### PR TITLE
fix: deterministic evidence ratio for Critic (#184)

### DIFF
--- a/.claude/agents/calibration/critic.md
+++ b/.claude/agents/calibration/critic.md
@@ -25,8 +25,26 @@ You will receive:
 2. **Converter assessment** — `ruleImpactAssessment` showing actual implementation difficulty per rule
 3. **Gap analysis** — actionable pixel gaps between Figma and generated code
 4. **Prior evidence** — cross-run calibration evidence for the proposed rules (accumulated from past runs)
+5. **Evidence ratios** — `evidenceRatios` object with pre-computed statistical summaries per rule
 
 Use ALL inputs to form pro/con arguments. Do not rely on proposals alone.
+
+### Evidence Ratios (critical for contradictory evidence)
+
+The `evidenceRatios` field contains **deterministic, pre-computed** ratio summaries for each proposed rule. Use these instead of manually interpreting raw overscored/underscored counts.
+
+Each ratio entry includes:
+- `dominantDirection`: `"overscored"` | `"underscored"` | `"mixed"` — the clear signal direction
+- `dominantRate`: percentage of fixtures agreeing (e.g., 0.7 = 70%)
+- `expectedDifficulty`: the most common difficulty from the dominant direction
+- `confidence`: `"high"` | `"medium"` | `"low"` | `"insufficient"` — based on sample size + dominance clarity
+- `summary`: human-readable conclusion
+
+**How to use evidence ratios:**
+- If `confidence` is `"high"` or `"medium"` and `dominantDirection` is NOT `"mixed"`, the direction is clear — do NOT treat it as contradictory even if both overscored and underscored entries exist.
+- If `confidence` is `"insufficient"` (< 3 samples), defer judgment — evidence is too thin.
+- If `dominantDirection` is `"mixed"`, the evidence genuinely lacks a clear signal — REJECT or HOLD.
+- The `summary` field gives a one-line verdict you can reference in your reasoning.
 
 ## Rejection Rules
 
@@ -38,9 +56,13 @@ Reject if ANY of these apply:
    - `confidence: medium` → reject if change exceeds 50% of current value
    - `confidence: low` → reject if change exceeds 30% of current value
 3. **Severity jump without evidence**: severity change proposed without `confidence: high`
+4. **Contradictory evidence with no clear majority**: `evidenceRatios[ruleId].dominantDirection` is `"mixed"` — evidence lacks a clear signal
+
 Note: `supportingCases` includes evidence from prior calibration runs.
 A count of 3 may mean 1 case in the current run + 2 from prior runs.
 This is intentional — cross-run evidence increases confidence.
+
+**Important**: When `evidenceRatios` shows a clear dominant direction (e.g., 70%+ rate), do NOT reject solely because both overscored and underscored entries exist. The ratio resolves the contradiction — trust the pre-computed signal.
 
 ## Decisions
 

--- a/src/agents/contracts/evidence.ts
+++ b/src/agents/contracts/evidence.ts
@@ -33,6 +33,23 @@ export type CrossRunEvidenceGroup = z.infer<typeof CrossRunEvidenceGroupSchema>;
 
 export type CrossRunEvidence = Record<string, CrossRunEvidenceGroup>;
 
+// --- Evidence ratio summary (deterministic pre-computation for Critic) ---
+
+export const EvidenceRatioSummarySchema = z.object({
+  totalSamples: z.number(),
+  overscoredCount: z.number(),
+  underscoredCount: z.number(),
+  overscoredRate: z.number(),
+  underscoredRate: z.number(),
+  dominantDirection: z.enum(["overscored", "underscored", "mixed"]),
+  dominantRate: z.number(),
+  expectedDifficulty: z.string(),
+  confidence: z.enum(["high", "medium", "low", "insufficient"]),
+  summary: z.string(),
+});
+
+export type EvidenceRatioSummary = z.infer<typeof EvidenceRatioSummarySchema>;
+
 // --- Discovery evidence ---
 
 export const DISCOVERY_EVIDENCE_SCHEMA_VERSION = 1;

--- a/src/agents/evidence-collector.test.ts
+++ b/src/agents/evidence-collector.test.ts
@@ -6,6 +6,7 @@ import {
   appendCalibrationEvidence,
   enrichCalibrationEvidence,
   pruneCalibrationEvidence,
+  computeEvidenceRatio,
   loadDiscoveryEvidence,
   appendDiscoveryEvidence,
   pruneDiscoveryEvidence,
@@ -13,6 +14,7 @@ import {
 } from "./evidence-collector.js";
 import type {
   CalibrationEvidenceEntry,
+  CrossRunEvidenceGroup,
   DiscoveryEvidenceEntry,
 } from "./evidence-collector.js";
 
@@ -236,6 +238,119 @@ describe("evidence-collector", () => {
 
     it("handles missing file gracefully", () => {
       expect(() => pruneCalibrationEvidence(["rule-a"], calPath)).not.toThrow();
+    });
+  });
+
+  // --- Evidence ratio computation ---
+
+  describe("computeEvidenceRatio", () => {
+    it("returns insufficient for empty group", () => {
+      const group: CrossRunEvidenceGroup = {
+        overscoredCount: 0,
+        underscoredCount: 0,
+        overscoredDifficulties: [],
+        underscoredDifficulties: [],
+        allPro: [],
+        allCon: [],
+      };
+      const ratio = computeEvidenceRatio(group);
+      expect(ratio.confidence).toBe("insufficient");
+      expect(ratio.totalSamples).toBe(0);
+      expect(ratio.dominantDirection).toBe("mixed");
+    });
+
+    it("detects clear overscored direction (7/10 = 70%)", () => {
+      const group: CrossRunEvidenceGroup = {
+        overscoredCount: 7,
+        underscoredCount: 3,
+        overscoredDifficulties: ["easy", "easy", "easy", "easy", "moderate", "easy", "easy"],
+        underscoredDifficulties: ["hard", "hard", "failed"],
+        allPro: [],
+        allCon: [],
+      };
+      const ratio = computeEvidenceRatio(group);
+      expect(ratio.totalSamples).toBe(10);
+      expect(ratio.dominantDirection).toBe("overscored");
+      expect(ratio.dominantRate).toBe(0.7);
+      expect(ratio.expectedDifficulty).toBe("easy");
+      expect(ratio.confidence).toBe("high");
+      expect(ratio.summary).toContain("overscored");
+      expect(ratio.summary).toContain("7/10");
+    });
+
+    it("detects clear underscored direction (7/10 = 70%)", () => {
+      const group: CrossRunEvidenceGroup = {
+        overscoredCount: 3,
+        underscoredCount: 7,
+        overscoredDifficulties: ["easy", "easy", "easy"],
+        underscoredDifficulties: ["hard", "hard", "failed", "hard", "hard", "failed", "hard"],
+        allPro: [],
+        allCon: [],
+      };
+      const ratio = computeEvidenceRatio(group);
+      expect(ratio.dominantDirection).toBe("underscored");
+      expect(ratio.dominantRate).toBe(0.7);
+      expect(ratio.expectedDifficulty).toBe("hard");
+      expect(ratio.confidence).toBe("high");
+    });
+
+    it("returns mixed when neither side has 60%+ majority", () => {
+      const group: CrossRunEvidenceGroup = {
+        overscoredCount: 5,
+        underscoredCount: 5,
+        overscoredDifficulties: ["easy", "easy", "easy", "moderate", "easy"],
+        underscoredDifficulties: ["hard", "hard", "hard", "failed", "hard"],
+        allPro: [],
+        allCon: [],
+      };
+      const ratio = computeEvidenceRatio(group);
+      expect(ratio.dominantDirection).toBe("mixed");
+      expect(ratio.confidence).toBe("low");
+      expect(ratio.summary).toContain("Mixed signals");
+    });
+
+    it("returns insufficient confidence for < 3 samples", () => {
+      const group: CrossRunEvidenceGroup = {
+        overscoredCount: 2,
+        underscoredCount: 0,
+        overscoredDifficulties: ["easy", "easy"],
+        underscoredDifficulties: [],
+        allPro: [],
+        allCon: [],
+      };
+      const ratio = computeEvidenceRatio(group);
+      expect(ratio.dominantDirection).toBe("overscored");
+      expect(ratio.confidence).toBe("insufficient");
+    });
+
+    it("returns medium confidence for 60%+ with 3-4 samples", () => {
+      const group: CrossRunEvidenceGroup = {
+        overscoredCount: 2,
+        underscoredCount: 1,
+        overscoredDifficulties: ["easy", "easy"],
+        underscoredDifficulties: ["hard"],
+        allPro: [],
+        allCon: [],
+      };
+      const ratio = computeEvidenceRatio(group);
+      expect(ratio.dominantDirection).toBe("overscored");
+      expect(ratio.confidence).toBe("medium");
+      expect(ratio.dominantRate).toBeCloseTo(0.667, 2);
+    });
+
+    it("handles all-one-direction case", () => {
+      const group: CrossRunEvidenceGroup = {
+        overscoredCount: 5,
+        underscoredCount: 0,
+        overscoredDifficulties: ["easy", "easy", "moderate", "easy", "easy"],
+        underscoredDifficulties: [],
+        allPro: [],
+        allCon: [],
+      };
+      const ratio = computeEvidenceRatio(group);
+      expect(ratio.dominantDirection).toBe("overscored");
+      expect(ratio.dominantRate).toBe(1);
+      expect(ratio.confidence).toBe("high");
     });
   });
 

--- a/src/agents/evidence-collector.ts
+++ b/src/agents/evidence-collector.ts
@@ -10,10 +10,12 @@ import { CategorySchema } from "../core/contracts/category.js";
 import type {
   CalibrationEvidenceEntry,
   CrossRunEvidence,
+  CrossRunEvidenceGroup,
   DiscoveryEvidenceEntry,
+  EvidenceRatioSummary,
 } from "./contracts/evidence.js";
 
-export type { CalibrationEvidenceEntry, CrossRunEvidence, DiscoveryEvidenceEntry };
+export type { CalibrationEvidenceEntry, CrossRunEvidence, CrossRunEvidenceGroup, DiscoveryEvidenceEntry, EvidenceRatioSummary };
 export { DISCOVERY_EVIDENCE_SCHEMA_VERSION };
 
 const DEFAULT_CALIBRATION_PATH = resolve("data/calibration-evidence.json");
@@ -97,6 +99,116 @@ export function loadCalibrationEvidence(
   }
 
   return result;
+}
+
+/**
+ * Minimum sample size before ratio-based confidence kicks in.
+ * Below this threshold, confidence is "insufficient".
+ */
+const MIN_RATIO_SAMPLES = 3;
+
+/**
+ * Difficulty dominance: pick the most frequent difficulty from a list.
+ */
+function dominantDifficulty(difficulties: string[]): string {
+  if (difficulties.length === 0) return "moderate";
+  const counts: Record<string, number> = {};
+  for (const d of difficulties) {
+    counts[d] = (counts[d] ?? 0) + 1;
+  }
+  let best = difficulties[0]!;
+  let bestCount = 0;
+  for (const [d, c] of Object.entries(counts)) {
+    if (c > bestCount) {
+      bestCount = c;
+      best = d;
+    }
+  }
+  return best;
+}
+
+/**
+ * Compute a deterministic ratio summary from cross-run evidence for a single rule.
+ * This pre-digests contradictory evidence into a clear signal so the Critic
+ * doesn't have to do statistics — it just reads the conclusion.
+ */
+export function computeEvidenceRatio(group: CrossRunEvidenceGroup): EvidenceRatioSummary {
+  const total = group.overscoredCount + group.underscoredCount;
+
+  if (total === 0) {
+    return {
+      totalSamples: 0,
+      overscoredCount: 0,
+      underscoredCount: 0,
+      overscoredRate: 0,
+      underscoredRate: 0,
+      dominantDirection: "mixed",
+      dominantRate: 0,
+      expectedDifficulty: "moderate",
+      confidence: "insufficient",
+      summary: "No evidence available.",
+    };
+  }
+
+  const overscoredRate = group.overscoredCount / total;
+  const underscoredRate = group.underscoredCount / total;
+
+  // Determine dominant direction
+  let dir: "overscored" | "underscored" | "mixed";
+  let dominantRate: number;
+  if (overscoredRate >= 0.6) {
+    dir = "overscored";
+    dominantRate = overscoredRate;
+  } else if (underscoredRate >= 0.6) {
+    dir = "underscored";
+    dominantRate = underscoredRate;
+  } else {
+    dir = "mixed";
+    dominantRate = Math.max(overscoredRate, underscoredRate);
+  }
+
+  // Expected difficulty from the dominant direction's difficulties
+  const relevantDifficulties =
+    dir === "underscored"
+      ? group.underscoredDifficulties
+      : dir === "overscored"
+        ? group.overscoredDifficulties
+        : [...group.overscoredDifficulties, ...group.underscoredDifficulties];
+  const expectedDiff = dominantDifficulty(relevantDifficulties);
+
+  // Confidence based on sample size + dominance clarity
+  let confidence: "high" | "medium" | "low" | "insufficient";
+  if (total < MIN_RATIO_SAMPLES) {
+    confidence = "insufficient";
+  } else if (dominantRate >= 0.7 && total >= 5) {
+    confidence = "high";
+  } else if (dominantRate >= 0.6 && total >= MIN_RATIO_SAMPLES) {
+    confidence = "medium";
+  } else {
+    confidence = "low";
+  }
+
+  // Human-readable summary
+  const pct = (r: number) => `${Math.round(r * 100)}%`;
+  let summary: string;
+  if (dir === "mixed") {
+    summary = `Mixed signals: ${group.overscoredCount} overscored (${pct(overscoredRate)}) vs ${group.underscoredCount} underscored (${pct(underscoredRate)}) across ${total} fixtures. No clear direction.`;
+  } else {
+    summary = `${total} fixtures: ${dir} in ${dir === "overscored" ? group.overscoredCount : group.underscoredCount}/${total} (${pct(dominantRate)}). Expected difficulty: ${expectedDiff}. Confidence: ${confidence}.`;
+  }
+
+  return {
+    totalSamples: total,
+    overscoredCount: group.overscoredCount,
+    underscoredCount: group.underscoredCount,
+    overscoredRate: Math.round(overscoredRate * 1000) / 1000,
+    underscoredRate: Math.round(underscoredRate * 1000) / 1000,
+    dominantDirection: dir,
+    dominantRate: Math.round(dominantRate * 1000) / 1000,
+    expectedDifficulty: expectedDiff,
+    confidence,
+    summary,
+  };
 }
 
 /**

--- a/src/cli/commands/internal/calibrate-debate.test.ts
+++ b/src/cli/commands/internal/calibrate-debate.test.ts
@@ -51,11 +51,13 @@ describe("gatherEvidence", () => {
     expect(evidence.uncoveredStruggles).toHaveLength(0);
     expect(evidence.actionableGaps).toHaveLength(0);
     expect(evidence.priorEvidence).toEqual({});
+    expect(evidence.evidenceRatios).toEqual({});
   });
 
-  it("returns empty priorEvidence when no ruleIds proposed", () => {
+  it("returns empty priorEvidence and evidenceRatios when no ruleIds proposed", () => {
     const evidence = gatherEvidence(runDir, []);
     expect(evidence.priorEvidence).toEqual({});
+    expect(evidence.evidenceRatios).toEqual({});
   });
 });
 

--- a/src/cli/commands/internal/calibrate-debate.ts
+++ b/src/cli/commands/internal/calibrate-debate.ts
@@ -3,7 +3,8 @@ import { join } from "node:path";
 import type { CAC } from "cac";
 
 import { parseDebateResult } from "../../../agents/run-directory.js";
-import { loadCalibrationEvidence } from "../../../agents/evidence-collector.js";
+import { loadCalibrationEvidence, computeEvidenceRatio } from "../../../agents/evidence-collector.js";
+import type { EvidenceRatioSummary } from "../../../agents/contracts/evidence.js";
 import { resolveRunDir } from "./cli-helpers.js";
 
 // ─── calibrate-gather-evidence ──────────────────────────────────────────────
@@ -13,6 +14,7 @@ export interface GatheredEvidence {
   uncoveredStruggles: unknown[];
   actionableGaps: unknown[];
   priorEvidence: Record<string, unknown>;
+  evidenceRatios: Record<string, EvidenceRatioSummary>;
 }
 
 /**
@@ -25,6 +27,7 @@ export function gatherEvidence(runDir: string, proposedRuleIds: string[]): Gathe
     uncoveredStruggles: [],
     actionableGaps: [],
     priorEvidence: {},
+    evidenceRatios: {},
   };
 
   // 1. conversion.json → ruleImpactAssessment, uncoveredStruggles
@@ -54,13 +57,14 @@ export function gatherEvidence(runDir: string, proposedRuleIds: string[]): Gathe
     } catch { /* ignore malformed */ }
   }
 
-  // 3. Prior evidence filtered to proposed rules only
+  // 3. Prior evidence filtered to proposed rules only + ratio summaries
   if (proposedRuleIds.length > 0) {
     const allEvidence = loadCalibrationEvidence();
     const ruleSet = new Set(proposedRuleIds.map((id) => id.trim()));
     for (const [ruleId, group] of Object.entries(allEvidence)) {
       if (ruleSet.has(ruleId)) {
         result.priorEvidence[ruleId] = group;
+        result.evidenceRatios[ruleId] = computeEvidenceRatio(group);
       }
     }
   }
@@ -113,7 +117,8 @@ export function registerGatherEvidence(cli: CAC): void {
       // Write to file for orchestrator to include in Critic prompt
       const outPath = join(dir, "critic-evidence.json");
       writeFileSync(outPath, JSON.stringify(evidence, null, 2) + "\n", "utf-8");
-      console.log(`Gathered evidence: ${evidence.ruleImpactAssessment.length} impact assessments, ${evidence.actionableGaps.length} gaps, ${Object.keys(evidence.priorEvidence).length} prior rules`);
+      const ratioCount = Object.keys(evidence.evidenceRatios).length;
+      console.log(`Gathered evidence: ${evidence.ruleImpactAssessment.length} impact assessments, ${evidence.actionableGaps.length} gaps, ${Object.keys(evidence.priorEvidence).length} prior rules (${ratioCount} with ratio summaries)`);
       console.log(`Written to ${outPath}`);
     });
 }


### PR DESCRIPTION
## Summary

- Critic이 contradictory evidence를 "양쪽 다 존재 → reject"로 처리하던 문제 수정
- `computeEvidenceRatio()` deterministic 함수 추가 — cross-run evidence를 ratio/direction/confidence로 사전 계산
- `gatherEvidence()`가 `evidenceRatios`를 `critic-evidence.json`에 포함
- Critic 프롬프트에 ratio 기반 판단 가이드 추가

## 변경 내용

| 파일 | 변경 |
|------|------|
| `src/agents/contracts/evidence.ts` | `EvidenceRatioSummary` 타입 추가 |
| `src/agents/evidence-collector.ts` | `computeEvidenceRatio()` 함수 추가 |
| `src/cli/commands/internal/calibrate-debate.ts` | `gatherEvidence()`에 ratio 계산 통합, `GatheredEvidence`에 `evidenceRatios` 필드 추가 |
| `.claude/agents/calibration/critic.md` | ratio 기반 판단 가이드 + Rule 4 (mixed → REJECT) 추가 |

## 예시

```
Before: overscoredCount=3, underscoredCount=7 → Critic: "contradictory → REJECT"
After:  dominantDirection="underscored", dominantRate=0.7, confidence="high"
        → Critic: "70% underscored, clear signal → APPROVE"
```

## Test plan

- [x] `computeEvidenceRatio` — 7개 테스트 케이스 (empty, clear overscored/underscored, mixed, insufficient, medium, all-one-direction)
- [x] `gatherEvidence` — 기존 테스트에 `evidenceRatios` 검증 추가
- [x] 전체 657 테스트 통과, type check clean

## Context

- Closes #184
- #188 C-3 부분 해결 (코멘트 업데이트 완료)
- #191 (ablation 통합) 선행 작업 — ratio는 ablation 통합 후에도 안전망으로 유효

https://claude.ai/code/session_01MYoA8SpA4qAB2cYVm9aUqr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Evidence ratio analysis now provides deterministic statistical summaries per calibration rule, including overscored/underscored rates, dominance direction, confidence levels, and expected difficulty assessment to enhance proposal evaluation.

* **Tests**
  * Added comprehensive test coverage for ratio computation, validating behavior across edge cases including empty data, mixed signals, and varying confidence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->