### PR TITLE
feat: add isReadyForCodeGen field to MCP analyze response

### DIFF
--- a/src/core/contracts/index.ts
+++ b/src/core/contracts/index.ts
@@ -8,3 +8,4 @@ export * from "./issue.js";
 export * from "./score.js";
 export * from "./report.js";
 export * from "./visual-compare.js";
+export * from "./mcp-response.js";

--- a/src/core/contracts/mcp-response.ts
+++ b/src/core/contracts/mcp-response.ts
@@ -1,0 +1,63 @@
+import { z } from "zod";
+import { SeveritySchema } from "./severity.js";
+import { CategorySchema } from "./category.js";
+
+const GradeSchema = z.enum(["S", "A+", "A", "B+", "B", "C+", "C", "D", "F"]);
+
+const CategoryScoreResultSchema = z.object({
+  category: CategorySchema,
+  score: z.number(),
+  maxScore: z.number(),
+  percentage: z.number(),
+  issueCount: z.number().int().min(0),
+  uniqueRuleCount: z.number().int().min(0),
+  weightedIssueCount: z.number(),
+  densityScore: z.number(),
+  diversityScore: z.number(),
+  bySeverity: z.object({
+    blocking: z.number().int().min(0),
+    risk: z.number().int().min(0),
+    "missing-info": z.number().int().min(0),
+    suggestion: z.number().int().min(0),
+  }),
+});
+
+const McpIssueSchema = z.object({
+  ruleId: z.string(),
+  subType: z.string().optional(),
+  severity: SeveritySchema,
+  nodeId: z.string(),
+  nodePath: z.string(),
+  message: z.string(),
+});
+
+/**
+ * Zod schema for the MCP analyze tool response body.
+ * This is the shape of the JSON returned by `buildResultJson` in scoring.ts.
+ */
+export const McpAnalyzeResponseSchema = z.object({
+  version: z.string(),
+  analyzedAt: z.string(),
+  fileKey: z.string().optional(),
+  fileName: z.string(),
+  nodeCount: z.number().int().min(0),
+  maxDepth: z.number().int().min(0),
+  issueCount: z.number().int().min(0),
+  isReadyForCodeGen: z.boolean(),
+  blockingIssueCount: z.number().int().min(0),
+  scores: z.object({
+    overall: z.object({
+      score: z.number(),
+      maxScore: z.number(),
+      percentage: z.number(),
+      grade: GradeSchema,
+    }),
+    categories: z.record(CategorySchema, CategoryScoreResultSchema),
+  }),
+  issuesByRule: z.record(z.string(), z.number().int().min(0)),
+  issues: z.array(McpIssueSchema),
+  summary: z.string(),
+  failedRules: z.array(z.string()).optional(),
+});
+
+export type McpAnalyzeResponse = z.infer<typeof McpAnalyzeResponseSchema>;

--- a/src/core/engine/scoring.test.ts
+++ b/src/core/engine/scoring.test.ts
@@ -1,4 +1,5 @@
-import { calculateScores, formatScoreSummary, gradeToClassName, getCategoryLabel, getSeverityLabel, buildResultJson } from "./scoring.js";
+import { calculateScores, formatScoreSummary, gradeToClassName, getCategoryLabel, getSeverityLabel, buildResultJson, isReadyForCodeGen } from "./scoring.js";
+import type { Grade } from "./scoring.js";
 import type { AnalysisIssue, AnalysisResult } from "./rule-engine.js";
 import type { AnalysisFile, AnalysisNode } from "../contracts/figma-node.js";
 import type { Rule, RuleConfig, RuleViolation } from "../contracts/rule.js";
@@ -478,4 +479,61 @@ describe("buildResultJson", () => {
     const withoutKey = buildResultJson("TestFile", result, scores);
     expect(withoutKey.fileKey).toBeUndefined();
   });
