### PR TITLE
fix: Figma comment and deep link for instance-internal nodes

### DIFF
--- a/app/web/src/index.html
+++ b/app/web/src/index.html
@@ -372,7 +372,8 @@
       var token = getToken();
       if (!token) return;
       var fileKey = btn.dataset.fileKey;
-      var nodeId = CanICode.toCommentableNodeId(btn.dataset.nodeId.replace(/-/g, ':'));
+      var rawId = btn.dataset.nodeId.replace(/-/g, ':');
+      var nodeId = rawId.split(';')[0].replace(/^I/, '');
       var commentBody = '[CanICode] ' + btn.dataset.message;
       btn.disabled = true;
       btn.textContent = 'Sending...';

--- a/app/web/src/index.html
+++ b/app/web/src/index.html
@@ -372,7 +372,7 @@
       var token = getToken();
       if (!token) return;
       var fileKey = btn.dataset.fileKey;
-      var nodeId = btn.dataset.nodeId.replace(/-/g, ':').split(';')[0].replace(/^I/, '');
+      var nodeId = CanICode.toCommentableNodeId(btn.dataset.nodeId.replace(/-/g, ':'));
       var commentBody = '[CanICode] ' + btn.dataset.message;
       btn.disabled = true;
       btn.textContent = 'Sending...';

--- a/app/web/src/index.html
+++ b/app/web/src/index.html
@@ -372,7 +372,7 @@
       var token = getToken();
       if (!token) return;
       var fileKey = btn.dataset.fileKey;
-      var nodeId = btn.dataset.nodeId.replace(/-/g, ':');
+      var nodeId = btn.dataset.nodeId.replace(/-/g, ':').split(';')[0].replace(/^I/, '');
       var commentBody = '[CanICode] ' + btn.dataset.message;
       btn.disabled = true;
       btn.textContent = 'Sending...';

--- a/app/web/src/index.html
+++ b/app/web/src/index.html
@@ -153,7 +153,6 @@
         <label for="auth-token-input" class="web-input-label">Figma Personal Access Token</label>
         <input id="auth-token-input" type="password" placeholder="figd_..." class="web-input">
         <p class="web-hint">
-          <svg width="12" height="12" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>
           Stored in your browser session only. Sent directly from your browser to Figma when you analyze or post a comment.
         </p>
         <p class="web-hint" style="margin-top:8px">

--- a/app/web/src/index.html
+++ b/app/web/src/index.html
@@ -388,7 +388,7 @@
           var errMsg = res.status === 400 ? 'Bad request — check node ID format' : res.status === 403 ? 'Token lacks file access' : res.status === 404 ? 'File not found' : res.status === 429 ? 'Rate limited — try again later' : 'HTTP ' + res.status;
           throw new Error(errMsg + (errBody ? ': ' + errBody.slice(0, 100) : ''));
         }
-        btn.textContent = 'Sent \u2713';
+        btn.textContent = 'Sent';
         btn.classList.remove('rpt-btn-fail');
         btn.classList.add('rpt-btn-ok');
         window._trackEvent && window._trackEvent('cic_comment_posted', {});

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -7,7 +7,7 @@ export type { AnalysisResult, AnalysisIssue, RuleFailure, RuleEngineOptions } fr
 export { calculateScores, formatScoreSummary, getCategoryLabel, getSeverityLabel, gradeToClassName } from "./core/engine/scoring.js";
 export type { ScoreReport, CategoryScoreResult, Grade } from "./core/engine/scoring.js";
 export { transformFigmaResponse, transformFileNodesResponse } from "./core/adapters/figma-transformer.js";
-export { parseFigmaUrl, buildFigmaDeepLink } from "./core/adapters/figma-url-parser.js";
+export { parseFigmaUrl, buildFigmaDeepLink, toCommentableNodeId } from "./core/adapters/figma-url-parser.js";
 export type { FigmaUrlInfo } from "./core/adapters/figma-url-parser.js";
 export { CATEGORIES, CATEGORY_LABELS } from "./core/contracts/category.js";
 export type { Category } from "./core/contracts/category.js";

--- a/src/core/adapters/figma-url-parser.ts
+++ b/src/core/adapters/figma-url-parser.ts
@@ -58,6 +58,7 @@ export function toCommentableNodeId(nodeId: string): string {
 
 export function buildFigmaDeepLink(fileKey: string, nodeId: string): string {
   // Figma URLs use hyphens instead of colons: "3010:7457" → "3010-7457"
+  // Semicolons (instance path separators) are kept as-is — Figma expects them unencoded
   const urlNodeId = nodeId.replace(/:/g, "-");
-  return `https://www.figma.com/design/${fileKey}?node-id=${encodeURIComponent(urlNodeId)}`;
+  return `https://www.figma.com/design/${fileKey}?node-id=${urlNodeId}`;
 }

--- a/src/core/adapters/figma-url-parser.ts
+++ b/src/core/adapters/figma-url-parser.ts
@@ -57,8 +57,8 @@ export function toCommentableNodeId(nodeId: string): string {
 }
 
 export function buildFigmaDeepLink(fileKey: string, nodeId: string): string {
-  // Figma URLs: colons → hyphens, semicolons kept as-is (not encoded)
-  // e.g. "I175:7425;18:9402" → "node-id=I175-7425;18-9402"
-  const urlNodeId = nodeId.replace(/:/g, "-");
-  return `https://www.figma.com/design/${fileKey}?node-id=${urlNodeId}`;
+  // Strip instance-internal path to top-level node:
+  // "I175:7425;1442:7704" → "175:7425" → "175-7425"
+  const topNodeId = toCommentableNodeId(nodeId).replace(/:/g, "-");
+  return `https://www.figma.com/design/${fileKey}?node-id=${topNodeId}`;
 }

--- a/src/core/adapters/figma-url-parser.ts
+++ b/src/core/adapters/figma-url-parser.ts
@@ -57,8 +57,8 @@ export function toCommentableNodeId(nodeId: string): string {
 }
 
 export function buildFigmaDeepLink(fileKey: string, nodeId: string): string {
-  // Figma URLs use hyphens instead of colons: "3010:7457" → "3010-7457"
-  // Semicolons (instance path separators) are kept as-is — Figma expects them unencoded
+  // Figma URLs: colons → hyphens, semicolons kept as-is (not encoded)
+  // e.g. "I175:7425;18:9402" → "node-id=I175-7425;18-9402"
   const urlNodeId = nodeId.replace(/:/g, "-");
   return `https://www.figma.com/design/${fileKey}?node-id=${urlNodeId}`;
 }

--- a/src/core/adapters/figma-url-parser.ts
+++ b/src/core/adapters/figma-url-parser.ts
@@ -45,6 +45,19 @@ export class FigmaUrlParseError extends Error {
   }
 }
 
