### PR TITLE
feat: true roundtrip — apply gotcha answers to Figma design

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -28,11 +28,11 @@
 
 **3b. Claude Code Skill (`/canicode-roundtrip`)**
 - Location: `.claude/skills/canicode-roundtrip/SKILL.md` (copy to any project)
-- Data source: `analyze` + `gotcha-survey` MCP tools (canicode MCP server) + Figma MCP tools (`get_design_context`, `get_screenshot`)
-- Workflow: analyze → gate on `isReadyForCodeGen` → gotcha survey (if needed) → code generation with gotcha context injected inline
-- Orchestrates existing MCP tools — no new tools or CLI commands introduced
-- Gotcha answers are saved to `.claude/skills/canicode-gotchas/SKILL.md` (reusable) and also kept as inline conversation context for the implementation step
-- See #277
+- Data source: `analyze` + `gotcha-survey` MCP tools (canicode MCP server) + Figma MCP tools (`get_design_context`, `get_screenshot`, `use_figma`)
+- Workflow: analyze → gate on `isReadyForCodeGen` → gotcha survey (if needed) → **apply fixes to Figma via `use_figma`** → re-analyze → code generation
+- True roundtrip: gotcha answers are applied back to the Figma design (property modification, structural modification with confirmation, or annotations for unfixable issues) so the design itself improves
+- Requires Figma Full seat + file edit permission for `use_figma`; falls back to one-way flow (gotcha as code gen context) if no edit permission
+- See #281, ADR-010
 
 **4. Web App (GitHub Pages)**
 - Source: `app/web/src/index.html`

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -166,7 +166,7 @@ If user **declines** any structural modification, add an annotation instead (sam
 
 These rules cannot be auto-fixed via Plugin API. Add the gotcha answer as a Figma annotation on the node so designers see it in Dev Mode.
 
-**Rules**: `absolute-position-in-auto-layout`, `variant-structure-mismatch`
+**Rules from gotcha survey**: `absolute-position-in-auto-layout`, `variant-structure-mismatch`
 
 ```javascript
 const node = figma.getNodeById("nodeId");
@@ -179,11 +179,54 @@ if (node && "annotations" in node) {
 
 Important: use `labelMarkdown` only — `label` and `labelMarkdown` are mutually exclusive. Preserve existing annotations by spreading `node.annotations`.
 
+#### Strategy D: Auto-fix lower-severity issues from analysis
+
+The gotcha survey only covers blocking/risk severity (11 rules). The remaining 5 rules appear in the Step 1 analysis `issues` array but not in the survey. Process them directly — no gotcha question needed.
+
+**Auto-fix naming** — apply directly from the analysis issue data:
+
+**`non-standard-naming`** — The analysis identifies non-standard state names. Rename to the standard equivalent:
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node) node.name = "Hover"; // standardize from "hover_v1", "on_hover", etc.
+```
+Standard state names: Default, Hover, Active, Pressed, Selected, Highlighted, Disabled, Enabled, Focus, Focused, Dragged.
+
+**`inconsistent-naming-convention`** — The analysis identifies the dominant convention among siblings. Rename minority nodes to match:
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node) node.name = "CardTitle"; // convert to dominant convention (e.g., PascalCase)
+```
+
+**Annotate** — these require designer judgment, no auto-fix possible:
+
+**`raw-value`** — Raw colors/fonts/spacing without design tokens. Annotate which values need token binding:
+```javascript
+node.annotations = [...(node.annotations || []), {
+  labelMarkdown: "**[canicode] raw-value**\n\nThis node uses raw values without design tokens.\n**Issue:** {issue message from analysis}"
+}];
+```
+
+**`missing-interaction-state`** — Missing hover/active/disabled variants. Annotate what states are needed:
+```javascript
+node.annotations = [...(node.annotations || []), {
+  labelMarkdown: "**[canicode] missing-interaction-state**\n\nThis component is missing interaction state variants.\n**Missing:** {missing states from analysis}"
+}];
+```
+
+**`missing-prototype`** — Missing prototype interactions (rule currently disabled, include for completeness):
+```javascript
+node.annotations = [...(node.annotations || []), {
+  labelMarkdown: "**[canicode] missing-prototype**\n\nThis interactive element has no prototype interaction defined.\n**Expected:** {expected interaction from analysis}"
+}];
+```
+
 #### Execution order
 
 1. **Batch all property modifications** (Strategy A) into a single `use_figma` call for efficiency.
 2. **Present structural modifications** (Strategy B) one by one, apply confirmed ones.
 3. **Batch all annotations** (Strategy C + declined structural mods) into a single `use_figma` call.
+4. **Batch all auto-fixes and annotations for lower-severity issues** (Strategy D) into a single `use_figma` call.
 
 After applying, report what was done:
 
@@ -193,6 +236,8 @@ Applied {N} changes to the Figma design:
 - ✅ {nodeName}: itemSpacing → 16px (irregular-spacing)
 - ⏭️ {nodeName}: declined by user, added annotation (deep-nesting)
 - 📝 {nodeName}: annotation added (absolute-position-in-auto-layout)
+- 🔧 {nodeName}: auto-fixed to "Hover" (non-standard-naming)
+- 📝 {nodeName}: annotation — raw color needs token binding (raw-value)
 ```
 
 ### Step 5: Re-analyze and verify

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: canicode-roundtrip
-description: Run canicode analysis + gotcha survey, then implement with Figma MCP — full design-to-code roundtrip
+description: Analyze Figma design, fix gotchas via Plugin API, re-analyze, then implement — true design-to-code roundtrip
 disable-model-invocation: false
 ---
 
