### PR TITLE
feat: refactor: reclassify save-fixture as internal command

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -6,7 +6,6 @@
 - Data source: Figma REST API (requires FIGMA_TOKEN) or JSON fixture
 - Output: HTML report (opens in browser)
 - Options: `--preset`, `--token`, `--output`, `--config`
-- Also: `canicode save-fixture` to save Figma data as JSON for offline analysis
 - Also: `canicode implement` to prepare a design-to-code package (analysis + design tree + assets + prompt)
 - Component master resolution: fetches `componentDefinitions` for accurate component analysis
 - Annotations: NOT available (REST API annotations field is private beta)
@@ -45,6 +44,11 @@ Calibration is orchestrated by `scripts/calibrate.ts` (ADR-008). CLI for determi
 - Cross-run evidence: Evaluation appends overscored/underscored findings to `data/calibration-evidence.json`
 - After Arbitrator applies changes, evidence for applied rules is pruned (`calibrate-prune-evidence`)
 - Each run creates a self-contained directory: `logs/calibration/<fixture>--<timestamp>/`
+
+**`canicode calibrate-save-fixture`**
+- Role: Save Figma design as a fixture directory for calibration (internal command)
+- Input: Figma URL with node-id
+- Output: fixture directory with data.json, screenshot.png, vectors/, images/
 
 **`/calibrate` (Claude Code command)**
 - Wrapper: runs `npx tsx scripts/calibrate.ts $ARGUMENTS` and reports results

--- a/.claude/skills/canicode/SKILL.md
+++ b/.claude/skills/canicode/SKILL.md
@@ -10,7 +10,7 @@ Analyze Figma design files to score how development-friendly and AI-friendly the
 ## Prerequisites
 
 This skill uses the CLI. Requires either:
-- A **saved fixture** (from `canicode save-fixture`)
+- A **saved fixture** (from `canicode calibrate-save-fixture`)
 - A **FIGMA_TOKEN** for live Figma URLs
 
 ## How to Analyze
@@ -35,7 +35,7 @@ npx canicode analyze fixtures/my-design
 ### Save a fixture for offline analysis
 
 ```bash
-npx canicode save-fixture "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234" --output fixtures/my-design
+npx canicode calibrate-save-fixture "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234" --output fixtures/my-design
 ```
 
 ## Analysis Options

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Background
       description: Why is this needed? What problem does it solve?
-      placeholder: "save-fixture doesn't store component master nodes, so design-tree and analysis rules can't access component structure"
+      placeholder: "calibrate-save-fixture doesn't store component master nodes, so design-tree and analysis rules can't access component structure"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/fixture-from-discussion.yml
+++ b/.github/workflows/fixture-from-discussion.yml
@@ -104,7 +104,7 @@ jobs:
           FIGMA_TOKEN: ${{ secrets.FIGMA_TOKEN }}
         run: |
           FIXTURE_PATH="fixtures/${{ steps.parse.outputs.fixture_name }}.json"
-          node dist/cli/index.js save-fixture "${{ steps.parse.outputs.figma_url }}" \
+          node dist/cli/index.js calibrate-save-fixture "${{ steps.parse.outputs.figma_url }}" \
             --output "$FIXTURE_PATH" \
             --token "$FIGMA_TOKEN"
           echo "path=$FIXTURE_PATH" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Setup: `canicode init --token figd_xxxxxxxxxxxxx`
 | View, Collab | 6 req/month | 6 req/month |
 | Dev, Full | 6 req/month | 10–20 req/min |
 
