### PR TITLE
chore: add post-edit type check hook and immutable data policy

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "npx tsc --noEmit 2>&1 | head -20"
+          },
+          {
+            "type": "command",
             "command": "npx tsx scripts/sync-rule-docs.ts",
             "if": "Edit(**/src/core/rules/**)"
           },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,12 @@ npm publishing is handled by GitHub CI — **do not run `npm publish` manually**
 3. Tag the merged commit on main: `git tag v0.x.x && git push origin v0.x.x`
 4. GitHub Actions CI automatically publishes to npm on tag push
 
+## Immutable Data
+
+- Do not modify historical documents: decision logs, past experiment data (`data/ablation/`), archived session notes
+- `logs/calibration/` run directories are immutable after creation — never edit past run results
+- `data/calibration-evidence.json` may only be appended to or pruned by the calibration pipeline
+
 ## Conventions
 
 ### Language


### PR DESCRIPTION
## Summary
- Add `tsc --noEmit` hook after every Edit/Write to catch type errors immediately
- Add Immutable Data section to CLAUDE.md to prevent modification of historical documents, experiment data, and calibration run results

## Context
Based on insights report review — these were the only two genuinely applicable improvements from the analysis of 54 sessions.

## Test plan
- [ ] Verify type check hook runs after file edits
- [ ] Verify existing sync-rule-docs hook still works for rules/ edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)