### PR TITLE
feat: refactor: reclassify implement as calibrate-implement

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -6,7 +6,6 @@
 - Data source: Figma REST API (requires FIGMA_TOKEN) or JSON fixture
 - Output: HTML report (opens in browser)
 - Options: `--preset`, `--token`, `--output`, `--config`
-- Also: `canicode implement` to prepare a design-to-code package (analysis + design tree + assets + prompt)
 - Component master resolution: fetches `componentDefinitions` for accurate component analysis
 - Annotations: NOT available (REST API annotations field is private beta)
 
@@ -49,6 +48,11 @@ Calibration is orchestrated by `scripts/calibrate.ts` (ADR-008). CLI for determi
 - Role: Save Figma design as a fixture directory for calibration (internal command)
 - Input: Figma URL with node-id
 - Output: fixture directory with data.json, screenshot.png, vectors/, images/
+
+**`canicode calibrate-implement`**
+- Role: Prepare design-to-code package for calibration (analysis + design tree + assets + prompt)
+- Input: Figma URL or fixture directory
+- Output: canicode-implement/ directory with analysis.json, design-tree.txt, PROMPT.md, assets
 
 **`/calibrate` (Claude Code command)**
 - Wrapper: runs `npx tsx scripts/calibrate.ts $ARGUMENTS` and reports results

--- a/.claude/skills/canicode-implement/SKILL.md
+++ b/.claude/skills/canicode-implement/SKILL.md
@@ -20,19 +20,19 @@ One of:
 ### From a local fixture (simplest)
 
 ```bash
-npx canicode implement ./fixtures/my-design
+npx canicode calibrate-implement ./fixtures/my-design
 ```
 
 ### From a Figma URL
 
 ```bash
-npx canicode implement "https://www.figma.com/design/ABC/File?node-id=1-234"
+npx canicode calibrate-implement "https://www.figma.com/design/ABC/File?node-id=1-234"
 ```
 
 ### With a custom prompt (for your stack)
 
 ```bash
-npx canicode implement ./fixtures/my-design --prompt ./my-react-prompt.md
+npx canicode calibrate-implement ./fixtures/my-design --prompt ./my-react-prompt.md
 ```
 
 The default prompt generates HTML+CSS. Write your own prompt for React, Vue, or any other stack.
@@ -60,7 +60,7 @@ canicode-implement/
 
 ## Next Steps
 
-After running `canicode implement`:
+After running `canicode calibrate-implement`:
 
 1. Open `design-tree.txt` -- this is the primary input for the AI
 2. Open `PROMPT.md` -- this contains the coding conventions

--- a/.claude/skills/design-to-code/PROMPT.md
+++ b/.claude/skills/design-to-code/PROMPT.md
@@ -3,7 +3,7 @@
 This prompt is used by all code generation pipelines:
 - Calibration Converter
 - Ablation experiments (API-based)
-- User-facing `canicode implement` command (default prompt)
+- `canicode calibrate-implement` command (default prompt)
 
 ## Stack
 - HTML + CSS (single file)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ claude mcp add canicode -- npx -y -p canicode canicode-mcp
 | **MCP Server** | Claude Code / Cursor / Claude Desktop integration |
 | **Claude Code Skill** | Lightweight, no MCP install |
 | **CLI** | Full control, CI/CD, offline analysis |