-# CanICode Roundtrip -- Design Analysis to Code Generation
+# CanICode Roundtrip — True Design-to-Code Roundtrip
 
-Orchestrate the full design-to-code flow: analyze a Figma design for readiness, collect gotcha answers for problem areas, then generate code with Figma MCP — all gotcha context injected inline so the implementation avoids known pitfalls.
+Orchestrate the full design-to-code roundtrip: analyze a Figma design for readiness, collect gotcha answers for problem areas, **apply fixes directly to the Figma design** via `use_figma`, re-analyze to verify the design improved, then generate code. The design itself gets better — the next analysis passes without gotchas.
 
 ## Prerequisites
 
-- **Figma MCP server** installed (provides `get_design_context`, `get_screenshot`, and other Figma tools)
+- **Figma MCP server** installed (provides `get_design_context`, `get_screenshot`, `use_figma`, and other Figma tools)
 - **canicode MCP server** installed: `claude mcp add canicode -e FIGMA_TOKEN=figd_xxx -- npx -y -p canicode canicode-mcp`
 - **FIGMA_TOKEN** configured for live Figma URLs
+- **Figma Full seat + file edit permission** (required for `use_figma` to modify the design)
 
 ## Workflow
 
@@ -40,7 +41,7 @@ Design grade: **{grade}** ({percentage}%) — {issueCount} issues found.
 
 If `isReadyForCodeGen` is `true` (grade S, A+, or A):
 - Tell the user: "This design scored **{grade}** — ready for code generation with no gotchas needed."
-- Skip directly to **Step 4**.
+- Skip directly to **Step 6**.
 
 If `isReadyForCodeGen` is `false` (grade B+ or below):
 - Tell the user: "This design scored **{grade}** — running gotcha survey to identify implementation pitfalls."
