### PR TITLE
feat: gotcha skill file writer for Claude Code

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -19,6 +19,12 @@
 - Uses CLI (`canicode analyze`) with FIGMA_TOKEN
 - Lightweight alternative to MCP server — no canicode MCP installation needed
 
+**3a. Claude Code Skill (`/canicode-gotchas`)**
+- Location: `.claude/skills/canicode-gotchas/SKILL.md` (copy to any project)
+- Data source: `gotcha-survey` MCP tool (requires canicode MCP server)
+- Workflow: calls gotcha-survey → presents questions to user → collects answers → writes `.claude/skills/canicode-gotchas/SKILL.md` in the user's project
+- Output: skill file with design gotcha Q&A pairs (nodeId, ruleId, severity, question, answer) for code generation reference
+
 **4. Web App (GitHub Pages)**
 - Source: `app/web/src/index.html`
 - Build: `pnpm build:web` → `app/web/dist/` (deployed via GitHub Pages)

--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: canicode-gotchas
+description: Run a gotcha survey for a Figma design and save answers as a Claude Code skill file for code generation reference
+---
+
+# CanICode Gotchas -- Design Gotcha Survey & Skill Writer
+
+Run a gotcha survey on a Figma design to identify implementation pitfalls, collect developer answers, and save them as a skill file that code generation agents can reference automatically.
+
+## Prerequisites
+
+- **canicode MCP server** installed: `claude mcp add canicode -e FIGMA_TOKEN=figd_xxx -- npx -y -p canicode canicode-mcp`
+- **FIGMA_TOKEN** configured for live Figma URLs
+
+## Workflow
+
+### Step 1: Run the gotcha survey
+
+Call the `gotcha-survey` MCP tool with the user's Figma URL:
+
+```
+gotcha-survey({ input: "<figma-url-or-fixture-path>" })
+```
+
+The tool returns:
+- `designGrade`: overall grade (S, A+, A, B+, B, C+, C, D, F)
+- `isReadyForCodeGen`: whether the design can be implemented without gotchas
+- `questions`: array of gotcha questions (may be empty)
+
+### Step 2: Check if survey is needed
+
+If `isReadyForCodeGen` is `true` or `questions` is empty:
+- Tell the user: "This design scored **{designGrade}** and is ready for code generation — no gotchas to resolve."
+- Do NOT write a skill file.
+- Stop here.
+
+### Step 3: Present questions to the user
+
+For each question in the `questions` array, present it to the user one at a time:
+
+```
+**[{severity}] {ruleId}** — node: {nodeName}
+
+{question}
+
+> Hint: {hint}
+> Example: {example}
+```
+
+Wait for the user's answer before moving to the next question. The user may:
+- Answer the question directly
+- Say "skip" to skip a question
+- Say "n/a" if the question is not applicable
+
+### Step 4: Write the gotcha skill file
+
+After collecting all answers, write the completed file to:
+
+```
+.claude/skills/canicode-gotchas/SKILL.md
+```
+
+This file goes in the **user's project** (current working directory), NOT in the canicode repo.
+
+Always overwrite any existing file at this path — each run produces a fresh file based on the latest analysis.
+
+## Output Template
+
+The written SKILL.md must follow this exact format:
+
+````markdown
+---
+name: canicode-gotchas
+description: Design gotcha answers for {designName} — reference during code generation
+---
+
+# Design Gotchas — {designName}
+
+Collected from canicode gotcha survey. Reference these answers when implementing this design.
+
+## Metadata
+
+- **Figma URL**: {figmaUrl}
+- **Grade**: {designGrade}
+- **Analyzed at**: {analyzedAt}
+
+## Gotchas
+
+### {ruleId} — {nodeName}
+
+- **Severity**: {severity}
+- **Node ID**: {nodeId}
+- **Question**: {question}
+- **Answer**: {userAnswer}
+
+(repeat for each question)
+````
+
+### Field mapping
+
+| Field | Source |
+|-------|--------|
+| `designName` | Figma file name or fixture name from the input |
+| `figmaUrl` | The input URL or fixture path provided by the user |
+| `designGrade` | `designGrade` from gotcha-survey response |
+| `analyzedAt` | Current timestamp (ISO 8601) |
+| `ruleId` | `ruleId` from each question |
+| `nodeName` | `nodeName` from each question |
+| `severity` | `severity` from each question (blocking / risk) |
+| `nodeId` | `nodeId` from each question |
+| `question` | `question` from each question |
+| `userAnswer` | The answer collected from the user in Step 3 |
+
+### Skipped questions
+
+If the user skipped a question or said "n/a", still include it in the output with:
+
+```markdown
+- **Answer**: _(skipped)_
+```
+
+This ensures the code generation agent knows the gotcha exists even if no answer was provided.
+
+## Edge Cases
+
+- **No questions returned**: The design is ready for code generation. Inform the user and stop (Step 2).
+- **User wants to re-run**: Always overwrite the existing file. No merge or append — fresh output each time.
+- **MCP tool not available**: If the `gotcha-survey` tool is not found, tell the user to install the canicode MCP server (see Prerequisites).
+- **Partial answers**: If the user stops mid-survey, write the file with answers collected so far. Mark remaining questions as _(skipped)_.


### PR DESCRIPTION
## Summary

Create a Claude Code skill file (.claude/skills/canicode-gotchas/SKILL.md) that guides Claude Code through the gotcha survey workflow: call the gotcha-survey MCP tool, present questions to the user, collect answers, and write the responses as a SKILL.md file in the user's project. The skill file itself is a prompt/guide that Claude Code follows — no runtime code is needed. The output SKILL.md written by Claude Code into the user's project will contain the analysis target, grade, each Q&A pair with nodeId, so that code generation agents can reference gotchas automatically.

## Tasks

- Define the gotcha SKILL.md output template format
- Write the gotcha survey skill with full workflow instructions
- Update ARCHITECTURE.md to document the gotcha skill

## Self-review

Clean documentation-only change that adds a well-structured Claude Code skill file and corresponding ARCHITECTURE.md entry. The SKILL.md follows existing skill patterns, covers all acceptance criteria (template format, workflow, overwrite semantics, edge cases), and correctly references all GotchaSurveyQuestion fields from the contract. No TypeScript code changes, no convention violations.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 1

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #272

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))