-| **`canicode implement`** | Generate code-ready package (analysis + assets + prompt) |
 | **[GitHub Action](https://github.com/marketplace/actions/canicode-action)** | PR gate with score threshold |
 
 </details>
@@ -138,31 +137,6 @@ For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZA
 
 </details>
 
-
-<details>
-<summary><strong>Design to Code</strong> (prepare implementation package)</summary>
-
-```bash
-canicode implement ./fixtures/my-design
-canicode implement "https://www.figma.com/design/ABC/File?node-id=1-234" --prompt ./my-react-prompt.md --image-scale 3
-```
-
-Outputs a ready-to-use package for AI code generation:
-- `analysis.json` — issues + scores
-- `design-tree.txt` — DOM-like tree with CSS styles + token estimate
-- `images/` — PNG assets with human-readable names (`hero-banner@2x.png`)
-- `vectors/` — SVG assets
-- `PROMPT.md` — code generation prompt (default: HTML+CSS, or your custom prompt)
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `--prompt` | built-in HTML+CSS | Path to your custom prompt file for any stack |
-| `--image-scale` | `2` | Image export scale: `2` for PC, `3` for mobile |
-| `--output` | `./canicode-implement/` | Output directory |
-
-Feed `design-tree.txt` + `PROMPT.md` to your AI assistant (Claude, Cursor, etc.) to generate code.
-
-</details>
 
 <details>
 <summary><strong>Claude Code Skill</strong> (lightweight, no MCP install)</summary>

--- a/src/cli/commands/internal/calibrate-implement.ts
+++ b/src/cli/commands/internal/calibrate-implement.ts
@@ -4,12 +4,12 @@ import { resolve, dirname } from "node:path";
 import type { CAC } from "cac";
 import { z } from "zod";
 
-import { parseFigmaUrl } from "../../core/adapters/figma-url-parser.js";
-import { analyzeFile } from "../../core/engine/rule-engine.js";
-import { loadFile, isFigmaUrl, isJsonFile, isFixtureDir } from "../../core/engine/loader.js";
-import { getFigmaToken } from "../../core/engine/config-store.js";
-import { calculateScores, buildResultJson } from "../../core/engine/scoring.js";
-import { collectVectorNodes, collectImageNodes, sanitizeFilename } from "../helpers.js";
+import { parseFigmaUrl } from "../../../core/adapters/figma-url-parser.js";
+import { analyzeFile } from "../../../core/engine/rule-engine.js";
+import { loadFile, isFigmaUrl, isJsonFile, isFixtureDir } from "../../../core/engine/loader.js";
+import { getFigmaToken } from "../../../core/engine/config-store.js";
+import { calculateScores, buildResultJson } from "../../../core/engine/scoring.js";
+import { collectVectorNodes, collectImageNodes, sanitizeFilename } from "../../helpers.js";
 
 const ImplementOptionsSchema = z.object({
   token: z.string().optional(),
@@ -19,18 +19,18 @@ const ImplementOptionsSchema = z.object({
 });
 
 
-export function registerImplement(cli: CAC): void {
+export function registerCalibrateImplement(cli: CAC): void {
   cli
     .command(
-      "implement <input>",
-      "Prepare design-to-code package: analysis + design tree + assets + prompt"
+      "calibrate-implement <input>",
+      "Prepare design-to-code package for calibration: analysis + design tree + assets + prompt"
     )
     .option("--token <token>", "Figma API token (or use FIGMA_TOKEN env var)")
     .option("--output <dir>", "Output directory (default: ./canicode-implement/)")
     .option("--prompt <path>", "Custom prompt file (default: built-in HTML+CSS prompt)")
     .option("--image-scale <n>", "Image export scale: 2 for PC (default), 3 for mobile")
-    .example("  canicode implement ./fixtures/my-design")
-    .example("  canicode implement ./fixtures/my-design --prompt ./my-react-prompt.md --image-scale 3")
+    .example("  canicode calibrate-implement ./fixtures/my-design")
+    .example("  canicode calibrate-implement ./fixtures/my-design --prompt ./my-react-prompt.md --image-scale 3")
     .action(async (input: string, rawOptions: Record<string, unknown>) => {
       try {
         const parseResult = ImplementOptionsSchema.safeParse(rawOptions);
@@ -112,7 +112,7 @@ export function registerImplement(cli: CAC): void {
           if (figmaToken) {
             const imgScale = options.imageScale !== undefined ? Number(options.imageScale) : 2;
 
-            const { FigmaClient } = await import("../../core/adapters/figma-client.js");
+            const { FigmaClient } = await import("../../../core/adapters/figma-client.js");
             const client = new FigmaClient({ token: figmaToken });
 
             // Download screenshot
@@ -220,7 +220,7 @@ export function registerImplement(cli: CAC): void {
         }
 
         // 4. Design tree (after assets so image paths are available)
-        const { generateDesignTreeWithStats } = await import("../../core/design-tree/design-tree.js");
+        const { generateDesignTreeWithStats } = await import("../../../core/design-tree/design-tree.js");
         const treeOptions = {
           ...(vectorDir && existsSync(vectorDir) ? { vectorDir } : {}),
           ...(imageDir && existsSync(imageDir) ? { imageDir } : {}),
@@ -242,8 +242,8 @@ export function registerImplement(cli: CAC): void {
           const { dirname: dirnameFn, resolve: resolveFn } = await import("node:path");
           const { fileURLToPath } = await import("node:url");
           const cliDir = dirnameFn(fileURLToPath(import.meta.url));
-          const projectRoot = resolveFn(cliDir, "../..");
-          const altRoot = resolveFn(cliDir, "..");
+          const projectRoot = resolveFn(cliDir, "../../..");
+          const altRoot = resolveFn(cliDir, "../..");
 
           let prompt = "";
           for (const root of [projectRoot, altRoot]) {

--- a/src/cli/docs.ts
+++ b/src/cli/docs.ts
@@ -14,7 +14,6 @@ CANICODE DOCUMENTATION (v${pkg.version})
 
   canicode docs setup      Full setup guide (CLI, MCP, Skills)
   canicode docs config     Config override guide + example
-  canicode docs implement  Design-to-code package guide
   canicode docs scoring    Scoring model explanation
 
 Full documentation: github.com/let-sunny/canicode#readme
@@ -188,50 +187,6 @@ USE CASES
 `.trimStart());
 }
 
-/** Print the implement command guide. */
-export function printDocsImplement(): void {
-  console.log(`
-DESIGN-TO-CODE IMPLEMENTATION GUIDE
-
-Prepare everything an AI needs to implement a Figma design as code.
-
-USAGE
-  canicode implement <figma-url-or-fixture> [options]
-
-OPTIONS
-  --prompt <path>      Custom prompt file (default: built-in HTML+CSS)
-  --image-scale <n>    Image export scale: 2 for PC (default), 3 for mobile
-  --output <dir>       Output directory (default: ./canicode-implement/)
-  --token <token>      Figma API token (for live URLs)
-
-OUTPUT
-  canicode-implement/
-    analysis.json      Analysis report with issues and scores
-    design-tree.txt    DOM-like tree with CSS styles (~N tokens)
-    images/            PNG assets with human-readable names (hero-banner@2x.png)
-    vectors/           SVG assets for vector nodes
-    PROMPT.md          Stack-specific code generation prompt
-
-WORKFLOW
-  1. Run: canicode implement ./my-fixture --prompt ./my-react-prompt.md
-  2. Feed design-tree.txt + PROMPT.md to your AI assistant
-  3. AI generates code matching the design pixel-perfectly
-  4. Verify with: canicode visual-compare ./output.html --figma-url <url>
-
-CUSTOM PROMPT
-  Default prompt generates HTML+CSS. For your own stack:
-  1. Write a prompt file (e.g. my-react-prompt.md)
-  2. Pass it: canicode implement ./fixture --prompt ./my-react-prompt.md
-  The design-tree.txt format is stack-agnostic — your prompt just needs
-  to describe how to convert it to your target framework.
-
-IMAGE SCALE
-  --image-scale 2     PC/desktop (default) — @2x retina
-  --image-scale 3     Mobile — @3x retina
-  SVG vectors are scale-independent and always included.
-`.trimStart());
-}
-
 /** Print the scoring model summary with pointer to full docs. */
 export function printDocsScoring(): void {
   console.log(`
@@ -253,7 +208,6 @@ const DOCS_TOPICS: Record<string, () => void> = {
   setup: printDocsSetup,
   install: printDocsSetup, // alias
   config: printDocsConfig,
-  implement: printDocsImplement,
   scoring: printDocsScoring,
   "visual-compare": printDocsVisualCompare,
   "design-tree": printDocsDesignTree,

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -25,7 +25,6 @@ describe.skipIf(!existsSync(CLI_PATH))("CLI --help", () => {
     const userCommands = [
       "analyze",
       "design-tree",
-      "implement",
       "visual-compare",
       "init",
       "config",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,7 +19,6 @@ import "../core/rules/index.js";
 // User-facing commands
 import { registerAnalyze } from "./commands/analyze.js";
 import { registerDesignTree } from "./commands/design-tree.js";
-import { registerImplement } from "./commands/implement.js";
 import { registerVisualCompare } from "./commands/visual-compare.js";
 import { registerInit } from "./commands/init.js";
 import { registerConfig } from "./commands/config.js";
@@ -39,6 +38,7 @@ import { registerFixtureManagement, registerEvidenceEnrich, registerEvidencePrun
 import { registerDesignTreeStrip } from "./commands/internal/design-tree-strip.js";
 import { registerHtmlPostprocess } from "./commands/internal/html-postprocess.js";
 import { registerCalibrateSaveFixture } from "./commands/internal/calibrate-save-fixture.js";
+import { registerCalibrateImplement } from "./commands/internal/calibrate-implement.js";
 import { registerCodeMetrics } from "./commands/internal/code-metrics.js";
 
 const require = createRequire(import.meta.url);
@@ -70,7 +70,6 @@ process.on("beforeExit", () => {
 // ============================================
 registerAnalyze(cli);
 registerDesignTree(cli);
-registerImplement(cli);
 registerVisualCompare(cli);
 registerInit(cli);
 registerConfig(cli);
@@ -92,6 +91,7 @@ registerEvidencePrune(cli);
 registerDesignTreeStrip(cli);
 registerHtmlPostprocess(cli);
 registerCalibrateSaveFixture(cli);
+registerCalibrateImplement(cli);
 registerCodeMetrics(cli);
 
 // ============================================

--- a/src/cli/internal-commands.ts
+++ b/src/cli/internal-commands.ts
@@ -2,6 +2,7 @@
 export const INTERNAL_COMMANDS = [
   "calibrate-analyze",
   "calibrate-evaluate",
+  "calibrate-implement",
   "calibrate-gap-report",
   "calibrate-run",
   "calibrate-gather-evidence",


### PR DESCRIPTION
## Summary

Reclassify the `implement` CLI command as `calibrate-implement` — an internal calibration command hidden from user-facing help. The current `implement` command prepares design-to-code packages (analysis + design tree + assets + prompt), but is calibration-only. A future user-facing implement flow (#236) will replace it. This rename avoids confusion by moving it to the internal commands section, following the same pattern as the recent `calibrate-save-fixture` reclassification (#259).

## Tasks

- Move implement.ts to internal/ and rename registration
- Update CLI index.ts — move from user-facing to internal section
- Add calibrate-implement to INTERNAL_COMMANDS list
- Update tests and docs references
- Update ARCHITECTURE.md command table

## Self-review

The core rename is clean and follows the calibrate-save-fixture pattern exactly — file move, import depth adjustments, CLI registration, docs removal, and ARCHITECTURE.md update are all correct. However, three files still reference the old `canicode implement` command name (README.md lines 74/146-147, .claude/skills/design-to-code/PROMPT.md line 6), which violates the acceptance criterion 'No references to old implement command remain (excluding git history).'
- Verdict: request-changes
- Errors: 0, Warnings: 3, Total: 4

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #254

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))