### PR TITLE
feat: expose gotcha survey as MCP tool

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -11,7 +11,7 @@
 
 **2. MCP Server (`canicode-mcp`)**
 - Install: `claude mcp add canicode -- npx -y -p canicode canicode-mcp`
-- Tools: `analyze`, `list-rules`, `visual-compare`, `version`, `docs`
+- Tools: `analyze`, `gotcha-survey`, `list-rules`, `visual-compare`, `version`, `docs`
 - Data source: Figma REST API via `input` param (Figma URL or fixture path). Requires FIGMA_TOKEN for live URLs.
 
 **3. Claude Code Skill (`/canicode`)**

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1,0 +1,174 @@
+import { generateGotchaSurvey } from "../core/gotcha/survey-generator.js";
+import { GotchaSurveySchema } from "../core/contracts/gotcha-survey.js";
+import type { AnalysisResult, AnalysisIssue } from "../core/engine/rule-engine.js";
+import type { ScoreReport } from "../core/engine/scoring.js";
+import type { AnalysisFile, AnalysisNode } from "../core/contracts/figma-node.js";
+import type { Rule, RuleConfig, RuleViolation } from "../core/contracts/rule.js";
+import type { Category } from "../core/contracts/category.js";
+import type { Severity } from "../core/contracts/severity.js";
+import { CATEGORIES } from "../core/contracts/category.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeRule(overrides: { id: string; category: Category }): Rule {
+  return {
+    definition: {
+      id: overrides.id,
+      name: overrides.id,
+      category: overrides.category,
+      why: "",
+      impact: "",
+      fix: "",
+    },
+    check: () => null,
+  };
+}
+
+function makeConfig(severity: Severity, score = -5): RuleConfig {
+  return { severity, score, enabled: true };
+}
+
+function makeViolation(
+  ruleId: string,
+  nodeId: string,
+  nodePath: string,
+): RuleViolation {
+  return { ruleId, nodeId, nodePath, message: "test", suggestion: "" };
+}
+
+function makeIssue(opts: {
+  ruleId: string;
+  category: Category;
+  severity: Severity;
+  nodeId?: string;
+  nodePath?: string;
+}): AnalysisIssue {
+  return {
+    violation: makeViolation(
+      opts.ruleId,
+      opts.nodeId ?? "1:1",
+      opts.nodePath ?? "Root > Node",
+    ),
+    rule: makeRule({ id: opts.ruleId, category: opts.category }),
+    config: makeConfig(opts.severity),
+    depth: 0,
+    maxDepth: 5,
+    calculatedScore: -5,
+  };
+}
+
+function makeResult(issues: AnalysisIssue[]): AnalysisResult {
+  const doc: AnalysisNode = {
+    id: "0:1",
+    name: "Document",
+    type: "DOCUMENT",
+    visible: true,
+  };
+  const file: AnalysisFile = {
+    fileKey: "test",
+    name: "Test",
+    lastModified: "",
+    version: "1",
+    document: doc,
+    components: {},
+    styles: {},
+  };
+  return {
+    file,
+    issues,
+    failedRules: [],
+    maxDepth: 5,
+    nodeCount: 100,
+    analyzedAt: new Date().toISOString(),
+  };
+}
+
+function makeScoreReport(grade: ScoreReport["overall"]["grade"]): ScoreReport {
+  const byCategory = Object.fromEntries(
+    CATEGORIES.map((c) => [
+      c,
+      {
+        category: c,
+        score: 50,
+        maxScore: 100,
+        percentage: 50,
+        issueCount: 0,
+        uniqueRuleCount: 0,
+        weightedIssueCount: 0,
+        densityScore: 100,
+        diversityScore: 100,
+        bySeverity: { blocking: 0, risk: 0, "missing-info": 0, suggestion: 0 },
+      },
+    ]),
+  ) as ScoreReport["byCategory"];
+
+  return {
+    overall: { score: 50, maxScore: 100, percentage: 50, grade },
+    byCategory,
+    summary: {
+      totalIssues: 0,
+      blocking: 0,
+      risk: 0,
+      missingInfo: 0,
+      suggestion: 0,
+      nodeCount: 100,
+    },
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("gotcha-survey MCP tool pipeline", () => {
+  it("returns valid GotchaSurvey JSON for designs with issues", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > Hero",
+      }),
+      makeIssue({
+        ruleId: "fixed-size-in-auto-layout",
+        category: "responsive-critical",
+        severity: "risk",
+        nodeId: "2:2",
+        nodePath: "Root > Card",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(makeResult(issues), makeScoreReport("C"));
+
+    const parsed = GotchaSurveySchema.safeParse(survey);
+    expect(parsed.success).toBe(true);
+    expect(survey.designGrade).toBe("C");
+    expect(survey.isReadyForCodeGen).toBe(false);
+    expect(survey.questions.length).toBeGreaterThan(0);
+  });
+
+  it("returns empty questions when isReadyForCodeGen is true", () => {
+    const survey = generateGotchaSurvey(makeResult([]), makeScoreReport("S"));
+
+    expect(survey.isReadyForCodeGen).toBe(true);
+    expect(survey.questions).toEqual([]);
+  });
+
+  it("survey output can be serialized to JSON text (as MCP tool returns)", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "1:1",
+        nodePath: "Root > Section > Frame",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(makeResult(issues), makeScoreReport("D"));
+    const jsonText = JSON.stringify(survey, null, 2);
+    const roundTripped = JSON.parse(jsonText) as unknown;
+
+    const parsed = GotchaSurveySchema.safeParse(roundTripped);
+    expect(parsed.success).toBe(true);
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -9,6 +9,7 @@ import { exec } from "node:child_process";
 import { analyzeFile } from "../core/engine/rule-engine.js";
 import { loadFile, isJsonFile, isFixtureDir } from "../core/engine/loader.js";
 import { calculateScores, buildResultJson } from "../core/engine/scoring.js";
+import { generateGotchaSurvey } from "../core/gotcha/survey-generator.js";
 import { generateHtmlReport } from "../core/report-html/index.js";
 import { getReportsDir, ensureReportsDir } from "../core/engine/config-store.js";
 import { getConfigsWithPreset, RULE_CONFIGS, type Preset } from "../core/rules/rule-config.js";
@@ -115,6 +116,88 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
       trackError(
         error instanceof Error ? error : new Error(String(error)),
         { tool: "analyze" },
+      );
+      trackEvent(EVENTS.ANALYSIS_FAILED, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  },
+);
+
+server.tool(
+  "gotcha-survey",
+  `Generate a gotcha survey from a Figma design analysis.
+
+Analyzes the design and returns a GotchaSurvey JSON with designGrade, isReadyForCodeGen, and questions[].
+When isReadyForCodeGen is true, questions will be empty (no survey needed).
+
+Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKEN env var or the token parameter for live Figma URLs.`,
+  {
+    input: z.string().describe("Figma URL or local fixture path. Requires FIGMA_TOKEN for live URLs."),
+    token: z.string().optional().describe("Figma API token (falls back to FIGMA_TOKEN env var)"),
+    preset: z.enum(["relaxed", "dev-friendly", "ai-ready", "strict"]).optional().describe("Analysis preset"),
+    targetNodeId: z.string().optional().describe("Scope analysis to a specific node ID"),
+    configPath: z.string().optional().describe("Path to config JSON file for rule overrides"),
+  },
+  {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: true,
+    title: "Gotcha Survey",
+  },
+  async ({ input, token, preset, targetNodeId, configPath }) => {
+    trackEvent(EVENTS.MCP_TOOL_CALLED, { tool: "gotcha-survey" });
+    try {
+      const { file, nodeId } = await loadFile(input, token);
+
+      const effectiveNodeId = targetNodeId ?? nodeId;
+
+      let configs: Record<string, RuleConfig> = preset
+        ? { ...getConfigsWithPreset(preset as Preset) }
+        : { ...RULE_CONFIGS };
+
+      if (configPath) {
+        const configFile = await loadConfigFile(configPath);
+        configs = mergeConfigs(configs, configFile);
+      }
+
+      const result = analyzeFile(file, {
+        configs: configs as Record<RuleId, RuleConfig>,
+        ...(effectiveNodeId ? { targetNodeId: effectiveNodeId } : {}),
+      });
+
+      const scores = calculateScores(result, configs as Record<RuleId, RuleConfig>);
+      const survey = generateGotchaSurvey(result, scores);
+
+      trackEvent(EVENTS.ANALYSIS_COMPLETED, {
+        nodeCount: result.nodeCount,
+        issueCount: result.issues.length,
+        grade: scores.overall.grade,
+        percentage: scores.overall.percentage,
+        source: isJsonFile(input) || isFixtureDir(input) ? "fixture" : "figma",
+      });
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(survey, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      trackError(
+        error instanceof Error ? error : new Error(String(error)),
+        { tool: "gotcha-survey" },
       );
       trackEvent(EVENTS.ANALYSIS_FAILED, {
         error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary

Expose the existing generateGotchaSurvey() function as a new MCP tool called 'gotcha-survey'. The tool accepts the same Figma URL input as the analyze tool, runs the full analyze→generateGotchaSurvey pipeline internally, and returns GotchaSurvey JSON (designGrade, isReadyForCodeGen, questions[]). When isReadyForCodeGen is true, questions should be empty since no survey is needed.

## Tasks

- Register gotcha-survey tool in MCP server
- Add gotcha-survey test
- Verify build and type check

## Self-review

Clean implementation that faithfully follows the existing analyze tool pattern. The gotcha-survey MCP tool correctly chains loadFile→analyzeFile→calculateScores→generateGotchaSurvey, returns structured JSON without side effects (no HTML report, no file writes), and handles errors consistently. All acceptance criteria are met. One minor documentation gap: ARCHITECTURE.md's MCP tools list should include the new tool.
- Verdict: approve
- Errors: 0, Warnings: 1, Total: 2

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #271

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))