@@ -54,7 +55,7 @@ Call the `gotcha-survey` MCP tool:
 gotcha-survey({ input: "<figma-url>" })
 ```
 
-If `questions` is empty, skip to **Step 4**.
+If `questions` is empty, skip to **Step 6**.
 
 For each question in the `questions` array, present it to the user one at a time:
 
@@ -72,59 +73,180 @@ Wait for the user's answer before moving to the next question. The user may:
 - Say "skip" to skip a question
 - Say "n/a" if the question is not applicable
 
-After all questions are answered:
+After all questions are answered, **save gotcha answers to file** at `.claude/skills/canicode-gotchas/SKILL.md` in the user's project. Always overwrite any existing file — each run produces a fresh file. Follow the format from the `/canicode-gotchas` skill.
 
-1. **Save gotcha answers to file** at `.claude/skills/canicode-gotchas/SKILL.md` in the user's project (same format as the standalone `/canicode-gotchas` skill). Always overwrite any existing file — each run produces a fresh file.
+Then proceed to **Step 4** to apply answers to the Figma design.
 
-The saved file must follow this format:
+### Step 4: Apply gotcha answers to Figma design
 
-````markdown
----
-name: canicode-gotchas
-description: Design gotcha answers for {designName} — reference during code generation
----
+Extract the `fileKey` from the Figma URL (format: `figma.com/design/:fileKey/...`).
 
-# Design Gotchas — {designName}
+For each answered gotcha (skip questions answered with "skip" or "n/a"), determine the apply strategy based on the `ruleId`:
 
-Collected from canicode gotcha survey. Reference these answers when implementing this design.
+#### Strategy A: Property Modification — apply directly
 
-## Metadata
+These rules have straightforward property changes. Apply without additional confirmation. Parse the user's answer to extract the target values.
 
-- **Figma URL**: {figmaUrl}
-- **Grade**: {designGrade}
-- **Analyzed at**: {timestamp ISO 8601}
+**`non-semantic-name`** — Rename the node to the answer:
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node) node.name = "hero-section";
+```
 
-## Gotchas
+**`irregular-spacing`** — Fix spacing to the grid-aligned value from the answer:
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node && "itemSpacing" in node) node.itemSpacing = 16;
+// For padding: node.paddingTop = 8; node.paddingBottom = 8; etc.
+```
 
-### {ruleId} — {nodeName}
+**`fixed-size-in-auto-layout`** — Change sizing mode per the answer (FILL, HUG, or FIXED):
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node && "layoutSizingHorizontal" in node) {
+  node.layoutSizingHorizontal = "FILL"; // or "HUG" or "FIXED"
+}
+```
 
-- **Severity**: {severity}
-- **Node ID**: {nodeId}
-- **Question**: {question}
-- **Answer**: {userAnswer}
+**`missing-size-constraint`** — Set min/max constraints from the answer:
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node && "minWidth" in node) {
+  node.minWidth = 320;  // from answer
+  node.maxWidth = 1200; // from answer, if provided
+}
+```
 
-(repeat for each question)
-````
+**`no-auto-layout`** — Set layout mode, direction, and spacing from the answer:
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node && "layoutMode" in node) {
+  node.layoutMode = "VERTICAL"; // or "HORIZONTAL"
+  node.itemSpacing = 16;
+  // Optionally set padding, alignment from the answer
+}
+```
 
-Mark skipped questions with `**Answer**: _(skipped)_`.
+#### Strategy B: Structural Modification — confirm with user first
 
-2. **Compile inline gotcha context** for use in Step 4 — the gotcha answers from the saved file are also kept in the conversation so the implementation step can reference them directly.
+These rules change the design structure. Show the proposed change and **ask for user confirmation** before applying.
 