-Hitting 429 errors? Make sure the file is in a paid workspace. Or `save-fixture` once and analyze locally. [Full details](https://developers.figma.com/docs/rest-api/rate-limits/)
+Hitting 429 errors? Make sure the file is in a paid workspace. Or `calibrate-save-fixture` once and analyze locally. [Full details](https://developers.figma.com/docs/rest-api/rate-limits/)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Setup: `canicode init --token figd_xxxxxxxxxxxxx`
 | View, Collab | 6 req/month | 6 req/month |
 | Dev, Full | 6 req/month | 10–20 req/min |
 
-Hitting 429 errors? Make sure the file is in a paid workspace. Or `calibrate-save-fixture` once and analyze locally. [Full details](https://developers.figma.com/docs/rest-api/rate-limits/)
+Hitting 429 errors? Make sure the file is in a paid workspace. Or save a fixture once and analyze locally. [Full details](https://developers.figma.com/docs/rest-api/rate-limits/)
 
 </details>
 

--- a/src/cli/commands/internal/calibrate-save-fixture.ts
+++ b/src/cli/commands/internal/calibrate-save-fixture.ts
@@ -4,10 +4,10 @@ import { resolve } from "node:path";
 import type { CAC } from "cac";
 import { z } from "zod";
 
-import { parseFigmaUrl } from "../../core/adapters/figma-url-parser.js";
-import { loadFile, isFigmaUrl } from "../../core/engine/loader.js";
-import { getFigmaToken } from "../../core/engine/config-store.js";
-import { collectVectorNodes, collectImageNodes, sanitizeFilename, countNodes } from "../helpers.js";
+import { parseFigmaUrl } from "../../../core/adapters/figma-url-parser.js";
+import { loadFile, isFigmaUrl } from "../../../core/engine/loader.js";
+import { getFigmaToken } from "../../../core/engine/config-store.js";
+import { collectVectorNodes, collectImageNodes, sanitizeFilename, countNodes } from "../../helpers.js";
 
 const SaveFixtureOptionsSchema = z.object({
   output: z.string().optional(),
@@ -18,18 +18,18 @@ const SaveFixtureOptionsSchema = z.object({
 });
 
 
-export function registerSaveFixture(cli: CAC): void {
+export function registerCalibrateSaveFixture(cli: CAC): void {
   cli
     .command(
-      "save-fixture <input>",
-      "Save Figma design as a fixture directory for offline analysis"
+      "calibrate-save-fixture <input>",
+      "Save Figma design as a fixture directory for calibration"
     )
     .option("--output <path>", "Output directory (default: fixtures/<name>/)")
     .option("--name <name>", "Fixture name (default: extracted from URL)")
     .option("--token <token>", "Figma API token (or use FIGMA_TOKEN env var)")
     .option("--image-scale <n>", "Image export scale: 2 for PC (default), 3 for mobile")
-    .example("  canicode save-fixture https://www.figma.com/design/ABC123/MyDesign?node-id=1-234")
-    .example("  canicode save-fixture https://www.figma.com/design/ABC123/MyDesign?node-id=1-234 --image-scale 3")
+    .example("  canicode calibrate-save-fixture https://www.figma.com/design/ABC123/MyDesign?node-id=1-234")
+    .example("  canicode calibrate-save-fixture https://www.figma.com/design/ABC123/MyDesign?node-id=1-234 --image-scale 3")
     .action(async (input: string, rawOptions: Record<string, unknown>) => {
       try {
         const parseResult = SaveFixtureOptionsSchema.safeParse(rawOptions);
@@ -41,7 +41,7 @@ export function registerSaveFixture(cli: CAC): void {
         const options = parseResult.data;
 
         if (!isFigmaUrl(input)) {
-          throw new Error("save-fixture requires a Figma URL as input.");
+          throw new Error("calibrate-save-fixture requires a Figma URL as input.");
         }
 
         // Validate --image-scale early (before any file I/O)
@@ -68,8 +68,8 @@ export function registerSaveFixture(cli: CAC): void {
         // 0. Resolve component master node trees
         const figmaTokenForComponents = options.token ?? getFigmaToken();
         if (figmaTokenForComponents) {
-          const { FigmaClient: FC } = await import("../../core/adapters/figma-client.js");
-          const { resolveComponentDefinitions, resolveInteractionDestinations } = await import("../../core/adapters/component-resolver.js");
+          const { FigmaClient: FC } = await import("../../../core/adapters/figma-client.js");
+          const { resolveComponentDefinitions, resolveInteractionDestinations } = await import("../../../core/adapters/component-resolver.js");
           const componentClient = new FC({ token: figmaTokenForComponents });
           try {
             const definitions = await resolveComponentDefinitions(componentClient, file.fileKey, file.document);
@@ -99,7 +99,7 @@ export function registerSaveFixture(cli: CAC): void {
         // 2. Download screenshot
         const figmaToken = options.token ?? getFigmaToken();
         if (figmaToken) {
-          const { FigmaClient } = await import("../../core/adapters/figma-client.js");
+          const { FigmaClient } = await import("../../../core/adapters/figma-client.js");
           const client = new FigmaClient({ token: figmaToken });
           const { nodeId } = parseFigmaUrl(input);
           const rootNodeId = nodeId?.replace(/-/g, ":") ?? file.document.id;

--- a/src/cli/commands/visual-compare.ts
+++ b/src/cli/commands/visual-compare.ts
@@ -18,7 +18,7 @@ export function registerVisualCompare(cli: CAC): void {
     .option("--output <dir>", "Output directory for screenshots and diff (default: /tmp/canicode-visual-compare)")
     .option("--width <px>", "Logical viewport width in CSS px (default: infer from Figma PNG ÷ export scale)")
     .option("--height <px>", "Logical viewport height in CSS px (default: infer from Figma PNG ÷ export scale)")
-    .option("--figma-scale <n>", "Figma export scale (default: 2, matches save-fixture / @2x PNGs)")
+    .option("--figma-scale <n>", "Figma export scale (default: 2, matches calibrate-save-fixture / @2x PNGs)")
     .option("--expand-root", "Replace root element's fixed width with 100% before rendering (for responsive comparison)")
     .example("  canicode visual-compare ./generated/index.html --figma-url 'https://www.figma.com/design/ABC/File?node-id=1-234'")
     .action(async (codePath: string, rawOptions: Record<string, unknown>) => {

--- a/src/cli/docs.ts
+++ b/src/cli/docs.ts
@@ -126,7 +126,7 @@ OPTIONS
   --output <dir>      Output directory (default: /tmp/canicode-visual-compare)
   --width <px>        Logical viewport width in CSS px (omit = infer from Figma PNG ÷ export scale)
   --height <px>       Logical viewport height in CSS px (omit = infer from Figma PNG ÷ export scale)
-  --figma-scale <n>   Figma Images API scale (default: 2, matches save-fixture @2x PNGs)
+  --figma-scale <n>   Figma Images API scale (default: 2, matches calibrate-save-fixture @2x PNGs)
 
 OUTPUT FILES
   /tmp/canicode-visual-compare/

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,7 +18,6 @@ import "../core/rules/index.js";
 
 // User-facing commands
 import { registerAnalyze } from "./commands/analyze.js";
-import { registerSaveFixture } from "./commands/save-fixture.js";
 import { registerDesignTree } from "./commands/design-tree.js";
 import { registerImplement } from "./commands/implement.js";
 import { registerVisualCompare } from "./commands/visual-compare.js";
@@ -36,6 +35,7 @@ import { registerGatherEvidence, registerFinalizeDebate } from "./commands/inter
 import { registerFixtureManagement, registerEvidenceEnrich, registerEvidencePrune } from "./commands/internal/fixture-management.js";
 import { registerDesignTreeStrip } from "./commands/internal/design-tree-strip.js";
 import { registerHtmlPostprocess } from "./commands/internal/html-postprocess.js";
+import { registerCalibrateSaveFixture } from "./commands/internal/calibrate-save-fixture.js";
 import { registerCodeMetrics } from "./commands/internal/code-metrics.js";
 
 const require = createRequire(import.meta.url);
@@ -66,7 +66,6 @@ process.on("beforeExit", () => {
 // User-facing commands
 // ============================================
 registerAnalyze(cli);
-registerSaveFixture(cli);
 registerDesignTree(cli);
 registerImplement(cli);
 registerVisualCompare(cli);
@@ -89,6 +88,7 @@ registerEvidenceEnrich(cli);
 registerEvidencePrune(cli);
 registerDesignTreeStrip(cli);
 registerHtmlPostprocess(cli);
+registerCalibrateSaveFixture(cli);
 registerCodeMetrics(cli);
 
 // ============================================

--- a/src/core/comparison/visual-compare.ts
+++ b/src/core/comparison/visual-compare.ts
@@ -41,7 +41,7 @@ export interface VisualCompareOptions {
    */
   viewport?: { width?: number; height?: number } | undefined;
   /**
-   * Figma Images API `scale` and assumed scale for fixture `figma.png` (e.g. from `save-fixture`).
+   * Figma Images API `scale` and assumed scale for fixture `figma.png` (e.g. from `calibrate-save-fixture`).
    * Default 2 matches REST exports and avoids comparing a @2x PNG against a 1× Playwright capture.
    */
   figmaExportScale?: number | undefined;


### PR DESCRIPTION
## Summary

Reclassify `save-fixture` from an external user-facing command to an internal calibration command. The command is renamed to `calibrate-save-fixture`, its source file moves from `src/cli/commands/save-fixture.ts` to `src/cli/commands/internal/calibrate-save-fixture.ts`, and all references across the codebase (CLI registration, docs, comments, ARCHITECTURE.md, SKILL.md, README, GitHub workflow, issue template) are updated to reflect the new internal-only status.

## Tasks

- Move and rename the command file
- Update CLI registration in index.ts
- Update all textual references to save-fixture
- Update GitHub workflow and issue template
- Delete the old command file and verify

## Self-review

Clean, well-executed refactor. The command file is correctly moved to src/cli/commands/internal/, renamed to follow the calibrate-* convention, re-registered in the internal section of index.ts, and all references across the codebase are updated. No stale 'save-fixture' references remain. Two minor warnings about external-facing docs referencing an internal command.
- Verdict: approve
- Errors: 0, Warnings: 2, Total: 2

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #253

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))