### PR TITLE
feat: add rule-to-gotcha question mapping table

### DIFF
--- a/src/core/rules/gotcha-questions.test.ts
+++ b/src/core/rules/gotcha-questions.test.ts
@@ -1,0 +1,67 @@
+import { RULE_CONFIGS } from "./rule-config.js";
+import {
+  GOTCHA_QUESTIONS,
+  GotchaQuestionSchema,
+  getGotchaQuestion,
+  formatGotchaQuestion,
+} from "./gotcha-questions.js";
+import type { RuleId } from "../contracts/rule.js";
+
+describe("gotcha-questions", () => {
+  const ruleIds = Object.keys(RULE_CONFIGS) as RuleId[];
+
+  it("covers all rule IDs from rule-config.ts", () => {
+    const gotchaIds = new Set(Object.keys(GOTCHA_QUESTIONS));
+    for (const id of ruleIds) {
+      expect(gotchaIds.has(id)).toBe(true);
+    }
+  });
+
+  it("has no extra entries beyond rule-config.ts", () => {
+    const configIds = new Set(ruleIds);
+    for (const id of Object.keys(GOTCHA_QUESTIONS)) {
+      expect(configIds.has(id)).toBe(true);
+    }
+  });
+
+  it("each entry has matching ruleId field", () => {
+    for (const [id, entry] of Object.entries(GOTCHA_QUESTIONS)) {
+      expect(entry.ruleId).toBe(id);
+    }
+  });
+
+  it("each entry passes Zod schema validation", () => {
+    for (const entry of Object.values(GOTCHA_QUESTIONS)) {
+      expect(() => GotchaQuestionSchema.parse(entry)).not.toThrow();
+    }
+  });
+
+  it("each question contains {nodeName} placeholder", () => {
+    for (const [id, entry] of Object.entries(GOTCHA_QUESTIONS)) {
+      expect(entry.question).toContain("{nodeName}");
+    }
+  });
+
+  it("each entry has non-empty hint and example", () => {
+    for (const entry of Object.values(GOTCHA_QUESTIONS)) {
+      expect(entry.hint.length).toBeGreaterThan(0);
+      expect(entry.example.length).toBeGreaterThan(0);
+    }
+  });
+
+  describe("getGotchaQuestion", () => {
+    it("returns the correct entry for a given ruleId", () => {
+      const result = getGotchaQuestion("no-auto-layout");
+      expect(result.ruleId).toBe("no-auto-layout");
+      expect(result.question).toContain("{nodeName}");
+    });
+  });
+
+  describe("formatGotchaQuestion", () => {
+    it("replaces {nodeName} placeholder with actual name", () => {
+      const result = formatGotchaQuestion("no-auto-layout", "Hero Section");
+      expect(result).toContain("Hero Section");
+      expect(result).not.toContain("{nodeName}");
+    });
+  });
+});