-### Step 4: Implement with Figma MCP
+**`non-layout-container`** — Convert Group/Section to Auto Layout frame:
+- Prompt: "I'll convert **{nodeName}** to an Auto Layout frame with {direction} layout and {spacing}px gap. Proceed?"
+- If confirmed:
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node && "layoutMode" in node) {
+  node.layoutMode = "VERTICAL";
+  node.itemSpacing = 12;
+}
+```
+
+**`deep-nesting`** — Flatten intermediate wrappers or extract sub-component:
+- Prompt: "I'll flatten **{nodeName}** by {description from answer}. This changes the layer hierarchy. Proceed?"
+- Apply based on the specific answer (remove wrappers, convert padding, etc.)
+
+**`missing-component`** — Convert frame to reusable component:
+- Prompt: "I'll convert **{nodeName}** to a reusable component. Proceed?"
+- If confirmed:
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node && node.type === "FRAME") {
+  figma.createComponentFromNode(node);
+}
+```
+
+**`detached-instance`** — Reconnect to original component:
+- Prompt: "I'll reconnect **{nodeName}** to its original component. Any overrides will be preserved. Proceed?"
+- This requires finding the original component — if not identifiable, fall back to annotation.
+
+If user **declines** any structural modification, add an annotation instead (same as Strategy C).
+
+#### Strategy C: Annotation — record on the design for designer reference
+
+These rules cannot be auto-fixed via Plugin API. Add the gotcha answer as a Figma annotation on the node so designers see it in Dev Mode.
+
+**Rules**: `absolute-position-in-auto-layout`, `variant-structure-mismatch`
+
+```javascript
+const node = figma.getNodeById("nodeId");
+if (node && "annotations" in node) {
+  node.annotations = [...(node.annotations || []), {
+    labelMarkdown: "**[canicode] {ruleId}**\n\n**Q:** {question}\n**A:** {answer}"
+  }];
+}
+```
+
+Important: use `labelMarkdown` only — `label` and `labelMarkdown` are mutually exclusive. Preserve existing annotations by spreading `node.annotations`.
+
+#### Execution order
+
+1. **Batch all property modifications** (Strategy A) into a single `use_figma` call for efficiency.
+2. **Present structural modifications** (Strategy B) one by one, apply confirmed ones.
+3. **Batch all annotations** (Strategy C + declined structural mods) into a single `use_figma` call.
+
+After applying, report what was done:
+
+```
+Applied {N} changes to the Figma design:
+- ✅ {nodeName}: renamed to "hero-section" (non-semantic-name)
+- ✅ {nodeName}: itemSpacing → 16px (irregular-spacing)
+- ⏭️ {nodeName}: declined by user, added annotation (deep-nesting)
+- 📝 {nodeName}: annotation added (absolute-position-in-auto-layout)
+```
+
+### Step 5: Re-analyze and verify
+
+Run `analyze` again on the same Figma URL:
+
+```
+analyze({ input: "<figma-url>" })
+```
+
+Compare the new grade with the original:
+
+**All gotcha issues resolved** (new grade is S, A+, or A):
+- Tell the user: "Design improved from **{oldGrade}** to **{newGrade}** — all gotcha issues resolved. Ready for code generation."
+- Clean up canicode annotations: remove annotations with `[canicode]` prefix from fixed nodes via `use_figma`:
+```javascript
+const nodeIds = ["id1", "id2"]; // nodes that now pass
+for (const id of nodeIds) {
+  const node = figma.getNodeById(id);
+  if (node && "annotations" in node) {
+    node.annotations = (node.annotations || []).filter(
+      a => !a.labelMarkdown?.startsWith("**[canicode]")
+    );
+  }
+}
+```
+- Proceed to **Step 6**.
+
+**Some issues remain**:
+- Show what improved and what still needs attention.
+- Ask: "Design improved from **{oldGrade}** to **{newGrade}**. {remainingCount} issues remain. Proceed to code generation?"
+- If yes → proceed to **Step 6** with remaining gotcha context.
+- If no → stop and let the user address remaining issues manually.
+
+### Step 6: Implement with Figma MCP
 
 Follow the **figma-implement-design** skill workflow to generate code from the Figma design.
 
-**If gotcha answers were collected in Step 3**, provide them as additional context when implementing:
+**If annotations or unresolved gotchas remain from Step 5**, provide them as additional context when implementing:
 
 - Gotchas with severity **blocking** MUST be addressed — the design cannot be implemented correctly without this information
 - Gotchas with severity **risk** SHOULD be addressed — they indicate potential issues that will surface later
 - Reference the specific node IDs from gotcha answers to locate the affected elements in the design
 
+**If all issues were resolved in Steps 4-5**, no additional gotcha context is needed — the design speaks for itself.
+
 ## Edge Cases
 
 - **No canicode MCP server**: If the `analyze` tool is not found, tell the user to install the canicode MCP server (see Prerequisites). The Figma MCP tools alone are not sufficient for this workflow.
