### PR TITLE
docs: correct ADR-009 from auto-discovery to orchestration skill

### DIFF
--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -44,11 +44,18 @@ Core decisions that shape every session. For full history see [GitHub Wiki Decis
 **Why**: Ensures provenance, consistent build environment, and review gate.
 **Impact**: Local `npm publish` is blocked by safety hooks.
 
-## ADR-009: Gotcha delivery via Figma MCP skill auto-discovery
+## ADR-009: Gotcha delivery via orchestration skill
 
-**Decision**: Gotcha answers are written as a `.claude/skills/canicode-gotchas/SKILL.md` file in the user's project. No explicit wiring to code generation prompts or skills is needed.
-**Why**: Claude Code automatically scans `.claude/skills/` and loads relevant skills based on the `description` field and conversation context. When a user asks "implement this design", Claude Code finds the gotcha skill file (description: "Design gotcha answers for … — reference during code generation") and includes it in the code generation context. This is the standard Figma MCP pattern — gotchas are "debugging guides" that prevent AI from repeating mistakes (e.g., always making badges oval instead of circular). See [From Claude Code to Figma — and Back Again](https://fig-events.figma.com/claude-to-figma/).
-**Impact**: Do NOT add explicit gotcha references to code generation prompts, PROMPT.md, or other skills. The skill file with an appropriate description is the complete delivery mechanism. Adding explicit references would bypass the skill system's design and create maintenance coupling.
+**Decision**: Deliver gotcha answers to code generation via an orchestration skill (`canicode-roundtrip`), not via auto-discovery of a separate skill file.
+**Why**: Analysis of all 7 official Figma skills shows cross-skill references are **explicit links** (`[figma-use](../figma-use/SKILL.md)`), not auto-discovery. `figma-implement-design` is a built-in skill that cannot be modified to reference `canicode-gotchas`. Therefore, a single orchestration skill handles the full flow: analyze → gotcha survey → code generation with gotcha context. This follows the established pattern: `figma-generate-design` builds on `figma-use`, and community skill `bridge-ds` orchestrates 6 skills + a knowledge-base with a recipe system. See #277.
+**Impact**: `canicode-gotchas` (standalone survey) is preserved, but code generation delivery is handled by `canicode-roundtrip`. Do not rely on auto-discovery to connect separate skill files — Figma skills only support explicit references.
+**References**:
+- [Figma skills for MCP](https://help.figma.com/hc/en-us/articles/39166810751895-Figma-skills-for-MCP) — official skill structure
+- [Figma community skills](https://www.figma.com/community/skills) — third-party skill ecosystem
+- [figma/mcp-server-guide/skills](https://github.com/figma/mcp-server-guide/tree/main/skills) — 7 official skill sources, explicit cross-skill reference pattern
+- [figma/community-resources/agent_skills](https://github.com/figma/community-resources/tree/main/agent_skills) — community skills (bridge-ds: recipe system, ds-compliance-audit)
+- [noemuch/bridge](https://github.com/noemuch/bridge) — bridge-ds source, learning-from-corrections pattern
+- [From Claude Code to Figma — and Back Again](https://fig-events.figma.com/claude-to-figma/) — gotcha pattern (49:36–50:17), skill auto-loading (42:26–42:43)
 
 ## ADR-008: Calibration pipeline — explicit claude -p orchestration
 

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -24,7 +24,7 @@
 - Data source: `gotcha-survey` MCP tool (requires canicode MCP server)
 - Workflow: calls gotcha-survey → presents questions to user → collects answers → writes `.claude/skills/canicode-gotchas/SKILL.md` in the user's project
 - Output: skill file with design gotcha Q&A pairs (nodeId, ruleId, severity, question, answer)
-- **How code generation consumes it**: The output skill file lives in `.claude/skills/` with a description field mentioning "code generation". Claude Code automatically scans skills and loads relevant ones based on description + conversation context. When a user asks "implement this design", the gotcha skill file is auto-loaded — no explicit wiring needed. This is the standard Figma MCP gotcha pattern (ADR-009).
+- **Code generation delivery**: Auto-discovery of a separate skill file cannot reach `figma-implement-design` (Figma skills only support explicit cross-references). The `canicode-roundtrip` orchestration skill (#277) connects analyze → gotcha survey → code generation in a single flow (ADR-009).
 
 **4. Web App (GitHub Pages)**
 - Source: `app/web/src/index.html`


### PR DESCRIPTION
## Summary
- ADR-009 corrected: "auto-discovery sufficient" → "orchestration skill required" (#277)
- ARCHITECTURE.md 3a updated to match

## Why
PR #276 merged with incorrect assumption that Claude Code skill auto-discovery would deliver gotcha answers to `figma-implement-design`. Analysis of all 7 official Figma skills + community skills (bridge-ds) confirmed:
- Cross-skill references are **explicit links**, not auto-discovery
- `figma-implement-design` is built-in and cannot be modified
- Orchestration skill pattern is the established approach (figma-generate-design → figma-use, bridge-ds → 6 skills + knowledge-base)

## Test plan
- [ ] ADR-009 references are valid
- [ ] ARCHITECTURE.md 3a correctly references #277 and ADR-009

🤖 Generated with [Claude Code](https://claude.com/claude-code)