--- a/src/core/rules/gotcha-questions.ts
+++ b/src/core/rules/gotcha-questions.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+import type { RuleId } from "../contracts/rule.js";
+
+/**
+ * Gotcha question template for a single rule.
+ * Used to generate user-facing surveys from analysis results (#236).
+ *
+ * - question: uses {nodeName} placeholder for the affected node
+ * - hint: guides the user on what kind of answer is expected
+ * - example: concrete example answer
+ */
+export const GotchaQuestionSchema = z.object({
+  ruleId: z.string(),
+  question: z.string(),
+  hint: z.string(),
+  example: z.string(),
+});
+
+export type GotchaQuestion = z.infer<typeof GotchaQuestionSchema>;
+
+/**
+ * Gotcha question mapping for all 16 rules.
+ * Keyed by ruleId for O(1) lookup during survey generation.
+ */
+export const GOTCHA_QUESTIONS: Record<RuleId, GotchaQuestion> = {
+  // ── Pixel Critical (blocking) ──
+
+  "no-auto-layout": {
+    ruleId: "no-auto-layout",
+    question: 'Frame "{nodeName}" has no Auto Layout. How should this area be laid out?',
+    hint: "Describe the flex direction, gap, and alignment",
+    example: "Vertical flex, gap 16px, items centered",
+  },
+  "absolute-position-in-auto-layout": {
+    ruleId: "absolute-position-in-auto-layout",
+    question: '"{nodeName}" uses absolute positioning inside an Auto Layout parent. Is this an intentional overlay, or should it flow with the layout?',
+    hint: "Specify if this is a badge/overlay, or should be part of the normal flow",
+    example: "This is a notification badge — position absolute, top-right corner",
+  },
+  "non-layout-container": {
+    ruleId: "non-layout-container",
+    question: '"{nodeName}" is a Group/Section used as a layout container. What layout structure should it have?',
+    hint: "Describe the intended layout: flex direction, wrap, gap",
+    example: "Horizontal flex, gap 12px, wrap on mobile",
+  },
+
+  // ── Responsive Critical (risk) ──
+
+  "fixed-size-in-auto-layout": {
+    ruleId: "fixed-size-in-auto-layout",
+    question: '"{nodeName}" has a fixed size inside Auto Layout. Should it be responsive?',
+    hint: "Specify which axis should be flexible (width, height, or both)",
+    example: "Width should FILL the parent, height can stay fixed",
+  },
+  "missing-size-constraint": {
+    ruleId: "missing-size-constraint",
+    question: '"{nodeName}" uses FILL sizing without min/max constraints. What are the size boundaries?',
+    hint: "Provide min-width, max-width, or both",
+    example: "min-width 320px, max-width 1200px",
+  },
+
+  // ── Code Quality (risk) ──
+
+  "missing-component": {
+    ruleId: "missing-component",
+    question: '"{nodeName}" appears to be a repeated structure. Should it be a reusable component?',
+    hint: "Describe if this should be extracted as a component and what props it needs",
+    example: "Yes, extract as ProductCard component with title, image, and price props",
+  },
+  "detached-instance": {
+    ruleId: "detached-instance",
+    question: '"{nodeName}" looks like a detached component instance. Should it use the original component or is it a new variant?',
+    hint: "Specify whether to restore the component link or create a new variant",
+    example: "This is a new variant — create a 'compact' variant of the original component",
+  },
+  "variant-structure-mismatch": {
+    ruleId: "variant-structure-mismatch",
+    question: '"{nodeName}" has variants with different child structures. Which structure is the canonical one?',
+    hint: "Describe which variant has the correct structure, or if they should all match",
+    example: "Default variant is canonical — other variants should toggle child visibility instead of adding/removing elements",
+  },
+  "deep-nesting": {
+    ruleId: "deep-nesting",
+    question: '"{nodeName}" is deeply nested. Can some intermediate layers be flattened or extracted?',
+    hint: "Identify which wrapper layers are unnecessary or should become sub-components",
+    example: "The inner wrapper is just for spacing — flatten it and use padding instead",
+  },
+
+  // ── Token Management ──
+
+  "raw-value": {
+    ruleId: "raw-value",
+    question: '"{nodeName}" uses raw values without design tokens. What tokens should be used?',
+    hint: "Specify the token names or variable references for colors, fonts, spacing, etc.",
+    example: "Use $color-primary for the fill, $font-body for the text style",
+  },
+  "irregular-spacing": {
+    ruleId: "irregular-spacing",
+    question: '"{nodeName}" has spacing values that are off the design grid. What should the correct spacing be?',
+    hint: "Provide the intended spacing value aligned to the grid system",
+    example: "Gap should be 16px (4pt grid), not 15px",
+  },
+
+  // ── Interaction ──
+
+  "missing-interaction-state": {
+    ruleId: "missing-interaction-state",
+    question: '"{nodeName}" appears interactive but is missing state variants. What interaction states are needed?',
+    hint: "List the needed states: Hover, Active, Disabled, Focus",
+    example: "Needs Hover (darken 10%) and Disabled (opacity 50%, no pointer events)",
+  },
+  "missing-prototype": {
+    ruleId: "missing-prototype",
+    question: '"{nodeName}" looks interactive but has no prototype interaction. What should happen on click/interaction?',
+    hint: "Describe the interaction behavior: navigation, overlay, state change, etc.",
+    example: "On click, navigate to the product detail page",
+  },
+
+  // ── Semantic ──
+
+  "non-standard-naming": {
+    ruleId: "non-standard-naming",
+    question: '"{nodeName}" uses non-standard state names. What naming convention should be followed?',
+    hint: "Specify the expected state name format (e.g., Hover, Disabled, Active)",
+    example: 'Use "Hover" instead of "hover_v1", "Disabled" instead of "off"',
+  },
+  "non-semantic-name": {
+    ruleId: "non-semantic-name",
+    question: '"{nodeName}" has a non-semantic name. What is the purpose of this element?',
+    hint: "Provide a descriptive name that reflects the element's role in the UI",
+    example: 'Rename "Frame 12" to "HeroSection" or "ProductGrid"',
+  },
+  "inconsistent-naming-convention": {
+    ruleId: "inconsistent-naming-convention",
+    question: '"{nodeName}" uses a different naming convention than its siblings. Which convention should be used?',
+    hint: "Choose one: camelCase, kebab-case, PascalCase, or Title Case",
+    example: "Use PascalCase for all component layers (e.g., CardTitle, CardBody)",
+  },
+};
+
+/**
+ * Get the gotcha question for a specific rule.
+ */
+export function getGotchaQuestion(ruleId: RuleId): GotchaQuestion {
+  return GOTCHA_QUESTIONS[ruleId];
+}
+
+/**
+ * Format a gotcha question by replacing the {nodeName} placeholder.
+ */
+export function formatGotchaQuestion(ruleId: RuleId, nodeName: string): string {
+  return GOTCHA_QUESTIONS[ruleId].question.replace("{nodeName}", nodeName);
+}


### PR DESCRIPTION
## Summary

- Add `GOTCHA_QUESTIONS` mapping table covering all 16 rules with question templates, hints, and example answers (`src/core/rules/gotcha-questions.ts`)
- Add `GotchaQuestionSchema` (Zod) for type-safe validation
- Add helper functions `getGotchaQuestion()` and `formatGotchaQuestion()` for survey generation
- Add 8 tests verifying full rule coverage, schema validation, and placeholder formatting

## Context

Part of #236 (pre-flight design quality gate). This mapping enables #258 (gotcha survey generation) by providing the question templates that translate rule violations into actionable user-facing questions.

## Test plan

- [x] All 16 rule IDs covered (verified against `RULE_CONFIGS`)
- [x] No extra/stale entries beyond `rule-config.ts`
- [x] Each entry has matching `ruleId` field
- [x] Zod schema validates all entries
- [x] Every question contains `{nodeName}` placeholder
- [x] All hints and examples are non-empty
- [x] `getGotchaQuestion` / `formatGotchaQuestion` work correctly
- [x] `pnpm lint && pnpm test:run && pnpm build` pass (680/680 tests)

Closes #257

https://claude.ai/code/session_01CNmRkcxeP6dxZjFXS1V7zR