### PR TITLE
fix: correct Stop hook schema in settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,8 +13,13 @@
     ],
     "Stop": [
       {
-        "type": "command",
-        "command": "pnpm lint 2>&1 && pnpm build 2>&1"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm lint 2>&1 && pnpm build 2>&1"
+          }
+        ]
       }
     ],
     "PostToolUse": [


### PR DESCRIPTION
## Summary
- `Stop` 훅이 `matcher` + `hooks` 배열 구조 없이 커맨드 객체를 직접 넣어 스키마 검증 실패
- settings.json 전체가 무시되어 안전 훅(rm -rf 차단 등)도 비활성화 상태였음
- 올바른 구조로 수정

## Test plan
- [ ] Claude Code 실행 시 Settings Error 메시지가 사라지는지 확인
- [ ] Stop 훅(`pnpm lint && pnpm build`)이 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)