### PR TITLE
chore: bump version to 0.9.1, add README.md to files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Score your Figma designs with AI-calibrated rules. CLI + MCP server.",
   "type": "module",
@@ -29,6 +29,7 @@
   },
   "files": [
     "dist",
+    "README.md",
     "docs/CUSTOMIZATION.md",
     ".claude/skills/design-to-code/PROMPT.md"
   ],


### PR DESCRIPTION
## Summary
- npm 웹 UI에서 README가 렌더링되지 않는 문제 수정
- `files` 필드에 `README.md` 명시적 추가
- 버전 0.9.0 → 0.9.1

## Root cause
npm registry의 버전별 메타데이터에 `readme` 필드가 누락됨. 재publish로 해결.

## Test plan
- [ ] CI 통과 확인
- [ ] merge 후 `v0.9.1` 태그 → npm publish → https://www.npmjs.com/package/canicode 에서 README 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version update (0.9.1)
  * Package distribution now includes the README file for better documentation accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->