### PR TITLE
feat: automated development pipeline (scripts/develop.ts)

### DIFF
--- a/.claude/agents/develop/fixer.md
+++ b/.claude/agents/develop/fixer.md
@@ -1,0 +1,69 @@
+---
+name: develop-fixer
+description: Fixes review findings or test failures while preserving implementation intent. Documents what was fixed and what was intentionally kept.
+tools: Bash, Read, Write, Edit, Glob, Grep
+model: claude-sonnet-4-6
+---
+
+You are the Fixer agent in an automated development pipeline. Your job is to fix identified issues while preserving the implementer's intentional design decisions.
+
+## Input
+
+Your prompt includes a "Context" section with:
+- `Run directory`: where to write output files
+- `CLAUDE.md`: project conventions
+- `implement-log.json`: implementer's decisions and known risks
+- One of:
+  - `review.json`: review findings to fix (from Review step)
+  - `test errors`: test/lint failure output (from Test step)
+  - `build errors`: build failure output (from Verify step)
+
+## Fixing Review Findings
+
+1. Read `implement-log.json` `decisions` — understand WHY code was written this way
+2. For each finding with `severity: "error"` or `"warning"`:
+   a. Read the file and understand the context
+   b. If `intentConflict: true`: only fix if the reviewer's reasoning is STRONGER than the implementer's stated decision
+   c. Fix the issue
+3. Skip findings with `severity: "suggestion"`
+4. Write `$RUN_DIR/fix-log.json` (see Output)
+5. Stage and commit: `fix: address review findings`
+
+## Fixing Test/Build Failures
+
+1. Read `implement-log.json` to understand implementation intent
+2. Read the error output — identify which files and lines fail
+3. Fix the root cause:
+   - Type errors → fix the types, not suppress them
+   - Test failures → fix the implementation to match test expectations (do NOT change tests unless they are genuinely wrong)
+   - Build errors → fix imports, exports, missing files
+4. Stage and commit: `fix: resolve test failures` or `fix: resolve build errors`
+
+## Output (for review fixes)
+
+Write `$RUN_DIR/fix-log.json`:
+
+```json
+{
+  "fixed": [
+    {
+      "finding": "Brief description of the finding",
+      "resolution": "What was changed and why"
+    }
+  ],
+  "skipped": [
+    {
+      "finding": "Brief description",
+      "reason": "Why this was intentionally kept — reference implementer's decision"
+    }
+  ]
+}
+```
+
+## Rules
+
+- PRESERVE intentional decisions from `implement-log.json` unless proven wrong
+- Fix only what's asked — do NOT make unrelated improvements
+- Do NOT add comments, docstrings, or type annotations to unchanged code
+- Stage specific files with `git add <file>`, not `git add .`
+- Always commit after fixing — unstaged changes break the next step

--- a/.claude/agents/develop/implementer.md
+++ b/.claude/agents/develop/implementer.md
@@ -1,0 +1,63 @@
+---
+name: develop-implementer
+description: Implements a planned feature by writing code, following project conventions, and documenting decisions for later review.
+tools: Bash, Read, Write, Glob, Edit, Grep
+model: claude-sonnet-4-6
+---
+
+You are the Implementer agent in an automated development pipeline. Your job is to write code according to a plan, then document your decisions so the Review step can understand your intent.
+
+## Input
+
+Your prompt includes a "Context" section with:
+- `Run directory`: where to write output files
+- `Issue`: title and body of the GitHub issue
+- `CLAUDE.md`: project conventions
+- `plan.json`: implementation plan from the Planner
+
+## Steps
+
+1. Read `plan.json` — understand ALL tasks and designDecisions
+2. Read CLAUDE.md — especially Code Style, TypeScript, Conventions sections
+3. For each task in order:
+   a. Read the existing files first (NEVER modify a file you haven't read)
+   b. Implement the change following project conventions
+   c. Keep changes minimal — only what the plan requires
+4. Write `$RUN_DIR/implement-log.json` (see Output below)
+5. Stage changed files with `git add <specific files>` (NOT `git add .`)
+6. Commit with a conventional commit message (e.g. `feat: add gotcha survey`)
+
+## Output
+
+Write `$RUN_DIR/implement-log.json` BEFORE committing:
+
+```json
+{
+  "filesChanged": ["src/path/to.ts", "src/other.ts"],
+  "commits": ["feat: add X feature"],
+  "decisions": [
+    "Chose to extend existing Y instead of creating new Z because ...",
+    "Followed pattern from src/core/engine/X.ts for consistency",
+    "Used zod schema because all external inputs require validation per CLAUDE.md"
+  ],
+  "knownRisks": [
+    "Edge case: empty input not handled — unclear from issue if this is needed",
+    "Type narrowing on line 42 may be too aggressive",
+    "Not sure if the responsive behavior is correct"
+  ]
+}
+```
+
+## Why decisions and knownRisks matter
+
+- `decisions`: The Review agent reads this to understand WHY you wrote code a certain way. Without this, the reviewer may flag intentional choices as bugs.
+- `knownRisks`: The Review agent pays EXTRA attention to these areas. Flag anything you're not confident about — it's better to admit uncertainty than to hide it.
+
+## Rules
+
+- Follow CLAUDE.md conventions strictly: ESM, .js extensions, strict TS, kebab-case files, etc.
+- Use existing project patterns and utilities — don't reinvent
+- Do NOT run tests — a separate step handles that
+- Do NOT create a PR — a separate step handles that
+- Do NOT make changes beyond what the plan specifies
+- Every file you touch must be listed in `filesChanged`

--- a/.claude/agents/develop/planner.md
+++ b/.claude/agents/develop/planner.md
@@ -18,7 +18,8 @@ Your prompt includes a "Context" section with:
 
 1. Read the issue carefully — understand WHAT is needed and WHY
 2. Read CLAUDE.md conventions (especially Project Structure, Code Style, TypeScript sections)
-3. Explore the codebase: use Glob to find relevant files, Grep to search for related code, Read to understand existing patterns
+3. Read `.claude/docs/ADR.md`, `.claude/docs/ARCHITECTURE.md`, `.claude/docs/DESIGN-TREE.md`, `.claude/docs/CALIBRATION.md` — understand architecture decisions and constraints
+4. Explore the codebase: use Glob to find relevant files, Grep to search for related code, Read to understand existing patterns
 4. Identify which files need to be created or modified
 5. Break down the work into ordered tasks
 6. Document your design decisions — WHY this approach, not just what

--- a/.claude/agents/develop/planner.md
+++ b/.claude/agents/develop/planner.md
@@ -1,0 +1,60 @@
+---
+name: develop-planner
+description: Reads a GitHub issue and codebase, produces a structured implementation plan with design decisions and risks.
+tools: Bash, Read, Glob, Grep
+model: claude-sonnet-4-6
+---
+
+You are the Planner agent in an automated development pipeline. Your job is to analyze a GitHub issue and the codebase, then produce a structured implementation plan.
+
+## Input
+
+Your prompt includes a "Context" section with:
+- `Run directory`: where to write output files
+- `Issue`: title and body of the GitHub issue
+- `CLAUDE.md`: project conventions and structure
+
+## Steps
+
+1. Read the issue carefully — understand WHAT is needed and WHY
+2. Read CLAUDE.md conventions (especially Project Structure, Code Style, TypeScript sections)
+3. Explore the codebase: use Glob to find relevant files, Grep to search for related code, Read to understand existing patterns
+4. Identify which files need to be created or modified
+5. Break down the work into ordered tasks
+6. Document your design decisions — WHY this approach, not just what
+
+## Output
+
+Write `$RUN_DIR/plan.json`:
+
+```json
+{
+  "summary": "One-paragraph summary of what needs to be done and why",
+  "tasks": [
+    {
+      "id": 1,
+      "title": "Short task title",
+      "description": "What to do and why",
+      "files": ["src/path/to/file.ts"],
+      "approach": "How to implement — reference existing patterns"
+    }
+  ],
+  "designDecisions": [
+    "Why this approach over alternatives",
+    "Why these specific files",
+    "Which existing patterns to follow and why"
+  ],
+  "testStrategy": "How to verify the implementation works",
+  "risks": ["Known unknowns, potential edge cases, areas of uncertainty"]
+}
+```
+
+## Rules
+
+- `designDecisions` is the MOST IMPORTANT field. Later steps (Implement, Review, Fix) read this to understand your reasoning. If they don't know WHY, they'll make wrong choices.
+- Each task must have concrete `files` — no vague "update relevant files"
+- Reference existing code patterns: "Follow the pattern in src/core/engine/X.ts"
+- Keep tasks ordered by dependency — task 2 may depend on task 1's output
+- Do NOT write any code — only plan
+- Do NOT commit anything
+- Print a one-line summary to stdout when done

--- a/.claude/agents/develop/planner.md
+++ b/.claude/agents/develop/planner.md
@@ -45,9 +45,20 @@ Write `$RUN_DIR/plan.json`:
     "Which existing patterns to follow and why"
   ],
   "testStrategy": "How to verify the implementation works",
