### PR TITLE
feat: gotcha survey generation from analysis results

### DIFF
--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { SeveritySchema } from "./severity.js";
+
+const GradeSchema = z.enum(["S", "A+", "A", "B+", "B", "C+", "C", "D", "F"]);
+
+export const GotchaSurveyQuestionSchema = z.object({
+  nodeId: z.string(),
+  nodeName: z.string(),
+  ruleId: z.string(),
+  severity: SeveritySchema,
+  question: z.string(),
+  hint: z.string(),
+  example: z.string(),
+});
+
+export type GotchaSurveyQuestion = z.infer<typeof GotchaSurveyQuestionSchema>;
+
+export const GotchaSurveySchema = z.object({
+  designGrade: GradeSchema,
+  isReadyForCodeGen: z.boolean(),
+  questions: z.array(GotchaSurveyQuestionSchema),
+});
+
+export type GotchaSurvey = z.infer<typeof GotchaSurveySchema>;

--- a/src/core/contracts/index.ts
+++ b/src/core/contracts/index.ts
@@ -9,3 +9,4 @@ export * from "./score.js";
 export * from "./report.js";
 export * from "./visual-compare.js";
 export * from "./mcp-response.js";
+export * from "./gotcha-survey.js";

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -1,0 +1,384 @@
+import { generateGotchaSurvey } from "./survey-generator.js";
+import { GotchaSurveySchema } from "../contracts/gotcha-survey.js";
+import type { AnalysisIssue, AnalysisResult } from "../engine/rule-engine.js";
+import type { ScoreReport } from "../engine/scoring.js";
+import type { AnalysisFile, AnalysisNode } from "../contracts/figma-node.js";
+import type { Rule, RuleConfig, RuleViolation } from "../contracts/rule.js";
+import type { Category } from "../contracts/category.js";
+import type { Severity } from "../contracts/severity.js";
+import { CATEGORIES } from "../contracts/category.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRule(overrides: { id: string; category: Category }): Rule {
+  return {
+    definition: {
+      id: overrides.id,
+      name: overrides.id,
+      category: overrides.category,
+      why: "",
+      impact: "",
+      fix: "",
+    },
+    check: () => null,
+  };
+}
+
+function makeConfig(severity: Severity, score = -5): RuleConfig {
+  return { severity, score, enabled: true };
+}
+
+function makeViolation(
+  ruleId: string,
+  nodeId: string,
+  nodePath: string,
+): RuleViolation {
+  return { ruleId, nodeId, nodePath, message: "test", suggestion: "" };
+}
+
+function makeIssue(opts: {
+  ruleId: string;
+  category: Category;
+  severity: Severity;
+  nodeId?: string;
+  nodePath?: string;
+  score?: number;
+}): AnalysisIssue {
+  return {
+    violation: makeViolation(
+      opts.ruleId,
+      opts.nodeId ?? "1:1",
+      opts.nodePath ?? "Root > Node",
+    ),
+    rule: makeRule({ id: opts.ruleId, category: opts.category }),
+    config: makeConfig(opts.severity, opts.score ?? -5),
+    depth: 0,
+    maxDepth: 5,
+    calculatedScore: opts.score ?? -5,
+  };
+}
+
+function makeResult(issues: AnalysisIssue[]): AnalysisResult {
+  const doc: AnalysisNode = {
+    id: "0:1",
+    name: "Document",
+    type: "DOCUMENT",
+    visible: true,
+  };
+  const file: AnalysisFile = {
+    fileKey: "test",
+    name: "Test",
+    lastModified: "",
+    version: "1",
+    document: doc,
+    components: {},
+    styles: {},
+  };
+  return {
+    file,
+    issues,
+    failedRules: [],
+    maxDepth: 5,
+    nodeCount: 100,
+    analyzedAt: new Date().toISOString(),
+  };
+}
+
+function makeScoreReport(grade: ScoreReport["overall"]["grade"]): ScoreReport {
+  const byCategory = Object.fromEntries(
+    CATEGORIES.map((c) => [
+      c,
+      {
+        category: c,
+        score: 50,
+        maxScore: 100,
+        percentage: 50,
+        issueCount: 0,
+        uniqueRuleCount: 0,
+        weightedIssueCount: 0,
+        densityScore: 100,
+        diversityScore: 100,
+        bySeverity: { blocking: 0, risk: 0, "missing-info": 0, suggestion: 0 },
+      },
+    ]),
+  ) as ScoreReport["byCategory"];
+
+  return {
+    overall: { score: 50, maxScore: 100, percentage: 50, grade },
+    byCategory,
+    summary: {
+      totalIssues: 0,
+      blocking: 0,
+      risk: 0,
+      missingInfo: 0,
+      suggestion: 0,
+      nodeCount: 100,
+    },
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("generateGotchaSurvey", () => {
+  it("returns empty questions for zero issues", () => {
+    const survey = generateGotchaSurvey(makeResult([]), makeScoreReport("S"));
+
+    expect(survey.questions).toEqual([]);
+    expect(survey.designGrade).toBe("S");
+    expect(survey.isReadyForCodeGen).toBe(true);
+  });
+
+  it("includes only blocking and risk severity issues", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > Hero",
+      }),
+      makeIssue({
+        ruleId: "fixed-size-in-auto-layout",
+        category: "responsive-critical",
+        severity: "risk",
+        nodeId: "2:2",
+        nodePath: "Root > Card",
+      }),
+      makeIssue({
+        ruleId: "raw-value",
+        category: "token-management",
+        severity: "missing-info",
+        nodeId: "3:3",
+        nodePath: "Root > Label",
+      }),
+      makeIssue({
+        ruleId: "non-semantic-name",
+        category: "semantic",
+        severity: "suggestion",
+        nodeId: "4:4",
+        nodePath: "Root > Frame 1",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("C"),
+    );
+
+    expect(survey.questions).toHaveLength(2);
+    expect(survey.questions.map((q) => q.ruleId)).toEqual([
+      "no-auto-layout",
+      "fixed-size-in-auto-layout",
+    ]);
+  });
+
+  it("orders blocking issues before risk issues", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "fixed-size-in-auto-layout",
+        category: "responsive-critical",
+        severity: "risk",
+        nodeId: "1:1",
+        nodePath: "Root > Card",
+      }),
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "2:2",
+        nodePath: "Root > Hero",
+      }),
+      makeIssue({
+        ruleId: "missing-size-constraint",
+        category: "responsive-critical",
+        severity: "risk",
+        nodeId: "3:3",
+        nodePath: "Root > Banner",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("D"),
+    );
+
+    expect(survey.questions[0]!.severity).toBe("blocking");
+    expect(survey.questions[1]!.severity).toBe("risk");
+    expect(survey.questions[2]!.severity).toBe("risk");
+  });
+
+  it("deduplicates same ruleId on sibling nodes (same parent)", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > Section > Child A",
+      }),
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:2",
+        nodePath: "Root > Section > Child B",
+      }),
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:3",
+        nodePath: "Root > Section > Child C",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("F"),
+    );
+
+    // 3 siblings with same rule → 1 question
+    expect(survey.questions).toHaveLength(1);
+    expect(survey.questions[0]!.nodeId).toBe("1:1");
+  });
+
+  it("keeps separate questions for same ruleId in different parents", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > Section A > Child",
+      }),
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "2:1",
+        nodePath: "Root > Section B > Child",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("F"),
+    );
+
+    expect(survey.questions).toHaveLength(2);
+  });
+
+  it("keeps separate questions for different ruleIds on same node", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > Section > Child",
+      }),
+      makeIssue({
+        ruleId: "non-layout-container",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > Section > Child",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("F"),
+    );
+
+    expect(survey.questions).toHaveLength(2);
+    expect(survey.questions.map((q) => q.ruleId)).toEqual([
+      "no-auto-layout",
+      "non-layout-container",
+    ]);
+  });
+
+  it("extracts nodeName from the last segment of nodePath", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > Section > Hero Banner",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("D"),
+    );
+
+    expect(survey.questions[0]!.nodeName).toBe("Hero Banner");
+    expect(survey.questions[0]!.question).toContain("Hero Banner");
+  });
+
+  it("substitutes {nodeName} in question text", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > MyFrame",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("D"),
+    );
+
+    expect(survey.questions[0]!.question).toBe(
+      'Frame "MyFrame" has no Auto Layout. How should this area be laid out?',
+    );
+  });
+
+  it("output passes GotchaSurveySchema validation", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > Hero",
+      }),
+      makeIssue({
+        ruleId: "fixed-size-in-auto-layout",
+        category: "responsive-critical",
+        severity: "risk",
+        nodeId: "2:2",
+        nodePath: "Root > Card",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("C"),
+    );
+
+    const result = GotchaSurveySchema.safeParse(survey);
+    expect(result.success).toBe(true);
+  });
+
+  it("sets isReadyForCodeGen based on grade", () => {
+    const empty = makeResult([]);
+
+    const sGrade = generateGotchaSurvey(empty, makeScoreReport("S"));
+    expect(sGrade.isReadyForCodeGen).toBe(true);
+
+    const aGrade = generateGotchaSurvey(empty, makeScoreReport("A"));
+    expect(aGrade.isReadyForCodeGen).toBe(true);
+
+    const cGrade = generateGotchaSurvey(empty, makeScoreReport("C"));
+    expect(cGrade.isReadyForCodeGen).toBe(false);
+
+    const fGrade = generateGotchaSurvey(empty, makeScoreReport("F"));
+    expect(fGrade.isReadyForCodeGen).toBe(false);
+  });
+});

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -1,0 +1,128 @@
+import type { AnalysisResult, AnalysisIssue } from "../engine/rule-engine.js";
+import type { ScoreReport } from "../engine/scoring.js";
+import { isReadyForCodeGen } from "../engine/scoring.js";
+import type { GotchaSurvey, GotchaSurveyQuestion } from "../contracts/gotcha-survey.js";
+import type { RuleId } from "../contracts/rule.js";
+import { GOTCHA_QUESTIONS } from "../rules/gotcha-questions.js";
+
+const NODE_PATH_SEPARATOR = " > ";
+
+/**
+ * Generate a gotcha survey from analysis results.
+ *
+ * Filters to blocking and risk severity issues, deduplicates repeated rules
+ * on sibling nodes (same parent + same ruleId), orders blocking first then
+ * risk by original traversal order, and maps each issue to a survey question
+ * using the GOTCHA_QUESTIONS lookup.
+ */
+export function generateGotchaSurvey(
+  result: AnalysisResult,
+  scores: ScoreReport,
+): GotchaSurvey {
+  const grade = scores.overall.grade;
+
+  // Step 1: Filter to blocking and risk severity only
+  const relevantIssues = result.issues.filter(
+    (issue) => issue.config.severity === "blocking" || issue.config.severity === "risk",
+  );
+
+  // Step 2: Deduplicate — same ruleId on siblings (same parent path) → keep first
+  const deduped = deduplicateSiblingIssues(relevantIssues);
+
+  // Step 3: Sort — blocking first, then risk; within same severity, preserve traversal order
+  const sorted = stableSortBySeverity(deduped);
+
+  // Step 4: Map to survey questions
+  const questions = sorted
+    .map((issue) => mapToQuestion(issue))
+    .filter((q): q is GotchaSurveyQuestion => q !== null);
+
+  return {
+    designGrade: grade,
+    isReadyForCodeGen: isReadyForCodeGen(grade),
+    questions,
+  };
+}
+
+/**
+ * Deduplicate issues where the same ruleId fires on multiple children of the
+ * same parent. Keeps the first occurrence (preserving traversal order).
+ */
+function deduplicateSiblingIssues(issues: AnalysisIssue[]): AnalysisIssue[] {
+  const seen = new Set<string>();
+  const result: AnalysisIssue[] = [];
+
+  for (const issue of issues) {
+    const parentPath = getParentPath(issue.violation.nodePath);
+    const key = `${parentPath}||${issue.violation.ruleId}`;
+
+    if (!seen.has(key)) {
+      seen.add(key);
+      result.push(issue);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Extract the parent path from a full node path.
+ * "Root > Section > Child" → "Root > Section"
+ * "Root" → "" (root node has no parent)
+ */
+function getParentPath(nodePath: string): string {
+  const lastSep = nodePath.lastIndexOf(NODE_PATH_SEPARATOR);
+  if (lastSep === -1) return "";
+  return nodePath.slice(0, lastSep);
+}
+
+/**
+ * Extract the node name from a full node path (last segment).
+ * "Root > Section > Child" → "Child"
+ */
+function getNodeName(nodePath: string): string {
+  const lastSep = nodePath.lastIndexOf(NODE_PATH_SEPARATOR);
+  if (lastSep === -1) return nodePath;
+  return nodePath.slice(lastSep + NODE_PATH_SEPARATOR.length);
+}
+
+/**
+ * Stable sort: blocking before risk, preserving original array order within
+ * each severity group.
+ */
+function stableSortBySeverity(issues: AnalysisIssue[]): AnalysisIssue[] {
+  const blocking: AnalysisIssue[] = [];
+  const risk: AnalysisIssue[] = [];
+
+  for (const issue of issues) {
+    if (issue.config.severity === "blocking") {
+      blocking.push(issue);
+    } else {
+      risk.push(issue);
+    }
+  }
+
+  return [...blocking, ...risk];
+}
+
+/**
+ * Map an AnalysisIssue to a GotchaSurveyQuestion using the GOTCHA_QUESTIONS table.
+ * Returns null if no mapping exists for the ruleId.
+ */
+function mapToQuestion(issue: AnalysisIssue): GotchaSurveyQuestion | null {
+  const ruleId = issue.violation.ruleId as RuleId;
+  const template = GOTCHA_QUESTIONS[ruleId];
+  if (!template) return null;
+
+  const nodeName = getNodeName(issue.violation.nodePath);
+
+  return {
+    nodeId: issue.violation.nodeId,
+    nodeName,
+    ruleId,
+    severity: issue.config.severity,
+    question: template.question.replace("{nodeName}", nodeName),
+    hint: template.hint,
+    example: template.example,
+  };
+}


### PR DESCRIPTION
## Summary

Create a gotcha survey generator that takes analysis results (AnalysisResult + ScoreReport) and produces a structured survey with questions for blocking and risk issues. The survey uses the existing GOTCHA_QUESTIONS mapping table (#266) to generate user-facing questions grouped by node, with deduplication for repeated rules on sibling nodes. This is a core building block of the roundtrip integration (ADR-004) where canicode diagnoses issues and then elicits gotchas from users.

## Tasks

- Add Zod schema for survey output in contracts/
- Create survey-generator.ts with core generation logic
- Add tests for survey generator

## Self-review

Clean, well-structured implementation that correctly addresses all acceptance criteria. The survey generator follows project conventions, uses engine-level types as planned, and has comprehensive test coverage for filtering, deduplication, ordering, and schema validation. No correctness or security issues found.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 2

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #258

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))