### PR TITLE
feat: docs: update ARCHITECTURE.md internal/external command classification

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -29,12 +29,27 @@
 - Build: `pnpm build:plugin` → `app/figma-plugin/dist/` (gitignored)
 - Shared UI from `app/shared/` inlined at build time
 
+### CLI Commands (User-Facing)
+
+Registered in `src/cli/index.ts` (lines 71–77) + docs command (line 101). Internal commands are filtered from `--help` via the `INTERNAL_COMMANDS` array.
+
+| Command | Description |
+|---------|-------------|
+| `analyze <input>` | Analyze a Figma file or JSON fixture |
+| `design-tree <input>` | Generate a DOM-like design tree from a Figma file or fixture |
+| `visual-compare <codePath>` | Compare rendered code against Figma screenshot (pixel-level similarity) |
+| `init` | Set up canicode with Figma API token |
+| `config` | Manage canicode configuration |
+| `list-rules` | List all analysis rules with scores and severity |
+| `prompt` | Output the standard design-to-code prompt for AI code generation |
+| `docs [topic]` | Show documentation (topics: setup, rules, config, visual-compare, design-tree) |
+
 ## Internal (Claude Code Only)
 
-Calibration is orchestrated by `scripts/calibrate.ts` (ADR-008). CLI for deterministic steps, `claude -p` for judgment steps.
+### Orchestration Scripts
 
-**`scripts/calibrate.ts` (orchestration script)**
-- Role: Explicit step-by-step calibration pipeline
+**`scripts/calibrate.ts`**
+- Role: Explicit step-by-step calibration pipeline (ADR-008)
 - Input: fixture directory path (e.g. `fixtures/material3-kit`), or `--resume <run-dir>`
 - Flow: Analyze → Design Tree → Strip → Convert (7 parallel `claude -p` sessions) → Measure → Gap Analyze → Evaluate → Critic → Arbitrator → Evidence
 - Each step tracked in `index.json` for resume-from-failure
@@ -44,32 +59,58 @@ Calibration is orchestrated by `scripts/calibrate.ts` (ADR-008). CLI for determi
 - After Arbitrator applies changes, evidence for applied rules is pruned (`calibrate-prune-evidence`)
 - Each run creates a self-contained directory: `logs/calibration/<fixture>--<timestamp>/`
 
-**`canicode calibrate-save-fixture`**
-- Role: Save Figma design as a fixture directory for calibration (internal command)
-- Input: Figma URL with node-id
-- Output: fixture directory with data.json, screenshot.png, vectors/, images/
-
-**`canicode calibrate-implement`**
-- Role: Prepare design-to-code package for calibration (analysis + design tree + assets + prompt)
-- Input: Figma URL or fixture directory
-- Output: canicode-implement/ directory with analysis.json, design-tree.txt, PROMPT.md, assets
-
-**`/calibrate` (Claude Code command)**
-- Wrapper: runs `npx tsx scripts/calibrate.ts $ARGUMENTS` and reports results
-- Modes: `<fixture-path>` (single), `--all` (all active fixtures), `--resume <run-dir>`
-- `--all` mode: discovers active fixtures, runs sequentially, checks convergence via `fixture-done`, runs regression check, generates aggregate report
-
-**`scripts/develop.ts` (development pipeline)**
+**`scripts/develop.ts`**
 - Role: Automated feature development — reads a GitHub issue, plans, implements, tests, reviews, and creates a draft PR
 - Input: GitHub issue number (e.g. `247`), or `--resume <run-dir>`
 - Flow: Plan (agent) → Implement (agent) → Test (cli, retry loop) → Review (agent) → Fix (agent) → Verify (cli) → PR (cli)
 - State tracked in `logs/develop/<issue>--<timestamp>/index.json`
 - Test/Verify steps have internal fix retry loops (max 3 retries with fix agent)
 - JSON handoff chain: `plan.json` (designDecisions) → `implement-log.json` (decisions, knownRisks) → `review.json` (implementIntent, intentConflict) → `fix-log.json` (resolution, skipped reasons)