-  "risks": ["Known unknowns, potential edge cases, areas of uncertainty"]
+  "risks": ["Known unknowns, potential edge cases, areas of uncertainty"],
+  "split": false,
+  "remainingDescription": null
 }
 ```
+
+## Issue Splitting
+
+If the issue requires **more than 5 tasks**, the scope is too large for one PR. In this case:
+- Set `"split": true`
+- Include only the first 5 tasks (the most foundational ones)
+- Set `"remainingDescription"` to a description of the remaining work for a follow-up issue
+
+The orchestration script will automatically create a follow-up GitHub issue with the remaining work.
 
 ## Rules
 
@@ -55,6 +66,7 @@ Write `$RUN_DIR/plan.json`:
 - Each task must have concrete `files` — no vague "update relevant files"
 - Reference existing code patterns: "Follow the pattern in src/core/engine/X.ts"
 - Keep tasks ordered by dependency — task 2 may depend on task 1's output
+- **Max 5 tasks per plan** — split if more are needed
 - Do NOT write any code — only plan
 - Do NOT commit anything
 - Print a one-line summary to stdout when done

--- a/.claude/agents/develop/reviewer.md
+++ b/.claude/agents/develop/reviewer.md
@@ -22,11 +22,12 @@ Your prompt includes a "Context" section with:
 1. Read `implement-log.json` first — understand the implementer's intent
    - `decisions`: WHY they made each choice
    - `knownRisks`: WHERE they were unsure (focus extra attention here)
-2. Read the diff carefully
-3. For each changed file, read the FULL file (not just the diff) to understand surrounding context
-4. Check against CLAUDE.md conventions
-5. Check against the issue requirements — is the implementation complete?
-6. Check `plan.json` designDecisions — does the code match the plan's rationale?
+2. Read `.claude/docs/ADR.md` and `.claude/docs/ARCHITECTURE.md` — understand architecture rules
+3. Read the diff carefully
+4. For each changed file, read the FULL file (not just the diff) to understand surrounding context
+5. Check against CLAUDE.md conventions
+6. Check against the issue requirements — is the implementation complete?
+7. Check `plan.json` designDecisions — does the code match the plan's rationale?
 
 ## Review Criteria
 

--- a/.claude/agents/develop/reviewer.md
+++ b/.claude/agents/develop/reviewer.md
@@ -1,0 +1,77 @@
+---
+name: develop-reviewer
+description: Reviews implementation changes against plan intent, project conventions, and correctness. Flags issues with intent-conflict awareness.
+tools: Read, Glob, Grep
+model: claude-sonnet-4-6
+---
+
+You are the Reviewer agent in an automated development pipeline. You are an INDEPENDENT reviewer — you did NOT write this code. Your job is to find real problems, not rubber-stamp.
+
+## Input
+
+Your prompt includes a "Context" section with:
+- `Run directory`: where to write output files
+- `Issue`: title and body of the GitHub issue
+- `CLAUDE.md`: project conventions
+- `plan.json`: what was planned (including designDecisions)
+- `implement-log.json`: what the implementer decided and what they're unsure about
+- `git diff`: the actual code changes
+
+## Review Process
+
+1. Read `implement-log.json` first — understand the implementer's intent
+   - `decisions`: WHY they made each choice
+   - `knownRisks`: WHERE they were unsure (focus extra attention here)
+2. Read the diff carefully
+3. For each changed file, read the FULL file (not just the diff) to understand surrounding context
+4. Check against CLAUDE.md conventions
+5. Check against the issue requirements — is the implementation complete?
+6. Check `plan.json` designDecisions — does the code match the plan's rationale?
+
+## Review Criteria
+
+1. **Correctness**: Logic errors, edge cases, off-by-one, null/undefined handling
+2. **Conventions**: CLAUDE.md compliance (ESM, .js extensions, strict TS, zod for external inputs, naming)
+3. **Security**: Injection risks, hardcoded secrets, unsafe operations
+4. **Completeness**: Does it fully address the issue? Any missing tasks from the plan?
+5. **Intent alignment**: Do the changes match plan.designDecisions?
+
+## Output
+
+Write `$RUN_DIR/review.json`:
+
+```json
+{
+  "verdict": "approve" | "request-changes",
+  "summary": "Overall assessment in 2-3 sentences",
+  "implementIntent": "My understanding of why the implementer made the key decisions they did",
+  "findings": [
+    {
+      "severity": "error" | "warning" | "suggestion",
+      "file": "src/path/to/file.ts",
+      "line": 42,
+      "issue": "What's wrong — be specific",
+      "suggestion": "How to fix it — be concrete",
+      "intentConflict": false
+    }
+  ]
+}
+```
+
+## intentConflict field
+
+Set `intentConflict: true` when your finding contradicts something the implementer explicitly stated in `decisions`. Example:
+- Implementer decision: "Used Map instead of Object for O(1) lookup"
+- Your finding: "Should use a plain object here"
+- This is an intentConflict — the implementer had a reason
+
+Intent conflicts require STRONGER evidence to justify changing. Only flag as error if you can prove the implementer's reasoning is wrong.
+
+## Rules
+
+- You are NOT the implementer. Review independently.
+- Only flag REAL issues — not style preferences already covered by project conventions
+- Don't flag things that `pnpm lint` would catch — the test step already handles those
+- If `knownRisks` mentions an area, verify it carefully — the implementer was already uncertain
+- Be specific: file path + line number + what's wrong + how to fix
+- Do NOT write or modify any code files — only write review.json

--- a/.claude/agents/develop/reviewer.md
+++ b/.claude/agents/develop/reviewer.md
@@ -31,10 +31,25 @@ Your prompt includes a "Context" section with:
 ## Review Criteria
 
 1. **Correctness**: Logic errors, edge cases, off-by-one, null/undefined handling
-2. **Conventions**: CLAUDE.md compliance (ESM, .js extensions, strict TS, zod for external inputs, naming)
+2. **Completeness**: Does it fully address the issue? Any missing tasks from the plan?
 3. **Security**: Injection risks, hardcoded secrets, unsafe operations
-4. **Completeness**: Does it fully address the issue? Any missing tasks from the plan?
-5. **Intent alignment**: Do the changes match plan.designDecisions?
+4. **Intent alignment**: Do the changes match plan.designDecisions?
+
+## Checklist (MUST verify each item)
+
+These are mechanical checks. For each, report pass/fail in your review:
+
+- [ ] All relative imports use `.js` extension
+- [ ] ESM only (`import`/`export`, no `require`)
+- [ ] File names are kebab-case
+- [ ] Types/interfaces are PascalCase, functions/variables are camelCase
+- [ ] External inputs validated with Zod schema in `contracts/`
+- [ ] Array/object access checks for `undefined` (`noUncheckedIndexedAccess`)
+- [ ] No explicit `undefined` assignment to optional properties (`exactOptionalPropertyTypes`)
+- [ ] Test files co-located as `*.test.ts`
+- [ ] `git add <specific files>` not `git add .`
+- [ ] Commit message follows conventional commits (feat/fix/refactor/...)
+- [ ] No hardcoded secrets, API keys, or tokens
 
 ## Output
 

--- a/.claude/agents/develop/reviewer.md
+++ b/.claude/agents/develop/reviewer.md
@@ -51,6 +51,15 @@ These are mechanical checks. For each, report pass/fail in your review:
 - [ ] Commit message follows conventional commits (feat/fix/refactor/...)
 - [ ] No hardcoded secrets, API keys, or tokens
 
+## Architecture Checks (MUST verify)
+
+- [ ] New files follow ARCHITECTURE.md directory structure (core/ for shared, cli/ for CLI, contracts/ for schemas, etc.)
+- [ ] No ADR violations (design-tree over raw JSON, no custom rules, zod for validation, etc.)
+- [ ] New features have corresponding tests (co-located `*.test.ts`)
+- [ ] External inputs go through Zod schema in `contracts/`
+- [ ] No new dependencies added without justification
+- [ ] No `@/*` import aliases — relative paths only
+
 ## Output
 
 Write `$RUN_DIR/review.json`:

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -40,8 +40,8 @@ npx tsx scripts/develop.ts 236
 # Resume from failure
 npx tsx scripts/develop.ts --resume logs/develop/236--2026-04-16-1200
 
-# Resume from specific step
-npx tsx scripts/develop.ts --resume logs/develop/236--2026-04-16-1200 --from 4
+# Resume from specific step (name or 1-based index: plan=1, implement=2, test=3, review=4, fix=5, verify=6, pr=7)
+npx tsx scripts/develop.ts --resume logs/develop/236--2026-04-16-1200 --from review
 ```
 
 ## Rules

--- a/.claude/commands/develop.md
+++ b/.claude/commands/develop.md
@@ -1,0 +1,51 @@
+Run the automated development pipeline for a GitHub issue.
+
+Input: $ARGUMENTS (issue number, or `--resume <run-dir>` with optional `--from <step>`)
+
+## Instructions
+
+Run the development script:
+
+```bash
+npx tsx scripts/develop.ts $ARGUMENTS
+```
+
+The script (`scripts/develop.ts`) orchestrates:
+1. **Plan** (Agent) — Read issue, explore codebase, produce plan.json
+2. **Implement** (Agent) — Write code per plan, commit, produce implement-log.json
+3. **Test** (CLI, non-blocking) — `pnpm lint && pnpm test:run`, failures forwarded to Review
+4. **Review** (Agent) — Independent review with intent-conflict awareness
+5. **Fix** (Agent) — Fix review findings while preserving implementation intent
+6. **Verify** (CLI + circuit breaker) — `pnpm lint && pnpm test:run && pnpm build`, auto-retry with re-plan
+7. **PR** (CLI) — `gh pr create --draft`
+
+State tracked in `logs/develop/<issue>--<timestamp>/index.json`.
+
+### After the script completes
+
+Report the summary from index.json:
+- Which steps completed, skipped, or failed
+- Plan summary and task count
+- Review verdict and finding counts
+- Circuit breaker state (if verify needed retries)
+- PR URL (if created)
+- Path to the run directory
+
+### Examples
+
+```bash
+# New run
+npx tsx scripts/develop.ts 236
+
+# Resume from failure
+npx tsx scripts/develop.ts --resume logs/develop/236--2026-04-16-1200
+
+# Resume from specific step
+npx tsx scripts/develop.ts --resume logs/develop/236--2026-04-16-1200 --from 4
+```
+
+## Rules
+
+- The script handles all orchestration — do NOT manually run individual steps.
+- If the script fails, check `$RUN_DIR/index.json` for the failed step and error.
+- To re-run from a specific step, use `--resume` with `--from`.

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -60,6 +60,8 @@ Calibration is orchestrated by `scripts/calibrate.ts` (ADR-008). CLI for determi
 - Flow: Plan (agent) → Implement (agent) → Test (cli, retry loop) → Review (agent) → Fix (agent) → Verify (cli) → PR (cli)
 - State tracked in `logs/develop/<issue>--<timestamp>/index.json`
 - Test/Verify steps have internal fix retry loops (max 3 retries with fix agent)
+- JSON handoff chain: `plan.json` (designDecisions) → `implement-log.json` (decisions, knownRisks) → `review.json` (implementIntent, intentConflict) → `fix-log.json` (resolution, skipped reasons)
+- Each `claude -p` agent receives previous step JSONs so it understands "why", not just "what"
 - See: issue #247
 
 ## File Output Structure
@@ -88,9 +90,12 @@ logs/calibration/REPORT.md                  # Cross-run aggregate report
 logs/develop/                               # Development pipeline runs
 logs/develop/<issue>--<timestamp>/          # One development run = one folder
   ├── index.json                            #   Pipeline state (per-step status, resume point)
-  ├── plan.json                             #   Implementation plan (tasks, risks)
-  ├── review.json                           #   Self-review findings
-  ├── implement-output.txt                  #   Implementer agent output
+  ├── plan.json                             #   Implementation plan (tasks, designDecisions, risks)
+  ├── implement-log.json                    #   Decisions + knownRisks (context chain for Review/Fix)
+  ├── implement-output.txt                  #   Implementer agent raw output
+  ├── test-result.json                      #   Test pass/fail + error details
+  ├── review.json                           #   Self-review (implementIntent, intentConflict flags)
+  ├── fix-log.json                          #   What was fixed/skipped and why
   └── pr-url.txt                            #   Created PR URL
 logs/activity/                              # Nightly orchestration logs
 ```

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -54,6 +54,14 @@ Calibration is orchestrated by `scripts/calibrate.ts` (ADR-008). CLI for determi
 - Input: fixture directory path (e.g. `fixtures/my-designs`) — auto-discovers active fixtures
 - Flow: `fixture-list` → sequential `scripts/calibrate.ts` per fixture → `fixture-done` (converged) → `calibrate-gap-report` → `logs/calibration/REPORT.md`
 
+**`scripts/develop.ts` (development pipeline)**
+- Role: Automated feature development — reads a GitHub issue, plans, implements, tests, reviews, and creates a draft PR
+- Input: GitHub issue number (e.g. `247`), or `--resume <run-dir>`
+- Flow: Plan (agent) → Implement (agent) → Test (cli, retry loop) → Review (agent) → Fix (agent) → Verify (cli) → PR (cli)
+- State tracked in `logs/develop/<issue>--<timestamp>/index.json`
+- Test/Verify steps have internal fix retry loops (max 3 retries with fix agent)
+- See: issue #247
+
 ## File Output Structure
 
 ```text
@@ -77,5 +85,12 @@ logs/calibration/<name>--<timestamp>/       # One calibration run = one folder
   ├── code.png                              #   Code rendering screenshot
   └── diff.png                              #   Pixel diff image
 logs/calibration/REPORT.md                  # Cross-run aggregate report
+logs/develop/                               # Development pipeline runs
+logs/develop/<issue>--<timestamp>/          # One development run = one folder
+  ├── index.json                            #   Pipeline state (per-step status, resume point)
+  ├── plan.json                             #   Implementation plan (tasks, risks)
+  ├── review.json                           #   Self-review findings
+  ├── implement-output.txt                  #   Implementer agent output
+  └── pr-url.txt                            #   Created PR URL
 logs/activity/                              # Nightly orchestration logs
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,8 @@ app/                          # Browser runtime
 └── commands/                 # Claude Code commands (calibrate-loop, calibrate-night)
 
 scripts/                        # Orchestration scripts (run with tsx)
-└── calibrate.ts              # Calibration pipeline orchestrator (ADR-008)
+├── calibrate.ts              # Calibration pipeline orchestrator (ADR-008)
+└── develop.ts                # Development pipeline orchestrator (#247)
 ```
 
 ## Architecture Decision Records

--- a/scripts/develop.ts
+++ b/scripts/develop.ts
@@ -209,21 +209,23 @@ function loadClaudeMd(): string {
   return existsSync(path) ? readFileSync(path, "utf-8") : "";
 }
 
-function buildBaseContext(issue: IssueData, runDir: string): string {
-  return `## Project Instructions (CLAUDE.md)
+/** Load an agent definition file from .claude/agents/develop/ */
+function loadAgent(name: string): string {
+  const path = resolve(PROJECT_ROOT, `.claude/agents/develop/${name}.md`);
+  return readFileSync(path, "utf-8");
+}
 
-${loadClaudeMd()}
-
-## Target Issue
-
-**#${issue.number}: ${issue.title}**
-
-${issue.body}
-
-## Run Directory
-
-${runDir}
-`;
+/** Build the context block injected after the agent definition */
+function buildContext(issue: IssueData, runDir: string, extras: Record<string, string> = {}): string {
+  const sections = [
+    `Run directory: ${runDir}`,
+    `Issue: #${issue.number} — ${issue.title}\n\n${issue.body}`,
+    `CLAUDE.md:\n\n${loadClaudeMd()}`,
+  ];
+  for (const [label, content] of Object.entries(extras)) {
+    sections.push(`${label}:\n\n${content}`);
+  }
+  return `## Context (injected by orchestration script)\n\n${sections.join("\n\n---\n\n")}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -264,13 +266,15 @@ async function main(): Promise<void> {
     issue = fetchIssue(issueNum);
     console.log(`\nStarting development pipeline for: #${issue.number} ${issue.title}`);
 
-    // Create branch
+    // Create branch — fail if it already exists (use --resume for existing runs)
     const branchName = `develop/${issue.number}`;
     try {
       execSync(`git checkout -b ${shellEscape(branchName)} main`, { encoding: "utf-8", cwd: PROJECT_ROOT });
     } catch {
-      // Branch may already exist (from a previous attempt)
-      execSync(`git checkout ${shellEscape(branchName)}`, { encoding: "utf-8", cwd: PROJECT_ROOT });
+      console.error(`Error: Branch '${branchName}' already exists.`);
+      console.error(`  To resume a previous run: npx tsx scripts/develop.ts --resume <run-dir>`);
+      console.error(`  To start fresh: git branch -D ${branchName}`);
+      process.exit(1);
     }
 
     runDir = createDevelopRunDir(issue.number);
@@ -303,55 +307,13 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
     return step.status !== "completed" && step.status !== "skipped";
   };
 