+
+  it("includes isReadyForCodeGen field", () => {
+    const result = makeResult([]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+
+    expect(typeof json.isReadyForCodeGen).toBe("boolean");
+  });
+
+  it("includes blockingIssueCount field", () => {
+    const result = makeResult([
+      makeIssue({ ruleId: "no-auto-layout", category: "pixel-critical", severity: "blocking" }),
+      makeIssue({ ruleId: "no-auto-layout", category: "pixel-critical", severity: "blocking" }),
+      makeIssue({ ruleId: "raw-value", category: "token-management", severity: "missing-info" }),
+    ]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+
+    expect(json.blockingIssueCount).toBe(2);
+  });
+
+  it("isReadyForCodeGen is true when no issues (S grade)", () => {
+    const result = makeResult([]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+
+    expect(json.isReadyForCodeGen).toBe(true);
+  });
+
+  it("blockingIssueCount is 0 when no blocking issues", () => {
+    const result = makeResult([
+      makeIssue({ ruleId: "raw-value", category: "token-management", severity: "suggestion" }),
+    ]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+
+    expect(json.blockingIssueCount).toBe(0);
+  });
+});
+
+// ─── isReadyForCodeGen helper ─────────────────────────────────────────────────
+
+describe("isReadyForCodeGen helper", () => {
+  const truthy: Grade[] = ["S", "A+", "A"];
+  const falsy: Grade[] = ["B+", "B", "C+", "C", "D", "F"];
+
+  for (const grade of truthy) {
+    it(`returns true for grade ${grade}`, () => {
+      expect(isReadyForCodeGen(grade)).toBe(true);
+    });
+  }
+
+  for (const grade of falsy) {
+    it(`returns false for grade ${grade}`, () => {
+      expect(isReadyForCodeGen(grade)).toBe(false);
+    });
+  }
 });

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -136,6 +136,15 @@ function calculateGrade(percentage: number): Grade {
 }
 
 /**
+ * Returns true if the design is ready for code generation.
+ * S, A+, and A grades (percentage >= 85) indicate the design has minimal blockers
+ * and can be implemented accurately by AI or developers.
+ */
+export function isReadyForCodeGen(grade: Grade): boolean {
+  return grade === "S" || grade === "A+" || grade === "A";
+}
+
+/**
  * Convert grade to a CSS-safe class name suffix
  * e.g. "A+" -> "Aplus", "B+" -> "Bplus", "C+" -> "Cplus"
  */
@@ -415,6 +424,8 @@ export function buildResultJson(
     nodeCount: result.nodeCount,
     maxDepth: result.maxDepth,
     issueCount: result.issues.length,
+    isReadyForCodeGen: isReadyForCodeGen(scores.overall.grade),
+    blockingIssueCount: scores.summary.blocking,
     scores: {
       overall: scores.overall,
       categories: scores.byCategory,


### PR DESCRIPTION
## Summary

Closes #256 (part of #236)

- Add `isReadyForCodeGen: boolean` to MCP analyze response — `true` for S/A+/A grades (≥85%), `false` otherwise
- Add `blockingIssueCount: number` — count of blocking-severity issues from existing score data
- Add `McpAnalyzeResponseSchema` Zod schema in `contracts/` documenting the full response shape
- 13 new tests: 9 grade boundary tests + 4 integration tests via `buildResultJson`

Purely additive change — no existing fields modified, no breaking changes for MCP consumers.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:run` — 672 tests pass (13 new)
- [x] `pnpm build` succeeds
- [x] `isReadyForCodeGen` returns `true` for S, A+, A grades
- [x] `isReadyForCodeGen` returns `false` for B+, B, C+, C, D, F grades
- [x] `blockingIssueCount` correctly counts only blocking-severity issues

https://claude.ai/code/session_01Fr7YFumbYBdbpHht3FCs8g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added code generation readiness indicator—automatically determines if code quality meets requirements based on grades S, A+, or A
  * Added blocking issue counter to analysis results for improved issue tracking and prioritization
  * Introduced response validation framework for the analyze tool

* **Tests**
  * Enhanced test coverage for scoring evaluation and readiness logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->