+/**
+ * Extract the commentable node ID from a potentially nested instance path.
+ * Instance-internal IDs like "I3010:7457;1442:7704" use semicolons to
+ * separate path segments. The Figma Comments API only accepts simple IDs
+ * (e.g. "3010:7457"), so we take the first segment and strip the "I" prefix.
+ */
+export function toCommentableNodeId(nodeId: string): string {
+  const firstSegment = nodeId.split(";")[0]!;
+  return firstSegment.replace(/^I/, "");
+}
+
 export function buildFigmaDeepLink(fileKey: string, nodeId: string): string {
-  return `https://www.figma.com/design/${fileKey}?node-id=${encodeURIComponent(nodeId)}`;
+  // Figma URLs use hyphens instead of colons: "3010:7457" → "3010-7457"
+  const urlNodeId = nodeId.replace(/:/g, "-");
+  return `https://www.figma.com/design/${fileKey}?node-id=${encodeURIComponent(urlNodeId)}`;
 }

--- a/src/core/report-html/index.ts
+++ b/src/core/report-html/index.ts
@@ -107,7 +107,8 @@ function renderFigmaCommentScript(figmaToken: string): string {
     const FIGMA_TOKEN = '${figmaToken}';
     async function postComment(btn) {
       const fileKey = btn.dataset.fileKey;
-      const nodeId = btn.dataset.nodeId.replace(/-/g, ':').split(';')[0].replace(/^I/, '');
+      const nodeId = btn.dataset.nodeId.replace(/-/g, ':');
+      const commentNodeId = nodeId.split(';')[0].replace(/^I/, '');
       const message = btn.dataset.message;
       const commentBody = '[CanICode] ' + message;
       btn.disabled = true;
@@ -117,7 +118,7 @@ function renderFigmaCommentScript(figmaToken: string): string {
         const res = await fetch('https://api.figma.com/v1/files/' + fileKey + '/comments', {
           method: 'POST',
           headers: { 'X-FIGMA-TOKEN': FIGMA_TOKEN, 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message: commentBody, client_meta: { node_id: nodeId, node_offset: { x: 0, y: 0 } } }),
+          body: JSON.stringify({ message: commentBody, client_meta: { node_id: commentNodeId, node_offset: { x: 0, y: 0 } } }),
         });
         if (!res.ok) {
           const errBody = await res.text().catch(() => '');

--- a/src/core/report-html/index.ts
+++ b/src/core/report-html/index.ts
@@ -125,7 +125,7 @@ function renderFigmaCommentScript(figmaToken: string): string {
           const errMsg = res.status === 400 ? 'Bad request' : res.status === 403 ? 'Token lacks file access' : res.status === 404 ? 'File not found' : res.status === 429 ? 'Rate limited' : 'HTTP ' + res.status;
           throw new Error(errMsg + (errBody ? ': ' + errBody.slice(0, 100) : ''));
         }
-        btn.textContent = 'Sent \\u2713';
+        btn.textContent = 'Sent';
         btn.classList.remove('rpt-btn-fail');
         btn.classList.add('rpt-btn-ok');
       } catch (e) {

--- a/src/core/report-html/index.ts
+++ b/src/core/report-html/index.ts
@@ -107,7 +107,7 @@ function renderFigmaCommentScript(figmaToken: string): string {
     const FIGMA_TOKEN = '${figmaToken}';
     async function postComment(btn) {
       const fileKey = btn.dataset.fileKey;
-      const nodeId = btn.dataset.nodeId.replace(/-/g, ':');
+      const nodeId = btn.dataset.nodeId.replace(/-/g, ':').split(';')[0].replace(/^I/, '');
       const message = btn.dataset.message;
       const commentBody = '[CanICode] ' + message;
       btn.disabled = true;


### PR DESCRIPTION
## Summary
- **Comment API 400 fix**: Instance-internal node IDs like `I3010:7457;1442:7704` are stripped to `3010:7457` before posting — Figma Comments API only accepts simple node IDs
- **Deep link fix**: Strip instance path to top-level node and convert colons to hyphens (`I175:7425;1442:7704` → `node-id=175-7425`)
- **UI cleanup**: Remove lock icon from authorize modal, remove checkmark from Sent button

## Test plan
- [x] `pnpm test:run` — 656 tests pass
- [x] Deep link navigates to correct node in Figma
- [x] Comment posts successfully on instance-internal nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Figma node identifiers to ensure accurate comment posting and deep link generation across nested components.

* **UI Changes**
  * Removed decorative icon from the Figma Personal Access Token authorization hint paragraph.
  * Updated post-comment success indicator from "Sent ✓" to "Sent" for cleaner UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->