-  const baseContext = buildBaseContext(issue, runDir);
-
   // ─── Step 1: Plan (agent) ──────────────────────────────────────────
   if (shouldRun(DEV_STEP_NAMES.PLAN)) {
     markRunning(index, DEV_STEP_NAMES.PLAN);
     try {
-      const planPrompt = `You are a software architect planning the implementation for a GitHub issue.
-
-${baseContext}
-
-## Your Task
-
-Analyze the issue and the codebase, then produce a detailed implementation plan.
-
-### Instructions
-
-1. Read the issue carefully and understand the requirements
-2. Explore the relevant parts of the codebase (use Glob, Grep, Read)
-3. Identify which files need to be created or modified
-4. Break down the work into ordered tasks
-
-### Output Format
-
-Write a JSON plan to ${join(runDir, "plan.json")} with this structure:
-
-\`\`\`json
-{
-  "summary": "One-paragraph summary of what needs to be done",
-  "tasks": [
-    {
-      "id": 1,
-      "title": "Short task title",
-      "description": "What to do and why",
-      "files": ["src/path/to/file.ts"],
-      "approach": "How to implement this"
-    }
-  ],
-  "designDecisions": [
-    "Why this approach over alternatives — e.g. 'Extend existing X instead of creating new Y because Z'",
-    "Why touching these specific files — e.g. 'rule-config.ts owns all score values per ADR'"
-  ],
-  "testStrategy": "How to verify the implementation",
-  "risks": ["Potential issues to watch for"]
-}
-\`\`\`
-
-The \`designDecisions\` field is CRITICAL — it tells the next steps WHY you chose this plan so they don't undo intentional choices.
-
-Write the plan file, then print a one-line summary to stdout.`;
+      const agentDef = loadAgent("planner");
+      const context = buildContext(issue, runDir);
+      const planPrompt = `${agentDef}\n\n${context}`;
 
       const planOutput = runAgent(planPrompt, "Planner");
 
@@ -381,52 +343,21 @@ Write the plan file, then print a one-line summary to stdout.`;
     markRunning(index, DEV_STEP_NAMES.IMPLEMENT);
     try {
       const plan = readFileSync(join(runDir, "plan.json"), "utf-8");
-
-      const implementPrompt = `You are a senior TypeScript developer implementing a planned feature.
-
-${baseContext}
-
-## Implementation Plan
-
-${plan}
-
-## Your Task
-
-Implement ALL tasks from the plan above. Follow these rules:
-
-1. Follow the project conventions in CLAUDE.md strictly (ESM, .js extensions, strict TS, etc.)
-2. Create/modify files as specified in the plan
-3. Do NOT run tests — a separate step handles that
-4. Do NOT create a PR — a separate step handles that
-
-### IMPORTANT: Write implement-log.json BEFORE committing
-
-After implementing, write ${join(runDir, "implement-log.json")} with:
-
-\`\`\`json
-{
-  "filesChanged": ["src/path/to.ts", "src/other.ts"],
-  "commits": ["feat: add X feature"],
-  "decisions": [
-    "Chose to extend existing Y instead of creating new Z because ...",
-    "Followed pattern from src/core/engine/X.ts for consistency"
-  ],
-  "knownRisks": [
-    "Edge case: empty input not handled yet",
-    "Not confident about the type narrowing in line 42"
-  ]
-}
-\`\`\`
-
-The \`decisions\` field tells the Review step WHY you made each choice — this prevents the reviewer from flagging intentional decisions as bugs.
-The \`knownRisks\` field tells the Review step what YOU are unsure about — the reviewer will focus extra attention there.
-
-Then stage your changes with \`git add\` and commit with a conventional commit message.`;
+      const agentDef = loadAgent("implementer");
+      const context = buildContext(issue, runDir, { "plan.json": plan });
+      const implementPrompt = `${agentDef}\n\n${context}`;
 
       const implOutput = runAgent(implementPrompt, "Implementer");
 
-      // Check that changes were made
-      const diffStat = execSync("git diff --stat HEAD~1 2>/dev/null || git diff --stat HEAD", {
+      // Check that changes were committed
+      const commitCount = execSync("git rev-list --count main...HEAD", {
+        encoding: "utf-8",
+        cwd: PROJECT_ROOT,
+      }).trim();
+      if (commitCount === "0") {
+        throw new Error("Implementer did not create any commits");
+      }
+      const diffStat = execSync("git diff --stat main...HEAD", {
         encoding: "utf-8",
         cwd: PROJECT_ROOT,
       }).trim();
@@ -487,33 +418,12 @@ Then stage your changes with \`git add\` and commit with a conventional commit m
           const implLog = existsSync(join(runDir, "implement-log.json"))
             ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
             : "{}";
-          const fixPrompt = `You are a TypeScript developer fixing test/lint failures.
-
-${baseContext}
-
-## Implementation Context (from implement-log.json)
-
-${implLog}
-
-Pay attention to \`decisions\` — these explain WHY the code was written this way.
-Pay attention to \`knownRisks\` — the implementer was already unsure about these areas.
-
-## Test Failure
-
-The following test/lint command failed:
-
-\`\`\`
-${lastError.slice(0, 3000)}
-\`\`\`
-
-## Your Task
-
-1. Read the failing files and understand the errors
-2. Fix the issues — type errors, test failures, etc.
-3. Stage and commit your fixes with message: "fix: resolve test failures"
-
-Do NOT change test expectations unless the test is genuinely wrong.
-Focus on fixing the implementation to match what tests expect.`;
+          const fixerDef = loadAgent("fixer");
+          const fixContext = buildContext(issue, runDir, {
+            "implement-log.json": implLog,
+            "Test errors": lastError.slice(0, 3000),
+          });
+          const fixPrompt = `${fixerDef}\n\n${fixContext}`;
 
           try {
             runAgent(fixPrompt, `Test Fix (attempt ${attempt + 1})`);
@@ -555,7 +465,6 @@ Focus on fixing the implementation to match what tests expect.`;
           ? diff.slice(0, maxDiffLen) + `\n\n... (truncated, ${diff.length - maxDiffLen} chars omitted)`
           : diff;
 
-        // Load context from previous steps
         const planJson = existsSync(join(runDir, "plan.json"))
           ? readFileSync(join(runDir, "plan.json"), "utf-8")
           : "{}";
@@ -563,61 +472,13 @@ Focus on fixing the implementation to match what tests expect.`;
           ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
           : "{}";
 
-        const reviewPrompt = `You are a code reviewer checking a feature branch.
-
-${baseContext}
-
-## Implementation Plan (plan.json)
-
-${planJson}
-
-## Implementation Log (implement-log.json)
-
-${implLog}
-
-Read \`decisions\` carefully — these explain WHY the implementer made each choice.
-Read \`knownRisks\` carefully — the implementer flagged these as uncertain areas. Pay EXTRA attention here.
-
-## Changes (git diff main...HEAD)
-
-\`\`\`diff
-${truncatedDiff}
-\`\`\`
-
-## Your Task
-
-Review the changes for:
-1. **Correctness**: Logic errors, edge cases, off-by-one errors
-2. **Conventions**: Does it follow CLAUDE.md conventions? (ESM, .js extensions, strict TS, naming)
-3. **Security**: Injection risks, hardcoded secrets, unsafe operations
-4. **Completeness**: Does it fully address the issue requirements?
-5. **Intent alignment**: Do the changes match the plan's designDecisions?
-
-### Output Format
-
-Write a JSON review to ${join(runDir, "review.json")} with this structure:
-
-\`\`\`json
-{
-  "verdict": "approve" | "request-changes",
-  "summary": "Overall assessment",
-  "implementIntent": "My understanding of the implementer's design decisions and trade-offs",
-  "findings": [
-    {
-      "severity": "error" | "warning" | "suggestion",
-      "file": "path/to/file.ts",
-      "line": 42,
-      "issue": "What's wrong",
-      "suggestion": "How to fix it",
-      "intentConflict": false
-    }
-  ]
-}
-\`\`\`
-
-The \`intentConflict\` field: set to true if the finding contradicts a stated decision from implement-log.json. These need careful judgment — the implementer may have had a good reason.
-
-Be strict but fair. Only flag real issues, not style preferences already handled by the project conventions.`;
+        const reviewerDef = loadAgent("reviewer");
+        const reviewContext = buildContext(issue, runDir, {
+          "plan.json": planJson,
+          "implement-log.json": implLog,
+          "git diff main...HEAD": truncatedDiff,
+        });
+        const reviewPrompt = `${reviewerDef}\n\n${reviewContext}`;
 
         const reviewOutput = runAgent(reviewPrompt, "Reviewer");
 
@@ -671,43 +532,12 @@ Be strict but fair. Only flag real issues, not style preferences already handled
           ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
           : "{}";
 
-        const fixPrompt = `You are a TypeScript developer fixing code review findings.
-
-${baseContext}
-
-## Implementation Intent (implement-log.json)
-
-${implLog}
-
-Read \`decisions\` — these explain WHY the code was written this way. Do NOT undo intentional decisions unless the finding proves them wrong.
-
-## Review Findings to Fix
-
-${JSON.stringify(actionable, null, 2)}
-
-Note: findings with \`intentConflict: true\` contradict a stated design decision. Be careful — fix them only if the reviewer's reasoning is stronger.
-
-## Your Task
-
-1. Read each file mentioned in the findings
-2. Fix all errors and warnings
-3. Write ${join(runDir, "fix-log.json")} with what you fixed and why:
-
-\`\`\`json
-{
-  "fixed": [
-    { "finding": "description", "resolution": "what was changed and why" }
-  ],
-  "skipped": [
-    { "finding": "description", "reason": "why this was intentionally kept" }
-  ]
-}
-\`\`\`
-
-4. Stage and commit with message: "fix: address review findings"
-
-Do NOT fix suggestions — only errors and warnings.
-Do NOT make unrelated changes.`;
+        const fixerDef = loadAgent("fixer");
+        const fixContext = buildContext(issue, runDir, {
+          "implement-log.json": implLog,
+          "review.json (actionable findings)": JSON.stringify(actionable, null, 2),
+        });
+        const fixPrompt = `${fixerDef}\n\n${fixContext}`;
 
         runAgent(fixPrompt, "Fixer");
 
@@ -727,10 +557,11 @@ Do NOT make unrelated changes.`;
     markRunning(index, DEV_STEP_NAMES.VERIFY);
     try {
       runCli("pnpm lint", "Type check (verify)");
+      runCli("pnpm test:run", "Tests (verify)");
       runCli("pnpm build", "Build (verify)");
 
       markCompleted(index, DEV_STEP_NAMES.VERIFY, {
-        summary: "Lint + build passed",
+        summary: "Lint + tests + build passed",
       });
     } catch (err) {
       // One retry with fix agent
@@ -738,30 +569,20 @@ Do NOT make unrelated changes.`;
       const implLogVerify = existsSync(join(runDir, "implement-log.json"))
         ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
         : "{}";
-      const fixPrompt = `You are a TypeScript developer fixing build/lint failures.
-
-${baseContext}
-
-## Implementation Intent (implement-log.json)
-
-${implLogVerify}
-
-## Build/Lint Failure
-
-\`\`\`
-${(err instanceof Error ? err.message : String(err)).slice(0, 3000)}
-\`\`\`
-
-## Your Task
-
-Fix the build/lint errors. Stage and commit with message: "fix: resolve build errors"`;
+      const fixerDefVerify = loadAgent("fixer");
+      const fixContextVerify = buildContext(issue, runDir, {
+        "implement-log.json": implLogVerify,
+        "Build errors": (err instanceof Error ? err.message : String(err)).slice(0, 3000),
+      });
+      const fixPrompt = `${fixerDefVerify}\n\n${fixContextVerify}`;
 
       try {
         runAgent(fixPrompt, "Verify Fix");
         // Re-run verify
         runCli("pnpm lint", "Type check (verify retry)");
+        runCli("pnpm test:run", "Tests (verify retry)");
         runCli("pnpm build", "Build (verify retry)");
-        markCompleted(index, DEV_STEP_NAMES.VERIFY, { summary: "Lint + build passed (after fix)" });
+        markCompleted(index, DEV_STEP_NAMES.VERIFY, { summary: "Lint + tests + build passed (after fix)" });
       } catch (retryErr) {
         markFailed(index, DEV_STEP_NAMES.VERIFY, retryErr instanceof Error ? retryErr.message : String(retryErr));
         throw retryErr;
@@ -776,9 +597,20 @@ Fix the build/lint errors. Stage and commit with message: "fix: resolve build er
       // Push branch
       runCli(`git push -u origin ${shellEscape(index.branch)}`, "Push branch");
 
-      // Build PR body from plan and review
+      // Build PR body from plan, review, and fix results
       const plan = readJson<{ summary: string; tasks: Array<{ title: string }> }>(join(runDir, "plan.json"));
       const taskList = plan.tasks.map((t) => `- ${t.title}`).join("\n");
+
+      // Include self-review results if available
+      let reviewSection = "";
+      if (existsSync(join(runDir, "review.json"))) {
+        const review = readJson<{ verdict: string; summary: string; findings: Array<{ severity: string }> }>(
+          join(runDir, "review.json"),
+        );
+        const errorCount = review.findings.filter((f) => f.severity === "error").length;
+        const warningCount = review.findings.filter((f) => f.severity === "warning").length;
+        reviewSection = `\n## Self-review\n\n${review.summary}\n- Verdict: ${review.verdict}\n- Errors: ${errorCount}, Warnings: ${warningCount}, Total: ${review.findings.length}\n`;
+      }
 
       const prBody = `## Summary
 
@@ -787,7 +619,7 @@ ${plan.summary}
 ## Tasks
 
 ${taskList}
-
+${reviewSection}
 ## Test plan
 
 - [ ] \`pnpm lint\` passes

--- a/scripts/develop.ts
+++ b/scripts/develop.ts
@@ -251,6 +251,14 @@ async function main(): Promise<void> {
       console.log("All steps completed. Nothing to resume.");
       return;
     }
+
+    // Ensure we're on the correct branch
+    const currentBranch = execSync("git branch --show-current", { encoding: "utf-8", cwd: PROJECT_ROOT }).trim();
+    if (currentBranch !== index.branch) {
+      console.log(`  Switching to branch: ${index.branch}`);
+      execSync(`git checkout ${shellEscape(index.branch)}`, { encoding: "utf-8", cwd: PROJECT_ROOT });
+    }
+
     index.status = "running";
     saveIndex(index);
     console.log(`Resuming development from step: ${resumeFrom}`);
@@ -389,6 +397,7 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
     markRunning(index, DEV_STEP_NAMES.TEST);
     let testPassed = false;
     let lastError = "";
+    let passedAttempt = 0;
 
     for (let attempt = 0; attempt <= MAX_TEST_RETRIES; attempt++) {
       try {
@@ -400,6 +409,7 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
         runCli("pnpm lint", "Type check");
         runCli("pnpm test:run", "Tests");
         testPassed = true;
+        passedAttempt = attempt + 1;
         break;
       } catch (err) {
         lastError = err instanceof Error ? err.message : String(err);
@@ -437,7 +447,7 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
     if (testPassed) {
       writeFileSync(join(runDir, "test-result.json"), JSON.stringify({
         passed: true,
-        attempt: getStep(index, DEV_STEP_NAMES.TEST).retries + 1,
+        attempt: passedAttempt,
       }, null, 2) + "\n");
       markCompleted(index, DEV_STEP_NAMES.TEST, {
         summary: "Lint + tests passed",
@@ -487,12 +497,9 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
           if (jsonMatch) {
             writeFileSync(join(runDir, "review.json"), jsonMatch[0] + "\n");
           } else {
-            // No structured review — treat as approve
-            writeFileSync(join(runDir, "review.json"), JSON.stringify({
-              verdict: "approve",
-              summary: "Review completed (unstructured output)",
-              findings: [],
-            }, null, 2) + "\n");
+            // Save raw output for debugging, then fail
+            writeFileSync(join(runDir, "review-raw.txt"), reviewOutput);
+            throw new Error("Reviewer did not produce structured review.json. Raw output saved to review-raw.txt");
           }
         }
 

--- a/scripts/develop.ts
+++ b/scripts/develop.ts
@@ -340,10 +340,16 @@ Write a JSON plan to ${join(runDir, "plan.json")} with this structure:
       "approach": "How to implement this"
     }
   ],
+  "designDecisions": [
+    "Why this approach over alternatives — e.g. 'Extend existing X instead of creating new Y because Z'",
+    "Why touching these specific files — e.g. 'rule-config.ts owns all score values per ADR'"
+  ],
   "testStrategy": "How to verify the implementation",
   "risks": ["Potential issues to watch for"]
 }
 \`\`\`
+
+The \`designDecisions\` field is CRITICAL — it tells the next steps WHY you chose this plan so they don't undo intentional choices.
 
 Write the plan file, then print a one-line summary to stdout.`;
 
@@ -392,15 +398,30 @@ Implement ALL tasks from the plan above. Follow these rules:
 2. Create/modify files as specified in the plan
 3. Do NOT run tests — a separate step handles that
 4. Do NOT create a PR — a separate step handles that
-5. After implementation, stage your changes with \`git add\` and commit with a conventional commit message
 
-### Important
+### IMPORTANT: Write implement-log.json BEFORE committing
 
-- Read existing files before modifying them
-- Keep changes minimal — only what the plan requires
-- Use the project's existing patterns and utilities
+After implementing, write ${join(runDir, "implement-log.json")} with:
 
-After completing all tasks, print a summary of what you implemented.`;
+\`\`\`json
+{
+  "filesChanged": ["src/path/to.ts", "src/other.ts"],
+  "commits": ["feat: add X feature"],
+  "decisions": [
+    "Chose to extend existing Y instead of creating new Z because ...",
+    "Followed pattern from src/core/engine/X.ts for consistency"
+  ],
+  "knownRisks": [
+    "Edge case: empty input not handled yet",
+    "Not confident about the type narrowing in line 42"
+  ]
+}
+\`\`\`
+
+The \`decisions\` field tells the Review step WHY you made each choice — this prevents the reviewer from flagging intentional decisions as bugs.
+The \`knownRisks\` field tells the Review step what YOU are unsure about — the reviewer will focus extra attention there.
+
+Then stage your changes with \`git add\` and commit with a conventional commit message.`;
 
       const implOutput = runAgent(implementPrompt, "Implementer");
 
@@ -412,9 +433,19 @@ After completing all tasks, print a summary of what you implemented.`;
 
       writeFileSync(join(runDir, "implement-output.txt"), implOutput);
 
+      // Ensure implement-log.json exists (agent may have skipped it)
+      if (!existsSync(join(runDir, "implement-log.json"))) {
+        writeFileSync(join(runDir, "implement-log.json"), JSON.stringify({
+          filesChanged: [],
+          commits: [],
+          decisions: ["(implement-log.json not written by agent)"],
+          knownRisks: [],
+        }, null, 2) + "\n");
+      }
+
       markCompleted(index, DEV_STEP_NAMES.IMPLEMENT, {
         summary: diffStat.split("\n").pop() ?? "Changes committed",
-        outputs: ["implement-output.txt"],
+        outputs: ["implement-output.txt", "implement-log.json"],
       });
     } catch (err) {
       markFailed(index, DEV_STEP_NAMES.IMPLEMENT, err instanceof Error ? err.message : String(err));
@@ -443,12 +474,29 @@ After completing all tasks, print a summary of what you implemented.`;
         lastError = err instanceof Error ? err.message : String(err);
         console.warn(`  [test] Failed (attempt ${attempt + 1}): ${lastError.slice(0, 200)}`);
 
+        // Save test failure for context
+        writeFileSync(join(runDir, "test-result.json"), JSON.stringify({
+          passed: false,
+          attempt: attempt + 1,
+          errors: lastError.slice(0, 5000),
+        }, null, 2) + "\n");
+
         if (attempt < MAX_TEST_RETRIES) {
           // Ask fix agent to resolve the issue
           console.log(`  [agent] Calling fix agent for test failure...`);
+          const implLog = existsSync(join(runDir, "implement-log.json"))
+            ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
+            : "{}";
           const fixPrompt = `You are a TypeScript developer fixing test/lint failures.
 
 ${baseContext}
+
+## Implementation Context (from implement-log.json)
+
+${implLog}
+
+Pay attention to \`decisions\` — these explain WHY the code was written this way.
+Pay attention to \`knownRisks\` — the implementer was already unsure about these areas.
 
 ## Test Failure
 
@@ -477,8 +525,13 @@ Focus on fixing the implementation to match what tests expect.`;
     }
 
     if (testPassed) {
+      writeFileSync(join(runDir, "test-result.json"), JSON.stringify({
+        passed: true,
+        attempt: getStep(index, DEV_STEP_NAMES.TEST).retries + 1,
+      }, null, 2) + "\n");
       markCompleted(index, DEV_STEP_NAMES.TEST, {
         summary: "Lint + tests passed",
+        outputs: ["test-result.json"],
       });
     } else {
       markFailed(index, DEV_STEP_NAMES.TEST, `Tests failed after ${MAX_TEST_RETRIES + 1} attempts: ${lastError.slice(0, 500)}`);
@@ -502,9 +555,28 @@ Focus on fixing the implementation to match what tests expect.`;
           ? diff.slice(0, maxDiffLen) + `\n\n... (truncated, ${diff.length - maxDiffLen} chars omitted)`
           : diff;
 
+        // Load context from previous steps
+        const planJson = existsSync(join(runDir, "plan.json"))
+          ? readFileSync(join(runDir, "plan.json"), "utf-8")
+          : "{}";
+        const implLog = existsSync(join(runDir, "implement-log.json"))
+          ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
+          : "{}";
+
         const reviewPrompt = `You are a code reviewer checking a feature branch.
 
 ${baseContext}
+
+## Implementation Plan (plan.json)
+
+${planJson}
+
+## Implementation Log (implement-log.json)
+
+${implLog}
+
+Read \`decisions\` carefully — these explain WHY the implementer made each choice.
+Read \`knownRisks\` carefully — the implementer flagged these as uncertain areas. Pay EXTRA attention here.
 
 ## Changes (git diff main...HEAD)
 
@@ -519,6 +591,7 @@ Review the changes for:
 2. **Conventions**: Does it follow CLAUDE.md conventions? (ESM, .js extensions, strict TS, naming)
 3. **Security**: Injection risks, hardcoded secrets, unsafe operations
 4. **Completeness**: Does it fully address the issue requirements?
+5. **Intent alignment**: Do the changes match the plan's designDecisions?
 
 ### Output Format
 
@@ -528,17 +601,21 @@ Write a JSON review to ${join(runDir, "review.json")} with this structure:
 {
   "verdict": "approve" | "request-changes",
   "summary": "Overall assessment",
+  "implementIntent": "My understanding of the implementer's design decisions and trade-offs",
   "findings": [
     {
       "severity": "error" | "warning" | "suggestion",
       "file": "path/to/file.ts",
       "line": 42,
       "issue": "What's wrong",
-      "suggestion": "How to fix it"
+      "suggestion": "How to fix it",
+      "intentConflict": false
     }
   ]
 }
 \`\`\`
+
+The \`intentConflict\` field: set to true if the finding contradicts a stated decision from implement-log.json. These need careful judgment — the implementer may have had a good reason.
 
 Be strict but fair. Only flag real issues, not style preferences already handled by the project conventions.`;
 
@@ -590,19 +667,44 @@ Be strict but fair. Only flag real issues, not style preferences already handled
       if (actionable.length === 0) {
         markSkipped(index, DEV_STEP_NAMES.FIX, "No actionable findings");
       } else {
+        const implLog = existsSync(join(runDir, "implement-log.json"))
+          ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
+          : "{}";
+
         const fixPrompt = `You are a TypeScript developer fixing code review findings.
 
 ${baseContext}
+
+## Implementation Intent (implement-log.json)
+
+${implLog}
+
+Read \`decisions\` — these explain WHY the code was written this way. Do NOT undo intentional decisions unless the finding proves them wrong.
 
 ## Review Findings to Fix
 
 ${JSON.stringify(actionable, null, 2)}
 
+Note: findings with \`intentConflict: true\` contradict a stated design decision. Be careful — fix them only if the reviewer's reasoning is stronger.
+
 ## Your Task
 
 1. Read each file mentioned in the findings
 2. Fix all errors and warnings
-3. Stage and commit with message: "fix: address review findings"
+3. Write ${join(runDir, "fix-log.json")} with what you fixed and why:
+
+\`\`\`json
+{
+  "fixed": [
+    { "finding": "description", "resolution": "what was changed and why" }
+  ],
+  "skipped": [
+    { "finding": "description", "reason": "why this was intentionally kept" }
+  ]
+}
+\`\`\`
+
+4. Stage and commit with message: "fix: address review findings"
 
 Do NOT fix suggestions — only errors and warnings.
 Do NOT make unrelated changes.`;
@@ -611,6 +713,7 @@ Do NOT make unrelated changes.`;
 
         markCompleted(index, DEV_STEP_NAMES.FIX, {
           summary: `Fixed ${actionable.length} findings`,
+          outputs: ["fix-log.json"],
         });
       }
     } catch (err) {
@@ -632,9 +735,16 @@ Do NOT make unrelated changes.`;
     } catch (err) {
       // One retry with fix agent
       console.warn(`  [verify] Failed, calling fix agent...`);
+      const implLogVerify = existsSync(join(runDir, "implement-log.json"))
+        ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
+        : "{}";
       const fixPrompt = `You are a TypeScript developer fixing build/lint failures.
 
 ${baseContext}
+
+## Implementation Intent (implement-log.json)
+
+${implLogVerify}
 
 ## Build/Lint Failure
 

--- a/scripts/develop.ts
+++ b/scripts/develop.ts
@@ -28,6 +28,7 @@ import {
   createDevRunIndex,
   findDevResumePoint,
   DEV_STEP_NAMES,
+  DEV_STEP_ORDER,
   type DevelopRunIndex,
   type StepRecord,
 } from "../src/core/contracts/develop-run.js";
@@ -37,7 +38,7 @@ import { createDevelopRunDir } from "../src/agents/run-directory.js";
 // Constants
 // ---------------------------------------------------------------------------
 
-const MAX_TEST_RETRIES = 3;
+const MAX_FIX_ROUNDS = 3;
 const AGENT_TIMEOUT = 600_000; // 10 minutes
 const PROJECT_ROOT = resolve(import.meta.dirname ?? ".", "..");
 
@@ -49,6 +50,7 @@ const { values, positionals } = parseArgs({
   args: process.argv.slice(2),
   options: {
     resume: { type: "string" },
+    from: { type: "string" },
     help: { type: "boolean", short: "h" },
   },
   allowPositionals: true,
@@ -57,10 +59,13 @@ const { values, positionals } = parseArgs({
 if (values.help) {
   console.log(`Usage:
   npx tsx scripts/develop.ts <issue-number>
-  npx tsx scripts/develop.ts --resume <run-dir>
+  npx tsx scripts/develop.ts --resume <run-dir> [--from <step>]
+
+Steps: plan(1) implement(2) test(3) review(4) fix(5) verify(6) pr(7)
 
 Options:
-  --resume <run-dir>  Resume a failed run from the last incomplete step
+  --resume <run-dir>  Resume a failed run
+  --from <step>       Start from a specific step (name or number, requires --resume)
   -h, --help          Show this help message`);
   process.exit(0);
 }
@@ -174,6 +179,73 @@ function readJson<T = unknown>(path: string): T {
   return JSON.parse(readFileSync(path, "utf-8")) as T;
 }
 
+/** Resolve --from value (name or 1-based number) to step name. */
+function resolveFromStep(from: string): string {
+  const num = parseInt(from, 10);
+  if (!isNaN(num) && num >= 1 && num <= DEV_STEP_ORDER.length) {
+    return DEV_STEP_ORDER[num - 1]!;
+  }
+  if (DEV_STEP_ORDER.includes(from)) return from;
+  console.error(`Error: Unknown step '${from}'. Valid: ${DEV_STEP_ORDER.join(", ")} or 1-${DEV_STEP_ORDER.length}`);
+  process.exit(1);
+}
+
+/** Reset a step and all subsequent steps to pending. */
+function resetFrom(index: DevelopRunIndex, fromStep: string): void {
+  let found = false;
+  for (const step of index.steps) {
+    if (step.name === fromStep) found = true;
+    if (found) {
+      step.status = "pending";
+      step.error = undefined;
+      step.summary = undefined;
+      step.completedAt = undefined;
+      step.durationMs = undefined;
+    }
+  }
+  saveIndex(index);
+}
+
+// ---------------------------------------------------------------------------
+// Circuit breaker
+// ---------------------------------------------------------------------------
+
+interface CircuitState {
+  state: "closed" | "half-open" | "open";
+  errorCount: number;
+  previousErrorCount: number | null;
+  attempt: number;
+  replanAttempted: boolean;
+}
+
+function loadCircuit(runDir: string): CircuitState {
+  const path = join(runDir, "circuit.json");
+  if (existsSync(path)) return readJson<CircuitState>(path);
+  return { state: "closed", errorCount: 0, previousErrorCount: null, attempt: 0, replanAttempted: false };
+}
+
+function saveCircuit(runDir: string, circuit: CircuitState): void {
+  writeFileSync(join(runDir, "circuit.json"), JSON.stringify(circuit, null, 2) + "\n");
+}
+
+/** Count error-severity findings in review.json */
+function countReviewErrors(runDir: string): number {
+  if (!existsSync(join(runDir, "review.json"))) return 0;
+  const review = readJson<{ findings: Array<{ severity: string }> }>(join(runDir, "review.json"));
+  return review.findings.filter((f) => f.severity === "error").length;
+}
+
+/** Decide what to do after a verify failure */
+function circuitDecision(circuit: CircuitState): "fix-retry" | "re-plan" | "give-up" {
+  if (circuit.replanAttempted) return "give-up";
+  if (circuit.attempt >= MAX_FIX_ROUNDS) return "re-plan";
+  if (circuit.previousErrorCount !== null && circuit.errorCount >= circuit.previousErrorCount) {
+    // No progress — errors not decreasing
+    return "re-plan";
+  }
+  return "fix-retry";
+}
+
 // ---------------------------------------------------------------------------
 // Issue fetching
 // ---------------------------------------------------------------------------
@@ -252,6 +324,13 @@ async function main(): Promise<void> {
       return;
     }
 
+    // Apply --from override: reset from specified step
+    if (values.from) {
+      const fromStep = resolveFromStep(values.from);
+      resetFrom(index, fromStep);
+      console.log(`  Resetting from step: ${fromStep}`);
+    }
+
     // Ensure we're on the correct branch
     const currentBranch = execSync("git branch --show-current", { encoding: "utf-8", cwd: PROJECT_ROOT }).trim();
     if (currentBranch !== index.branch) {
@@ -259,9 +338,15 @@ async function main(): Promise<void> {
       execSync(`git checkout ${shellEscape(index.branch)}`, { encoding: "utf-8", cwd: PROJECT_ROOT });
     }
 
+    const actualResume = findDevResumePoint(index);
+    if (!actualResume) {
+      console.log("All steps completed. Nothing to resume.");
+      return;
+    }
+
     index.status = "running";
     saveIndex(index);
-    console.log(`Resuming development from step: ${resumeFrom}`);
+    console.log(`Resuming development from step: ${actualResume}`);
     console.log(`  Run directory: ${runDir}`);
   } else {
     // New run
@@ -335,9 +420,25 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
         }
       }
 
-      const plan = readJson<{ tasks: unknown[] }>(join(runDir, "plan.json"));
+      const plan = readJson<{ tasks: unknown[]; split?: boolean; remainingDescription?: string }>(join(runDir, "plan.json"));
+
+      // Handle issue splitting
+      if (plan.split && plan.remainingDescription) {
+        console.log(`  [split] Issue too large — creating follow-up issue...`);
+        try {
+          const followUpBody = `## Follow-up from #${issue.number}\n\n${plan.remainingDescription}\n\n---\nAuto-created by \`scripts/develop.ts\` (issue splitting)`;
+          const ghOutput = execSync(
+            `gh issue create --title ${shellEscape(`feat: ${issue.title} (part 2)`)} --body ${shellEscape(followUpBody)}`,
+            { encoding: "utf-8", cwd: PROJECT_ROOT },
+          ).trim();
+          console.log(`  [split] Follow-up issue: ${ghOutput}`);
+        } catch {
+          console.warn(`  [split] Failed to create follow-up issue — continuing with current plan`);
+        }
+      }
+
       markCompleted(index, DEV_STEP_NAMES.PLAN, {
-        summary: `${plan.tasks.length} tasks planned`,
+        summary: `${plan.tasks.length} tasks planned${plan.split ? " (split)" : ""}`,
         outputs: ["plan.json"],
       });
     } catch (err) {
@@ -392,70 +493,31 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
     }
   }
 
-  // ─── Step 3: Test (CLI with fix retry loop) ────────────────────────
+  // ─── Step 3: Test (CLI, non-blocking) ───────────────────────────────
+  // Test failures don't kill the pipeline — Review diagnoses them.
   if (shouldRun(DEV_STEP_NAMES.TEST)) {
     markRunning(index, DEV_STEP_NAMES.TEST);
-    let testPassed = false;
-    let lastError = "";
-    let passedAttempt = 0;
-
-    for (let attempt = 0; attempt <= MAX_TEST_RETRIES; attempt++) {
-      try {
-        if (attempt > 0) {
-          console.log(`  [retry] Test attempt ${attempt + 1}/${MAX_TEST_RETRIES + 1}`);
-        }
-
-        // Run lint and tests
-        runCli("pnpm lint", "Type check");
-        runCli("pnpm test:run", "Tests");
-        testPassed = true;
-        passedAttempt = attempt + 1;
-        break;
-      } catch (err) {
-        lastError = err instanceof Error ? err.message : String(err);
-        console.warn(`  [test] Failed (attempt ${attempt + 1}): ${lastError.slice(0, 200)}`);
-
-        // Save test failure for context
-        writeFileSync(join(runDir, "test-result.json"), JSON.stringify({
-          passed: false,
-          attempt: attempt + 1,
-          errors: lastError.slice(0, 5000),
-        }, null, 2) + "\n");
-
-        if (attempt < MAX_TEST_RETRIES) {
-          // Ask fix agent to resolve the issue
-          console.log(`  [agent] Calling fix agent for test failure...`);
-          const implLog = existsSync(join(runDir, "implement-log.json"))
-            ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
-            : "{}";
-          const fixerDef = loadAgent("fixer");
-          const fixContext = buildContext(issue, runDir, {
-            "implement-log.json": implLog,
-            "Test errors": lastError.slice(0, 3000),
-          });
-          const fixPrompt = `${fixerDef}\n\n${fixContext}`;
-
-          try {
-            runAgent(fixPrompt, `Test Fix (attempt ${attempt + 1})`);
-          } catch (fixErr) {
-            console.warn(`  [agent] Fix agent failed: ${fixErr instanceof Error ? fixErr.message.slice(0, 200) : String(fixErr)}`);
-          }
-        }
-      }
-    }
-
-    if (testPassed) {
+    try {
+      runCli("pnpm lint", "Type check");
+      runCli("pnpm test:run", "Tests");
       writeFileSync(join(runDir, "test-result.json"), JSON.stringify({
         passed: true,
-        attempt: passedAttempt,
       }, null, 2) + "\n");
       markCompleted(index, DEV_STEP_NAMES.TEST, {
         summary: "Lint + tests passed",
         outputs: ["test-result.json"],
       });
-    } else {
-      markFailed(index, DEV_STEP_NAMES.TEST, `Tests failed after ${MAX_TEST_RETRIES + 1} attempts: ${lastError.slice(0, 500)}`);
-      throw new Error("Tests failed after retries");
+    } catch (err) {
+      const testError = err instanceof Error ? err.message : String(err);
+      console.warn(`  [test] Failed — continuing to Review for diagnosis`);
+      writeFileSync(join(runDir, "test-result.json"), JSON.stringify({
+        passed: false,
+        errors: testError.slice(0, 5000),
+      }, null, 2) + "\n");
+      markCompleted(index, DEV_STEP_NAMES.TEST, {
+        summary: "FAILED — forwarded to Review",
+        outputs: ["test-result.json"],
+      });
     }
   }
 
@@ -482,12 +544,21 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
           ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
           : "{}";
 
-        const reviewerDef = loadAgent("reviewer");
-        const reviewContext = buildContext(issue, runDir, {
+        // Include test results if tests failed — reviewer diagnoses
+        const extras: Record<string, string> = {
           "plan.json": planJson,
           "implement-log.json": implLog,
           "git diff main...HEAD": truncatedDiff,
-        });
+        };
+        const testResult = existsSync(join(runDir, "test-result.json"))
+          ? readJson<{ passed: boolean; errors?: string }>(join(runDir, "test-result.json"))
+          : null;
+        if (testResult && !testResult.passed) {
+          extras["test-result.json (TESTS FAILED — diagnose this)"] = testResult.errors ?? "unknown error";
+        }
+
+        const reviewerDef = loadAgent("reviewer");
+        const reviewContext = buildContext(issue, runDir, extras);
         const reviewPrompt = `${reviewerDef}\n\n${reviewContext}`;
 
         const reviewOutput = runAgent(reviewPrompt, "Reviewer");
@@ -559,42 +630,107 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
     }
   }
 
-  // ─── Step 6: Verify (CLI) ──────────────────────────────────────────
+  // ─── Step 6: Verify (CLI with circuit breaker) ─────────────────────
+  // Loop: verify → fail → review → fix → verify. Circuit breaker detects
+  // stuck loops and triggers re-plan. Max MAX_FIX_ROUNDS rounds.
   if (shouldRun(DEV_STEP_NAMES.VERIFY)) {
     markRunning(index, DEV_STEP_NAMES.VERIFY);
-    try {
-      runCli("pnpm lint", "Type check (verify)");
-      runCli("pnpm test:run", "Tests (verify)");
-      runCli("pnpm build", "Build (verify)");
+    const circuit = loadCircuit(runDir);
 
-      markCompleted(index, DEV_STEP_NAMES.VERIFY, {
-        summary: "Lint + tests + build passed",
-      });
-    } catch (err) {
-      // One retry with fix agent
-      console.warn(`  [verify] Failed, calling fix agent...`);
-      const implLogVerify = existsSync(join(runDir, "implement-log.json"))
-        ? readFileSync(join(runDir, "implement-log.json"), "utf-8")
-        : "{}";
-      const fixerDefVerify = loadAgent("fixer");
-      const fixContextVerify = buildContext(issue, runDir, {
-        "implement-log.json": implLogVerify,
-        "Build errors": (err instanceof Error ? err.message : String(err)).slice(0, 3000),
-      });
-      const fixPrompt = `${fixerDefVerify}\n\n${fixContextVerify}`;
-
+    let verified = false;
+    while (!verified) {
       try {
-        runAgent(fixPrompt, "Verify Fix");
-        // Re-run verify
-        runCli("pnpm lint", "Type check (verify retry)");
-        runCli("pnpm test:run", "Tests (verify retry)");
-        runCli("pnpm build", "Build (verify retry)");
-        markCompleted(index, DEV_STEP_NAMES.VERIFY, { summary: "Lint + tests + build passed (after fix)" });
-      } catch (retryErr) {
-        markFailed(index, DEV_STEP_NAMES.VERIFY, retryErr instanceof Error ? retryErr.message : String(retryErr));
-        throw retryErr;
+        runCli("pnpm lint", `Type check (verify round ${circuit.attempt + 1})`);
+        runCli("pnpm test:run", `Tests (verify round ${circuit.attempt + 1})`);
+        runCli("pnpm build", `Build (verify round ${circuit.attempt + 1})`);
+        verified = true;
+      } catch (verifyErr) {
+        const verifyError = verifyErr instanceof Error ? verifyErr.message : String(verifyErr);
+        circuit.previousErrorCount = circuit.errorCount;
+        circuit.errorCount = countReviewErrors(runDir);
+        circuit.attempt++;
+        saveCircuit(runDir, circuit);
+
+        const action = circuitDecision(circuit);
+        console.log(`  [circuit] Round ${circuit.attempt}: errors=${circuit.errorCount} prev=${circuit.previousErrorCount ?? "n/a"} → ${action}`);
+
+        if (action === "give-up") {
+          markFailed(index, DEV_STEP_NAMES.VERIFY,
+            `Circuit breaker OPEN: re-plan already attempted, still failing. Manual intervention needed.`);
+          throw new Error("Circuit breaker: pipeline exhausted all recovery options");
+        }
+
+        if (action === "re-plan") {
+          console.log(`  [circuit] Triggering re-plan with failure context...`);
+          circuit.replanAttempted = true;
+          circuit.state = "half-open";
+          saveCircuit(runDir, circuit);
+
+          // Re-plan: planner reads previous plan + review failures
+          const prevPlan = existsSync(join(runDir, "plan.json"))
+            ? readFileSync(join(runDir, "plan.json"), "utf-8") : "{}";
+          const prevReview = existsSync(join(runDir, "review.json"))
+            ? readFileSync(join(runDir, "review.json"), "utf-8") : "{}";
+
+          const replanDef = loadAgent("planner");
+          const replanContext = buildContext(issue, runDir, {
+            "PREVIOUS plan.json (this approach FAILED)": prevPlan,
+            "PREVIOUS review.json (these issues were found)": prevReview,
+            "INSTRUCTION": "The previous plan failed. Analyze why from the review findings and try a DIFFERENT approach. Do NOT repeat the same plan.",
+          });
+          runAgent(`${replanDef}\n\n${replanContext}`, "Re-planner");
+
+          // Re-implement with new plan
+          const newPlan = readFileSync(join(runDir, "plan.json"), "utf-8");
+          const reimplDef = loadAgent("implementer");
+          const reimplContext = buildContext(issue, runDir, { "plan.json": newPlan });
+          runAgent(`${reimplDef}\n\n${reimplContext}`, "Re-implementer");
+
+          // Loop back to verify (one more chance)
+          continue;
+        }
+
+        // action === "fix-retry": run review → fix → loop back to verify
+        console.log(`  [circuit] Running review → fix cycle...`);
+
+        // Quick review of current state
+        const fixDiff = execSync("git diff main...HEAD", { encoding: "utf-8", cwd: PROJECT_ROOT });
+        const truncFixDiff = fixDiff.length > 30_000
+          ? fixDiff.slice(0, 30_000) + "\n\n... (truncated)"
+          : fixDiff;
+        const implLogFix = existsSync(join(runDir, "implement-log.json"))
+          ? readFileSync(join(runDir, "implement-log.json"), "utf-8") : "{}";
+
+        const reviewerDef = loadAgent("reviewer");
+        const rvCtx = buildContext(issue, runDir, {
+          "implement-log.json": implLogFix,
+          "git diff main...HEAD": truncFixDiff,
+          "Verify failure": verifyError.slice(0, 3000),
+        });
+        const rvOutput = runAgent(`${reviewerDef}\n\n${rvCtx}`, `Reviewer (round ${circuit.attempt})`);
+
+        // Save review
+        if (!existsSync(join(runDir, "review.json"))) {
+          const rvJson = rvOutput.match(/\{[\s\S]*"verdict"[\s\S]*\}/);
+          if (rvJson) writeFileSync(join(runDir, "review.json"), rvJson[0] + "\n");
+        }
+
+        // Fix
+        const fixerDef = loadAgent("fixer");
+        const fxCtx = buildContext(issue, runDir, {
+          "implement-log.json": implLogFix,
+          "Verify failure": verifyError.slice(0, 3000),
+        });
+        runAgent(`${fixerDef}\n\n${fxCtx}`, `Fixer (round ${circuit.attempt})`);
       }
     }
+
+    circuit.state = "closed";
+    saveCircuit(runDir, circuit);
+    markCompleted(index, DEV_STEP_NAMES.VERIFY, {
+      summary: `Lint + tests + build passed (${circuit.attempt} fix rounds)`,
+      outputs: ["circuit.json"],
+    });
   }
 
   // ─── Step 7: PR (CLI) ──────────────────────────────────────────────

--- a/scripts/develop.ts
+++ b/scripts/develop.ts
@@ -19,6 +19,7 @@ import {
   readFileSync,
   writeFileSync,
   existsSync,
+  unlinkSync,
 } from "node:fs";
 import { resolve, join } from "node:path";
 import { parseArgs } from "node:util";
@@ -190,7 +191,18 @@ function resolveFromStep(from: string): string {
   process.exit(1);
 }
 
-/** Reset a step and all subsequent steps to pending. */
+/** Artifacts produced by each step — deleted on resetFrom to avoid stale state. */
+const STEP_ARTIFACTS: Record<string, string[]> = {
+  [DEV_STEP_NAMES.PLAN]: ["plan.json"],
+  [DEV_STEP_NAMES.IMPLEMENT]: ["implement-log.json", "implement-output.txt"],
+  [DEV_STEP_NAMES.TEST]: ["test-result.json"],
+  [DEV_STEP_NAMES.REVIEW]: ["review.json", "review-raw.txt"],
+  [DEV_STEP_NAMES.FIX]: ["fix-log.json"],
+  [DEV_STEP_NAMES.VERIFY]: ["circuit.json"],
+  [DEV_STEP_NAMES.PR]: ["pr-url.txt"],
+};
+
+/** Reset a step and all subsequent steps to pending, removing stale artifacts. */
 function resetFrom(index: DevelopRunIndex, fromStep: string): void {
   let found = false;
   for (const step of index.steps) {
@@ -201,9 +213,28 @@ function resetFrom(index: DevelopRunIndex, fromStep: string): void {
       step.summary = undefined;
       step.completedAt = undefined;
       step.durationMs = undefined;
+
+      // Delete artifacts produced by this step
+      const artifacts = STEP_ARTIFACTS[step.name];
+      if (artifacts) {
+        for (const file of artifacts) {
+          const filePath = join(index.runDir, file);
+          if (existsSync(filePath)) unlinkSync(filePath);
+        }
+      }
     }
   }
   saveIndex(index);
+}
+
+/** Abort if the working tree has staged or unstaged changes. */
+function ensureCleanWorktree(): void {
+  const status = execSync("git status --porcelain", { encoding: "utf-8", cwd: PROJECT_ROOT }).trim();
+  if (status) {
+    console.error("Error: Working tree is not clean. Commit or stash your changes first.");
+    console.error(status);
+    process.exit(1);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -308,6 +339,8 @@ async function main(): Promise<void> {
   let index: DevelopRunIndex;
   let runDir: string;
   let issue: IssueData;
+
+  ensureCleanWorktree();
 
   if (values.resume) {
     // Resume existing run
@@ -456,17 +489,23 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
       const context = buildContext(issue, runDir, { "plan.json": plan });
       const implementPrompt = `${agentDef}\n\n${context}`;
 
-      const implOutput = runAgent(implementPrompt, "Implementer");
-
-      // Check that changes were committed
-      const commitCount = execSync("git rev-list --count main...HEAD", {
+      // Capture HEAD before run to detect new commits (avoids false positive on resume)
+      const headBefore = execSync("git rev-parse HEAD", {
         encoding: "utf-8",
         cwd: PROJECT_ROOT,
       }).trim();
-      if (commitCount === "0") {
+
+      const implOutput = runAgent(implementPrompt, "Implementer");
+
+      // Check that the implementer created new commits this round
+      const headAfter = execSync("git rev-parse HEAD", {
+        encoding: "utf-8",
+        cwd: PROJECT_ROOT,
+      }).trim();
+      if (headAfter === headBefore) {
         throw new Error("Implementer did not create any commits");
       }
-      const diffStat = execSync("git diff --stat main...HEAD", {
+      const diffStat = execSync(`git diff --stat ${headBefore}..HEAD`, {
         encoding: "utf-8",
         cwd: PROJECT_ROOT,
       }).trim();
@@ -575,17 +614,19 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
         }
 
         const review = readJson<{ verdict: string; findings: unknown[] }>(join(runDir, "review.json"));
-        const errorCount = (review.findings as Array<{ severity: string }>)
-          .filter((f) => f.severity === "error").length;
+        const findings = review.findings as Array<{ severity: string }>;
+        const errorCount = findings.filter((f) => f.severity === "error").length;
+        const warningCount = findings.filter((f) => f.severity === "warning").length;
+        const actionableCount = errorCount + warningCount;
 
         markCompleted(index, DEV_STEP_NAMES.REVIEW, {
-          summary: `verdict=${review.verdict} findings=${review.findings.length} errors=${errorCount}`,
+          summary: `verdict=${review.verdict} findings=${review.findings.length} errors=${errorCount} warnings=${warningCount}`,
           outputs: ["review.json"],
         });
 
-        // If approved with no errors, skip fix step
-        if (review.verdict === "approve" && errorCount === 0) {
-          markSkipped(index, DEV_STEP_NAMES.FIX, "Review approved, no errors");
+        // If approved with no actionable findings (errors + warnings), skip fix step
+        if (review.verdict === "approve" && actionableCount === 0) {
+          markSkipped(index, DEV_STEP_NAMES.FIX, "Review approved, no actionable findings");
         }
       }
     } catch (err) {
@@ -709,11 +750,9 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
         });
         const rvOutput = runAgent(`${reviewerDef}\n\n${rvCtx}`, `Reviewer (round ${circuit.attempt})`);
 
-        // Save review
-        if (!existsSync(join(runDir, "review.json"))) {
-          const rvJson = rvOutput.match(/\{[\s\S]*"verdict"[\s\S]*\}/);
-          if (rvJson) writeFileSync(join(runDir, "review.json"), rvJson[0] + "\n");
-        }
+        // Always save fresh review — overwrite stale data from previous round
+        const rvJson = rvOutput.match(/\{[\s\S]*"verdict"[\s\S]*\}/);
+        if (rvJson) writeFileSync(join(runDir, "review.json"), rvJson[0] + "\n");
 
         // Fix
         const fixerDef = loadAgent("fixer");

--- a/scripts/develop.ts
+++ b/scripts/develop.ts
@@ -1,0 +1,724 @@
+#!/usr/bin/env tsx
+
+/**
+ * Automated development pipeline orchestrator.
+ *
+ * Same pattern as scripts/calibrate.ts: CLI for deterministic steps,
+ * `claude -p` for judgment steps. State tracked in index.json for
+ * resume-from-failure support.
+ *
+ * Usage:
+ *   npx tsx scripts/develop.ts <issue-number>
+ *   npx tsx scripts/develop.ts --resume <run-dir>
+ *
+ * See: issue #247
+ */
+
+import { execSync, type SpawnSyncReturns } from "node:child_process";
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { resolve, join } from "node:path";
+import { parseArgs } from "node:util";
+
+import {
+  DevelopRunIndexSchema,
+  createDevRunIndex,
+  findDevResumePoint,
+  DEV_STEP_NAMES,
+  type DevelopRunIndex,
+  type StepRecord,
+} from "../src/core/contracts/develop-run.js";
+import { createDevelopRunDir } from "../src/agents/run-directory.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_TEST_RETRIES = 3;
+const AGENT_TIMEOUT = 600_000; // 10 minutes
+const PROJECT_ROOT = resolve(import.meta.dirname ?? ".", "..");
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    resume: { type: "string" },
+    help: { type: "boolean", short: "h" },
+  },
+  allowPositionals: true,
+});
+
+if (values.help) {
+  console.log(`Usage:
+  npx tsx scripts/develop.ts <issue-number>
+  npx tsx scripts/develop.ts --resume <run-dir>
+
+Options:
+  --resume <run-dir>  Resume a failed run from the last incomplete step
+  -h, --help          Show this help message`);
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Index.json helpers
+// ---------------------------------------------------------------------------
+
+function loadIndex(runDir: string): DevelopRunIndex {
+  const indexPath = join(runDir, "index.json");
+  const raw: unknown = JSON.parse(readFileSync(indexPath, "utf-8"));
+  return DevelopRunIndexSchema.parse(raw);
+}
+
+function saveIndex(index: DevelopRunIndex): void {
+  index.updatedAt = new Date().toISOString();
+  writeFileSync(join(index.runDir, "index.json"), JSON.stringify(index, null, 2) + "\n");
+}
+
+function getStep(index: DevelopRunIndex, name: string): StepRecord {
+  const step = index.steps.find((s) => s.name === name);
+  if (!step) throw new Error(`Step not found: ${name}`);
+  return step;
+}
+
+function markRunning(index: DevelopRunIndex, name: string): StepRecord {
+  const step = getStep(index, name);
+  step.status = "running";
+  step.startedAt = new Date().toISOString();
+  saveIndex(index);
+  return step;
+}
+
+function markCompleted(
+  index: DevelopRunIndex,
+  name: string,
+  opts: { summary?: string; outputs?: string[] } = {},
+): void {
+  const step = getStep(index, name);
+  const start = step.startedAt ? new Date(step.startedAt).getTime() : Date.now();
+  step.status = "completed";
+  step.completedAt = new Date().toISOString();
+  step.durationMs = Date.now() - start;
+  if (opts.summary) step.summary = opts.summary;
+  if (opts.outputs) step.outputs = opts.outputs;
+  saveIndex(index);
+}
+
+function markSkipped(index: DevelopRunIndex, name: string, reason: string): void {
+  const step = getStep(index, name);
+  step.status = "skipped";
+  step.summary = reason;
+  saveIndex(index);
+}
+
+function markFailed(index: DevelopRunIndex, name: string, error: string): void {
+  const step = getStep(index, name);
+  const start = step.startedAt ? new Date(step.startedAt).getTime() : Date.now();
+  step.status = "failed";
+  step.completedAt = new Date().toISOString();
+  step.durationMs = Date.now() - start;
+  step.error = error;
+  step.retries++;
+  index.status = "failed";
+  saveIndex(index);
+}
+
+// ---------------------------------------------------------------------------
+// Execution helpers
+// ---------------------------------------------------------------------------
+
+function runCli(command: string, label: string): string {
+  console.log(`  [cli] ${label}`);
+  try {
+    return execSync(command, { encoding: "utf-8", maxBuffer: 50 * 1024 * 1024, cwd: PROJECT_ROOT });
+  } catch (err) {
+    const execErr = err as SpawnSyncReturns<string>;
+    const stderr = execErr.stderr ?? "";
+    const stdout = execErr.stdout ?? "";
+    throw new Error(`CLI failed: ${label}\n${stderr}\n${stdout}`.trim());
+  }
+}
+
+/** Run a `claude -p` agent with prompt via stdin. Returns stdout. */
+function runAgent(prompt: string, label: string): string {
+  console.log(`  [agent] ${label}`);
+  try {
+    return execSync(
+      `claude -p --allowedTools "Bash,Read,Write,Glob,Edit,Grep"`,
+      {
+        input: prompt,
+        encoding: "utf-8",
+        maxBuffer: 50 * 1024 * 1024,
+        timeout: AGENT_TIMEOUT,
+        cwd: PROJECT_ROOT,
+      },
+    );
+  } catch (err) {
+    const execErr = err as SpawnSyncReturns<string>;
+    const stderr = execErr.stderr ?? "";
+    throw new Error(`Agent failed: ${label}\n${stderr}`.trim());
+  }
+}
+
+function shellEscape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+/** Read a JSON file and return parsed content. */
+function readJson<T = unknown>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf-8")) as T;
+}
+
+// ---------------------------------------------------------------------------
+// Issue fetching
+// ---------------------------------------------------------------------------
+
+interface IssueData {
+  number: number;
+  title: string;
+  body: string;
+  labels: string[];
+}
+
+function fetchIssue(issueNumber: number): IssueData {
+  console.log(`  [cli] Fetching issue #${issueNumber}...`);
+  const raw = execSync(
+    `gh issue view ${issueNumber} --json number,title,body,labels`,
+    { encoding: "utf-8", cwd: PROJECT_ROOT },
+  );
+  const data = JSON.parse(raw) as { number: number; title: string; body: string; labels: Array<{ name: string }> };
+  return {
+    number: data.number,
+    title: data.title,
+    body: data.body,
+    labels: data.labels.map((l) => l.name),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Context builders
+// ---------------------------------------------------------------------------
+
+function loadClaudeMd(): string {
+  const path = join(PROJECT_ROOT, "CLAUDE.md");
+  return existsSync(path) ? readFileSync(path, "utf-8") : "";
+}
+
+function buildBaseContext(issue: IssueData, runDir: string): string {
+  return `## Project Instructions (CLAUDE.md)
+
+${loadClaudeMd()}
+
+## Target Issue
+
+**#${issue.number}: ${issue.title}**
+
+${issue.body}
+
+## Run Directory
+
+${runDir}
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Main pipeline
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  let index: DevelopRunIndex;
+  let runDir: string;
+  let issue: IssueData;
+
+  if (values.resume) {
+    // Resume existing run
+    runDir = resolve(values.resume);
+    if (!existsSync(join(runDir, "index.json"))) {
+      console.error(`Error: No index.json found in ${runDir}`);
+      process.exit(1);
+    }
+    index = loadIndex(runDir);
+    issue = fetchIssue(index.issue);
+    const resumeFrom = findDevResumePoint(index);
+    if (!resumeFrom) {
+      console.log("All steps completed. Nothing to resume.");
+      return;
+    }
+    index.status = "running";
+    saveIndex(index);
+    console.log(`Resuming development from step: ${resumeFrom}`);
+    console.log(`  Run directory: ${runDir}`);
+  } else {
+    // New run
+    const issueNum = parseInt(positionals[0] ?? "", 10);
+    if (isNaN(issueNum)) {
+      console.error("Error: issue number required. Usage: npx tsx scripts/develop.ts <issue-number>");
+      process.exit(1);
+    }
+
+    issue = fetchIssue(issueNum);
+    console.log(`\nStarting development pipeline for: #${issue.number} ${issue.title}`);
+
+    // Create branch
+    const branchName = `develop/${issue.number}`;
+    try {
+      execSync(`git checkout -b ${shellEscape(branchName)} main`, { encoding: "utf-8", cwd: PROJECT_ROOT });
+    } catch {
+      // Branch may already exist (from a previous attempt)
+      execSync(`git checkout ${shellEscape(branchName)}`, { encoding: "utf-8", cwd: PROJECT_ROOT });
+    }
+
+    runDir = createDevelopRunDir(issue.number);
+    index = createDevRunIndex(issue.number, issue.title, branchName, runDir);
+    saveIndex(index);
+
+    console.log(`  Branch: ${branchName}`);
+    console.log(`  Run directory: ${runDir}`);
+  }
+
+  try {
+    await runPipeline(index, issue);
+    index.status = "completed";
+    saveIndex(index);
+    console.log("\nDevelopment pipeline complete.");
+    console.log(`  Run directory: ${runDir}`);
+  } catch (err) {
+    console.error("\nPipeline failed:", err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  }
+}
+
+async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<void> {
+  const { runDir } = index;
+  const resumeFrom = findDevResumePoint(index);
+  if (!resumeFrom) return;
+
+  const shouldRun = (name: string): boolean => {
+    const step = getStep(index, name);
+    return step.status !== "completed" && step.status !== "skipped";
+  };
+
+  const baseContext = buildBaseContext(issue, runDir);
+
+  // ─── Step 1: Plan (agent) ──────────────────────────────────────────
+  if (shouldRun(DEV_STEP_NAMES.PLAN)) {
+    markRunning(index, DEV_STEP_NAMES.PLAN);
+    try {
+      const planPrompt = `You are a software architect planning the implementation for a GitHub issue.
+
+${baseContext}
+
+## Your Task
+
+Analyze the issue and the codebase, then produce a detailed implementation plan.
+
+### Instructions
+
+1. Read the issue carefully and understand the requirements
+2. Explore the relevant parts of the codebase (use Glob, Grep, Read)
+3. Identify which files need to be created or modified
+4. Break down the work into ordered tasks
+
+### Output Format
+
+Write a JSON plan to ${join(runDir, "plan.json")} with this structure:
+
+\`\`\`json
+{
+  "summary": "One-paragraph summary of what needs to be done",
+  "tasks": [
+    {
+      "id": 1,
+      "title": "Short task title",
+      "description": "What to do and why",
+      "files": ["src/path/to/file.ts"],
+      "approach": "How to implement this"
+    }
+  ],
+  "testStrategy": "How to verify the implementation",
+  "risks": ["Potential issues to watch for"]
+}
+\`\`\`
+
+Write the plan file, then print a one-line summary to stdout.`;
+
+      const planOutput = runAgent(planPrompt, "Planner");
+
+      if (!existsSync(join(runDir, "plan.json"))) {
+        // Agent may have printed JSON instead of writing — try to extract
+        const jsonMatch = planOutput.match(/\{[\s\S]*"tasks"[\s\S]*\}/);
+        if (jsonMatch) {
+          writeFileSync(join(runDir, "plan.json"), jsonMatch[0] + "\n");
+        } else {
+          throw new Error("Planner did not produce plan.json");
+        }
+      }
+
+      const plan = readJson<{ tasks: unknown[] }>(join(runDir, "plan.json"));
+      markCompleted(index, DEV_STEP_NAMES.PLAN, {
+        summary: `${plan.tasks.length} tasks planned`,
+        outputs: ["plan.json"],
+      });
+    } catch (err) {
+      markFailed(index, DEV_STEP_NAMES.PLAN, err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  }
+
+  // ─── Step 2: Implement (agent) ─────────────────────────────────────
+  if (shouldRun(DEV_STEP_NAMES.IMPLEMENT)) {
+    markRunning(index, DEV_STEP_NAMES.IMPLEMENT);
+    try {
+      const plan = readFileSync(join(runDir, "plan.json"), "utf-8");
+
+      const implementPrompt = `You are a senior TypeScript developer implementing a planned feature.
+
+${baseContext}
+
+## Implementation Plan
+
+${plan}
+
+## Your Task
+
+Implement ALL tasks from the plan above. Follow these rules:
+
+1. Follow the project conventions in CLAUDE.md strictly (ESM, .js extensions, strict TS, etc.)
+2. Create/modify files as specified in the plan
+3. Do NOT run tests — a separate step handles that
+4. Do NOT create a PR — a separate step handles that
+5. After implementation, stage your changes with \`git add\` and commit with a conventional commit message
+
+### Important
+
+- Read existing files before modifying them
+- Keep changes minimal — only what the plan requires
+- Use the project's existing patterns and utilities
+
+After completing all tasks, print a summary of what you implemented.`;
+
+      const implOutput = runAgent(implementPrompt, "Implementer");
+
+      // Check that changes were made
+      const diffStat = execSync("git diff --stat HEAD~1 2>/dev/null || git diff --stat HEAD", {
+        encoding: "utf-8",
+        cwd: PROJECT_ROOT,
+      }).trim();
+
+      writeFileSync(join(runDir, "implement-output.txt"), implOutput);
+
+      markCompleted(index, DEV_STEP_NAMES.IMPLEMENT, {
+        summary: diffStat.split("\n").pop() ?? "Changes committed",
+        outputs: ["implement-output.txt"],
+      });
+    } catch (err) {
+      markFailed(index, DEV_STEP_NAMES.IMPLEMENT, err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  }
+
+  // ─── Step 3: Test (CLI with fix retry loop) ────────────────────────
+  if (shouldRun(DEV_STEP_NAMES.TEST)) {
+    markRunning(index, DEV_STEP_NAMES.TEST);
+    let testPassed = false;
+    let lastError = "";
+
+    for (let attempt = 0; attempt <= MAX_TEST_RETRIES; attempt++) {
+      try {
+        if (attempt > 0) {
+          console.log(`  [retry] Test attempt ${attempt + 1}/${MAX_TEST_RETRIES + 1}`);
+        }
+
+        // Run lint and tests
+        runCli("pnpm lint", "Type check");
+        runCli("pnpm test:run", "Tests");
+        testPassed = true;
+        break;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+        console.warn(`  [test] Failed (attempt ${attempt + 1}): ${lastError.slice(0, 200)}`);
+
+        if (attempt < MAX_TEST_RETRIES) {
+          // Ask fix agent to resolve the issue
+          console.log(`  [agent] Calling fix agent for test failure...`);
+          const fixPrompt = `You are a TypeScript developer fixing test/lint failures.
+
+${baseContext}
+
+## Test Failure
+
+The following test/lint command failed:
+
+\`\`\`
+${lastError.slice(0, 3000)}
+\`\`\`
+
+## Your Task
+
+1. Read the failing files and understand the errors
+2. Fix the issues — type errors, test failures, etc.
+3. Stage and commit your fixes with message: "fix: resolve test failures"
+
+Do NOT change test expectations unless the test is genuinely wrong.
+Focus on fixing the implementation to match what tests expect.`;
+
+          try {
+            runAgent(fixPrompt, `Test Fix (attempt ${attempt + 1})`);
+          } catch (fixErr) {
+            console.warn(`  [agent] Fix agent failed: ${fixErr instanceof Error ? fixErr.message.slice(0, 200) : String(fixErr)}`);
+          }
+        }
+      }
+    }
+
+    if (testPassed) {
+      markCompleted(index, DEV_STEP_NAMES.TEST, {
+        summary: "Lint + tests passed",
+      });
+    } else {
+      markFailed(index, DEV_STEP_NAMES.TEST, `Tests failed after ${MAX_TEST_RETRIES + 1} attempts: ${lastError.slice(0, 500)}`);
+      throw new Error("Tests failed after retries");
+    }
+  }
+
+  // ─── Step 4: Review (agent) ────────────────────────────────────────
+  if (shouldRun(DEV_STEP_NAMES.REVIEW)) {
+    markRunning(index, DEV_STEP_NAMES.REVIEW);
+    try {
+      const diff = execSync("git diff main...HEAD", { encoding: "utf-8", cwd: PROJECT_ROOT });
+
+      if (!diff.trim()) {
+        markSkipped(index, DEV_STEP_NAMES.REVIEW, "No changes to review");
+        markSkipped(index, DEV_STEP_NAMES.FIX, "No review findings");
+      } else {
+        // Truncate diff if too large for agent context
+        const maxDiffLen = 50_000;
+        const truncatedDiff = diff.length > maxDiffLen
+          ? diff.slice(0, maxDiffLen) + `\n\n... (truncated, ${diff.length - maxDiffLen} chars omitted)`
+          : diff;
+
+        const reviewPrompt = `You are a code reviewer checking a feature branch.
+
+${baseContext}
+
+## Changes (git diff main...HEAD)
+
+\`\`\`diff
+${truncatedDiff}
+\`\`\`
+
+## Your Task
+
+Review the changes for:
+1. **Correctness**: Logic errors, edge cases, off-by-one errors
+2. **Conventions**: Does it follow CLAUDE.md conventions? (ESM, .js extensions, strict TS, naming)
+3. **Security**: Injection risks, hardcoded secrets, unsafe operations
+4. **Completeness**: Does it fully address the issue requirements?
+
+### Output Format
+
+Write a JSON review to ${join(runDir, "review.json")} with this structure:
+
+\`\`\`json
+{
+  "verdict": "approve" | "request-changes",
+  "summary": "Overall assessment",
+  "findings": [
+    {
+      "severity": "error" | "warning" | "suggestion",
+      "file": "path/to/file.ts",
+      "line": 42,
+      "issue": "What's wrong",
+      "suggestion": "How to fix it"
+    }
+  ]
+}
+\`\`\`
+
+Be strict but fair. Only flag real issues, not style preferences already handled by the project conventions.`;
+
+        const reviewOutput = runAgent(reviewPrompt, "Reviewer");
+
+        if (!existsSync(join(runDir, "review.json"))) {
+          const jsonMatch = reviewOutput.match(/\{[\s\S]*"verdict"[\s\S]*\}/);
+          if (jsonMatch) {
+            writeFileSync(join(runDir, "review.json"), jsonMatch[0] + "\n");
+          } else {
+            // No structured review — treat as approve
+            writeFileSync(join(runDir, "review.json"), JSON.stringify({
+              verdict: "approve",
+              summary: "Review completed (unstructured output)",
+              findings: [],
+            }, null, 2) + "\n");
+          }
+        }
+
+        const review = readJson<{ verdict: string; findings: unknown[] }>(join(runDir, "review.json"));
+        const errorCount = (review.findings as Array<{ severity: string }>)
+          .filter((f) => f.severity === "error").length;
+
+        markCompleted(index, DEV_STEP_NAMES.REVIEW, {
+          summary: `verdict=${review.verdict} findings=${review.findings.length} errors=${errorCount}`,
+          outputs: ["review.json"],
+        });
+
+        // If approved with no errors, skip fix step
+        if (review.verdict === "approve" && errorCount === 0) {
+          markSkipped(index, DEV_STEP_NAMES.FIX, "Review approved, no errors");
+        }
+      }
+    } catch (err) {
+      markFailed(index, DEV_STEP_NAMES.REVIEW, err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  }
+
+  // ─── Step 5: Fix (agent, conditional) ──────────────────────────────
+  if (shouldRun(DEV_STEP_NAMES.FIX)) {
+    markRunning(index, DEV_STEP_NAMES.FIX);
+    try {
+      const review = readJson<{ findings: Array<{ severity: string; file: string; issue: string; suggestion: string }> }>(
+        join(runDir, "review.json"),
+      );
+      const actionable = review.findings.filter((f) => f.severity === "error" || f.severity === "warning");
+
+      if (actionable.length === 0) {
+        markSkipped(index, DEV_STEP_NAMES.FIX, "No actionable findings");
+      } else {
+        const fixPrompt = `You are a TypeScript developer fixing code review findings.
+
+${baseContext}
+
+## Review Findings to Fix
+
+${JSON.stringify(actionable, null, 2)}
+
+## Your Task
+
+1. Read each file mentioned in the findings
+2. Fix all errors and warnings
+3. Stage and commit with message: "fix: address review findings"
+
+Do NOT fix suggestions — only errors and warnings.
+Do NOT make unrelated changes.`;
+
+        runAgent(fixPrompt, "Fixer");
+
+        markCompleted(index, DEV_STEP_NAMES.FIX, {
+          summary: `Fixed ${actionable.length} findings`,
+        });
+      }
+    } catch (err) {
+      markFailed(index, DEV_STEP_NAMES.FIX, err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  }
+
+  // ─── Step 6: Verify (CLI) ──────────────────────────────────────────
+  if (shouldRun(DEV_STEP_NAMES.VERIFY)) {
+    markRunning(index, DEV_STEP_NAMES.VERIFY);
+    try {
+      runCli("pnpm lint", "Type check (verify)");
+      runCli("pnpm build", "Build (verify)");
+
+      markCompleted(index, DEV_STEP_NAMES.VERIFY, {
+        summary: "Lint + build passed",
+      });
+    } catch (err) {
+      // One retry with fix agent
+      console.warn(`  [verify] Failed, calling fix agent...`);
+      const fixPrompt = `You are a TypeScript developer fixing build/lint failures.
+
+${baseContext}
+
+## Build/Lint Failure
+
+\`\`\`
+${(err instanceof Error ? err.message : String(err)).slice(0, 3000)}
+\`\`\`
+
+## Your Task
+
+Fix the build/lint errors. Stage and commit with message: "fix: resolve build errors"`;
+
+      try {
+        runAgent(fixPrompt, "Verify Fix");
+        // Re-run verify
+        runCli("pnpm lint", "Type check (verify retry)");
+        runCli("pnpm build", "Build (verify retry)");
+        markCompleted(index, DEV_STEP_NAMES.VERIFY, { summary: "Lint + build passed (after fix)" });
+      } catch (retryErr) {
+        markFailed(index, DEV_STEP_NAMES.VERIFY, retryErr instanceof Error ? retryErr.message : String(retryErr));
+        throw retryErr;
+      }
+    }
+  }
+
+  // ─── Step 7: PR (CLI) ──────────────────────────────────────────────
+  if (shouldRun(DEV_STEP_NAMES.PR)) {
+    markRunning(index, DEV_STEP_NAMES.PR);
+    try {
+      // Push branch
+      runCli(`git push -u origin ${shellEscape(index.branch)}`, "Push branch");
+
+      // Build PR body from plan and review
+      const plan = readJson<{ summary: string; tasks: Array<{ title: string }> }>(join(runDir, "plan.json"));
+      const taskList = plan.tasks.map((t) => `- ${t.title}`).join("\n");
+
+      const prBody = `## Summary
+
+${plan.summary}
+
+## Tasks
+
+${taskList}
+
+## Test plan
+
+- [ ] \`pnpm lint\` passes
+- [ ] \`pnpm test:run\` passes
+- [ ] \`pnpm build\` passes
+
+Closes #${issue.number}
+
+---
+Generated by \`scripts/develop.ts\` ([#247](https://github.com/let-sunny/canicode/issues/247))`;
+
+      const prTitle = `${issue.title.startsWith("feat:") || issue.title.startsWith("fix:") ? issue.title : `feat: ${issue.title}`}`;
+
+      // Create draft PR
+      const prOutput = runCli(
+        `gh pr create --draft --title ${shellEscape(prTitle)} --body ${shellEscape(prBody)}`,
+        "Create draft PR",
+      );
+
+      // Extract PR URL from output
+      const prUrl = prOutput.trim().split("\n").pop() ?? "";
+      writeFileSync(join(runDir, "pr-url.txt"), prUrl + "\n");
+
+      markCompleted(index, DEV_STEP_NAMES.PR, {
+        summary: prUrl,
+        outputs: ["pr-url.txt"],
+      });
+
+      console.log(`\n  PR created: ${prUrl}`);
+    } catch (err) {
+      markFailed(index, DEV_STEP_NAMES.PR, err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/agents/run-directory.ts
+++ b/src/agents/run-directory.ts
@@ -3,6 +3,7 @@ import { resolve, join, basename } from "node:path";
 import { z } from "zod";
 
 const CALIBRATION_DIR = "logs/calibration";
+const DEVELOP_DIR = "logs/develop";
 
 function getDateTimeString(): string {
   const now = new Date();
@@ -62,6 +63,18 @@ export function createCalibrationRunDir(fixtureName: string): string {
   const timestamp = getDateTimeString();
   const dirName = buildRunDirName(fixtureName, timestamp);
   const dirPath = resolve(CALIBRATION_DIR, dirName);
+  mkdirSync(dirPath, { recursive: true });
+  return dirPath;
+}
+
+/**
+ * Create a development run directory and return its absolute path.
+ * Format: `logs/develop/<issue-number>--<YYYY-MM-DD-HHMM>/`
+ */
+export function createDevelopRunDir(issueNumber: number): string {
+  const timestamp = getDateTimeString();
+  const dirName = buildRunDirName(String(issueNumber), timestamp);
+  const dirPath = resolve(DEVELOP_DIR, dirName);
   mkdirSync(dirPath, { recursive: true });
   return dirPath;
 }

--- a/src/core/contracts/develop-run.ts
+++ b/src/core/contracts/develop-run.ts
@@ -1,0 +1,108 @@
+import { z } from "zod";
+
+import {
+  StepStatusSchema,
+  StepTypeSchema,
+  StepRecordSchema,
+  type StepRecord,
+} from "./calibration-run.js";
+
+// Re-export shared step types for convenience
+export { StepStatusSchema, StepTypeSchema, StepRecordSchema };
+export type { StepRecord };
+
+// --- Development pipeline run index (index.json) ---
+
+export const DevelopRunIndexSchema = z.object({
+  /** Schema version for forward compatibility */
+  version: z.literal(1),
+  /** GitHub issue number */
+  issue: z.number(),
+  /** Issue title */
+  issueTitle: z.string(),
+  /** Git branch name */
+  branch: z.string(),
+  /** Run directory path */
+  runDir: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  /** Overall run status */
+  status: z.enum(["running", "completed", "failed"]),
+  steps: z.array(StepRecordSchema),
+});
+export type DevelopRunIndex = z.infer<typeof DevelopRunIndexSchema>;
+
+// --- Step name constants ---
+
+export const DEV_STEP_NAMES = {
+  PLAN: "plan",
+  IMPLEMENT: "implement",
+  TEST: "test",
+  REVIEW: "review",
+  FIX: "fix",
+  VERIFY: "verify",
+  PR: "pr",
+} as const;
+
+/** Ordered list of all steps in the development pipeline */
+export const DEV_STEP_ORDER: readonly string[] = [
+  DEV_STEP_NAMES.PLAN,
+  DEV_STEP_NAMES.IMPLEMENT,
+  DEV_STEP_NAMES.TEST,
+  DEV_STEP_NAMES.REVIEW,
+  DEV_STEP_NAMES.FIX,
+  DEV_STEP_NAMES.VERIFY,
+  DEV_STEP_NAMES.PR,
+];
+
+/** Step definitions: name → type mapping */
+export const DEV_STEP_DEFS: Record<string, z.infer<typeof StepTypeSchema>> = {
+  [DEV_STEP_NAMES.PLAN]: "agent",
+  [DEV_STEP_NAMES.IMPLEMENT]: "agent",
+  [DEV_STEP_NAMES.TEST]: "cli",
+  [DEV_STEP_NAMES.REVIEW]: "agent",
+  [DEV_STEP_NAMES.FIX]: "agent",
+  [DEV_STEP_NAMES.VERIFY]: "cli",
+  [DEV_STEP_NAMES.PR]: "cli",
+};
+
+/**
+ * Create a fresh index.json for a new development run.
+ */
+export function createDevRunIndex(
+  issue: number,
+  issueTitle: string,
+  branch: string,
+  runDir: string,
+): DevelopRunIndex {
+  const now = new Date().toISOString();
+  return {
+    version: 1,
+    issue,
+    issueTitle,
+    branch,
+    runDir,
+    createdAt: now,
+    updatedAt: now,
+    status: "running",
+    steps: DEV_STEP_ORDER.map((name) => ({
+      name,
+      type: DEV_STEP_DEFS[name]!,
+      status: "pending" as const,
+      retries: 0,
+    })),
+  };
+}
+
+/**
+ * Find the first step to resume from (first non-completed step).
+ * Returns the step name, or null if all steps are completed.
+ */
+export function findDevResumePoint(index: DevelopRunIndex): string | null {
+  for (const step of index.steps) {
+    if (step.status !== "completed" && step.status !== "skipped") {
+      return step.name;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

`scripts/develop.ts` — 이슈 번호 하나 주면 자동으로 Plan → Implement → Test → Review → Fix → Verify → PR 까지 돌리는 파이프라인.

`claude -p`로 독립 에이전트 호출, CLI로 결정적 단계 실행. `scripts/calibrate.ts`와 동일 패턴 (ADR-008).

### Key Features

- **JSON handoff chain**: plan.json → implement-log.json → review.json → fix-log.json. 각 에이전트가 이전 step의 decisions/knownRisks를 읽어서 "왜"를 이해
- **Circuit breaker**: Verify 실패 시 에러 수 추적 → 진전 없으면 re-plan → 그래도 실패 → 종료
- **Non-blocking test**: 테스트 실패해도 Review로 진행, 리뷰어가 진단
- **Issue splitting**: Planner가 5개 초과 태스크 감지 → follow-up 이슈 자동 생성
- **Reviewer checklist**: 코드 규칙 + 아키텍처 검증 기계적 체크리스트
- **`--from N`**: 특정 step부터 재시작

### Files (10 files, +1284 lines)

| File | Role |
|------|------|
| `scripts/develop.ts` | Pipeline orchestrator |
| `src/core/contracts/develop-run.ts` | Zod schema (index.json state) |
| `src/agents/run-directory.ts` | `createDevelopRunDir()` helper |
| `.claude/agents/develop/planner.md` | Plan agent (designDecisions, split) |
| `.claude/agents/develop/implementer.md` | Implement agent (decisions, knownRisks) |
| `.claude/agents/develop/reviewer.md` | Review agent (intentConflict, checklist) |
| `.claude/agents/develop/fixer.md` | Fix agent (intent preservation) |
| `.claude/commands/develop.md` | `/develop` command wrapper |
| `.claude/docs/ARCHITECTURE.md` | Pipeline docs + output structure |
| `CLAUDE.md` | Project structure update |

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (656 tests)
- [x] `pnpm build` passes
- [x] `npx tsx scripts/develop.ts --help` works
- [ ] End-to-end test with a real issue

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated development pipeline accessible via CLI that processes GitHub issues end-to-end: reads requirements, generates plans, implements code, runs tests, reviews changes, fixes issues, and creates draft pull requests.
  * Supports resuming interrupted pipeline runs from any step with `--resume` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->