-- **No Figma MCP server**: If `get_design_context` is not found, tell the user to set up the Figma MCP server. Without it, the code generation phase cannot proceed.
+- **No Figma MCP server**: If `get_design_context` or `use_figma` is not found, tell the user to set up the Figma MCP server. Without it, the apply and code generation phases cannot proceed.
+- **No edit permission**: If `use_figma` fails with a permission error, tell the user they need Full seat + file edit permission. Fall back to the one-way flow: skip Steps 4-5 and proceed directly to Step 6 with gotcha answers as code generation context.
 - **User wants analysis only**: Suggest using `/canicode` instead — it runs analysis without the code generation phase.
 - **User wants gotcha survey only**: Suggest using `/canicode-gotchas` instead — it runs the survey and saves answers as a persistent skill file.
-- **Partial gotcha answers**: If the user stops mid-survey, proceed to Step 4 with the answers collected so far. Mark unanswered questions as skipped in the Gotcha Context Block.
-- **Very large design (many gotchas)**: The gotcha survey already deduplicates sibling nodes and filters to blocking/risk severity only, limiting the number of questions. If there are still many questions, ask the user if they want to focus on blocking issues only.
+- **Partial gotcha answers**: Apply only the answered questions. Skipped/n/a questions are neither applied nor annotated.
+- **use_figma call fails for a node**: Report the error for that specific node, continue with other nodes. Failed property modifications become annotations so the context is not lost.
+- **Re-analyze shows new issues**: Only address issues from the original gotcha survey. New issues may appear due to structural changes — report them but do not re-enter the gotcha loop.
+- **Very large design (many gotchas)**: The gotcha survey already deduplicates sibling nodes and filters to blocking/risk severity only. If there are still many questions, ask the user if they want to focus on blocking issues only.


### PR DESCRIPTION
## Summary

- Update `canicode-roundtrip` SKILL.md from one-way pipeline to true roundtrip
- Gotcha answers are now applied back to the Figma design via `use_figma` Plugin API
- **All 16 rules** covered with 4 strategies: property modification (5), structural modification with confirmation (4), annotation from gotcha (2), auto-fix/annotate from analysis (5)
- Re-analyze step verifies the design improved before proceeding to code generation
- Update ARCHITECTURE.md to reflect the new flow

## Changes

**SKILL.md**:
- New Step 4: Apply gotcha answers to Figma design (Strategy A/B/C/D)
- New Step 5: Re-analyze and verify
- Old Step 4 → Step 6: Implement with Figma MCP
- Updated prerequisites (Full seat + edit permission)
- Updated edge cases (no edit permission fallback, use_figma failures)

**ARCHITECTURE.md**:
- Updated 3b section to describe true roundtrip flow

## All 16 Rules — Strategy Mapping

| Strategy | Rules | Count | Source |
|----------|-------|-------|--------|
| A: Property mod (direct) | non-semantic-name, irregular-spacing, fixed-size-in-auto-layout, missing-size-constraint, no-auto-layout | 5 | gotcha survey |
| B: Structural mod (confirm) | non-layout-container, deep-nesting, missing-component, detached-instance | 4 | gotcha survey |
| C: Annotation (gotcha) | absolute-position-in-auto-layout, variant-structure-mismatch | 2 | gotcha survey |
| D: Auto-fix (analysis) | non-standard-naming, inconsistent-naming-convention | 2 | analysis issues |
| D: Annotate (analysis) | raw-value, missing-interaction-state, missing-prototype | 3 | analysis issues |

## Test plan

- [ ] Verify SKILL.md renders correctly in GitHub
- [ ] Test with a real Figma design using `/canicode-roundtrip`
- [ ] Verify `use_figma` property modifications work (naming, spacing, sizing)
- [ ] Verify annotation creation and cleanup
- [ ] Verify Strategy D auto-fixes (naming convention normalization)
- [ ] Verify fallback to one-way flow when no edit permission

Closes #281

🤖 Generated with [Claude Code](https://claude.com/claude-code)