-- Each `claude -p` agent receives previous step JSONs so it understands "why", not just "what"
+- Each `claude -p` agent receives previous step JSONs so it understands why, not just what
 - See: issue #247
 
-**`/review-run` (Claude Code command)**
+### CLI Commands (Internal)
+
+All 15 internal commands are registered in `src/cli/index.ts` (lines 82–95), hidden from `--help` via the `INTERNAL_COMMANDS` array in `src/cli/internal-commands.ts`. Source files live in `src/cli/commands/internal/`.
+
+**Calibration pipeline** — deterministic steps called by `scripts/calibrate.ts`:
+
+| Command | Description |
+|---------|-------------|
+| `calibrate-analyze <input>` | Run calibration analysis and output JSON for conversion step |
+| `calibrate-run <input>` | Run full calibration pipeline (analysis-only, conversion via /calibrate) |
+| `calibrate-evaluate [analysisJson] [conversionJson]` | Evaluate conversion results and generate calibration report |
+| `calibrate-gap-report` | Aggregate gap data and calibration runs into a rule review report |
+| `calibrate-gather-evidence <runDir>` | Gather structured evidence for Critic from run artifacts + cross-run data |
+| `calibrate-finalize-debate <runDir>` | Check early-stop or determine stoppingReason after debate |
+| `calibrate-enrich-evidence <runDir>` | Enrich evidence with Critic's pro/con/confidence from debate.json |
+| `calibrate-prune-evidence <runDir>` | Prune evidence for rules applied by the Arbitrator in the given run |
+
+**Fixture management** — fixture lifecycle and data preparation:
+
+| Command | Description |
+|---------|-------------|
+| `calibrate-save-fixture <input>` | Save Figma design as a fixture directory for calibration |
+| `calibrate-implement <input>` | Prepare design-to-code package: analysis + design tree + assets + prompt |
+| `fixture-list [fixturesDir]` | List active and done fixtures |
+| `fixture-done <fixturePath>` | Move a converged fixture to done/ |
+
+**Utility** — standalone processing steps:
+
+| Command | Description |
+|---------|-------------|
+| `design-tree-strip <input>` | Generate stripped design-tree variants for ablation |
+| `html-postprocess <input>` | Sanitize HTML and inject local fonts |
+| `code-metrics <input>` | Compute code metrics for an HTML file |
+
+### Claude Code Commands
+
+**`/calibrate`**
+- Wrapper: runs `npx tsx scripts/calibrate.ts $ARGUMENTS` and reports results
+- Modes: `<fixture-path>` (single), `--all` (all active fixtures), `--resume <run-dir>`
+- `--all` mode: discovers active fixtures, runs sequentially, checks convergence via `fixture-done`, runs regression check, generates aggregate report
+
+**`/review-run`**
 - Role: QA review of a completed `/develop` pipeline run — reads all output artifacts and produces a structured assessment
 - Input: run directory path (e.g. `logs/develop/253--2026-04-16-0903`)
 - Flow: index.json → plan.json → implement-log.json + git diff → test-result.json → review.json → fix-log.json → circuit.json → final verdict


### PR DESCRIPTION
## Summary

Update ARCHITECTURE.md to comprehensively document all internal CLI commands. Currently only calibrate-save-fixture and calibrate-implement are documented in the Internal section, but 15 internal commands exist in internal-commands.ts (including design-tree-strip, html-postprocess, code-metrics, and various calibrate-* / fixture-* commands). The command table needs to reflect the actual registration in src/cli/index.ts and src/cli/internal-commands.ts. Also verify CLAUDE.md has no stale command references.

## Tasks

- Add comprehensive internal CLI command table to ARCHITECTURE.md
- Add external CLI command reference table to ARCHITECTURE.md
- Verify CLAUDE.md has no stale command references
- Run pnpm lint to verify no regressions

## Self-review

Documentation-only change that accurately and comprehensively documents all 15 internal CLI commands and 8 user-facing CLI commands in ARCHITECTURE.md. All command names, argument signatures, and descriptions verified against source registrations in src/cli/internal-commands.ts and src/cli/commands/. CLAUDE.md confirmed to have no stale command references.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 2

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #255

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))