### PR TITLE
feat(gotcha): instance context on survey for instance-child nodes

### DIFF
--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -63,6 +63,13 @@ Core decisions that shape every session. For full history see [GitHub Wiki Decis
 **Why**: One-way flow (analyze → gotcha → code gen) is not a true roundtrip. Applying answers to the design means the next analysis passes without gotchas — the design itself improves. PoC confirmed all three strategies work via Figma Plugin API: `node.name`, `itemSpacing`, `setBoundVariable()`, `layoutSizingHorizontal`, `node.annotations`. Annotations enable designer communication for issues that require manual judgment.
 **Impact**: `canicode-roundtrip` becomes a true roundtrip: analyze → gotcha → apply to Figma → re-analyze → pass → code gen. All 16 rules are covered (modify or annotate). Requires Full seat + file edit permission. See #281.
 
+## ADR-011: Instance-child writes — try scene, then source definition, then annotate
+
+**Decision**: For gotcha apply (`use_figma` / Plugin API), attempt property writes on the scene node from `question.nodeId` first. On instance-override errors, resolve the source definition using `question.instanceContext.sourceNodeId` (and `getMainComponentAsync()` when needed) and apply there **only after explicit user confirmation**, because definition edits propagate to every instance of that component in the file. If the source is in an external library (`mainComponent` null) or the write still fails, fall back to annotations on the scene node.
+**Why**: Roundtrip Experiment 07 showed most violations sit under `INSTANCE` subtrees; many properties (for example `minWidth` / `maxWidth`) cannot be overridden on instance children, so naive `getNodeById` writes stall at D→C-style gains. Server-side `instanceContext` on `gotcha-survey` questions plus this three-tier policy unlocks meaningful fixes without silently reshaping shared components.
+**Impact**: `canicode-roundtrip` SKILL documents the matrix, `applyWithInstanceFallback`, and confirmation for definition-level changes. TypeScript adds `resolveGotchaApplyTarget` for programmatic consumers. See #286 and [Roundtrip Experiment 07](https://github.com/let-sunny/canicode/wiki/Roundtrip-Experiment-2026-04-17).
+**References**: [InstanceNode#mainComponent](https://www.figma.com/plugin-docs/api/InstanceNode/#maincomponent)
+
 ## ADR-008: Calibration pipeline — explicit claude -p orchestration
 
 **Decision**: Replace single-session delegated orchestrator with TypeScript script (`scripts/calibrate.ts`) that explicitly calls CLI commands for deterministic steps and `claude -p` for judgment steps (converter, gap-analyzer, critic, arbitrator). Strip ablation runs 7 parallel sessions. Delete `orchestrator.ts`.

--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -90,6 +90,7 @@ Collected from canicode gotcha survey. Reference these answers when implementing
 
 - **Severity**: {severity}
 - **Node ID**: {nodeId}
+- **Instance context** (omit this bullet if `instanceContext` was not in the survey question): parent instance `parentInstanceNodeId`, source node `sourceNodeId`, component `sourceComponentName` / `sourceComponentId` when present — roundtrip apply uses this to write on the source definition when instance overrides fail.
 - **Question**: {question}
 - **Answer**: {userAnswer}
 
@@ -108,6 +109,7 @@ Collected from canicode gotcha survey. Reference these answers when implementing
 | `nodeName` | `nodeName` from each question |
 | `severity` | `severity` from each question (blocking / risk) |
 | `nodeId` | `nodeId` from each question |
+| `instanceContext` | When present on the question, copy `parentInstanceNodeId`, `sourceNodeId`, `sourceComponentId`, `sourceComponentName` into the bullet above (roundtrip / Plugin apply) |
 | `question` | `question` from each question |
 | `userAnswer` | The answer collected from the user in Step 3 |
 

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -57,7 +57,15 @@ gotcha-survey({ input: "<figma-url>" })
 
 If `questions` is empty, skip to **Step 6**.
 
-For each question in the `questions` array, present it to the user one at a time:
+For each question in the `questions` array, present it to the user one at a time.
+
+Build the message from the question fields. **If `question.instanceContext` is present**, prepend one line before the question body:
+
+```
+_Instance note: This layer is inside an instance. Layout and size fixes may need to be applied on source component **{sourceComponentName or sourceComponentId or "unknown"}** (definition node `sourceNodeId`) and propagate to all instances — you will be asked to confirm before any definition-level write._
+```
+
+Then the standard block:
 
 ```
 **[{severity}] {ruleId}** — node: {nodeName}
@@ -81,50 +89,109 @@ Then proceed to **Step 4** to apply answers to the Figma design.
 
 Extract the `fileKey` from the Figma URL (format: `figma.com/design/:fileKey/...`).
 
-For each answered gotcha (skip questions answered with "skip" or "n/a"), determine the apply strategy based on the `ruleId`:
+For each answered gotcha (skip questions answered with "skip" or "n/a"), determine the apply strategy based on the `ruleId`.
+
+Use the **`nodeId` from the answered question** (same as `gotcha-survey` output). When the question includes **`instanceContext`**, treat layout and size-constraint changes as **high impact**: applying them on the source definition affects **every instance** of that component in the file. Ask for explicit user confirmation before writing to the definition node.
+
+#### Instance-child property overridability (Plugin API)
+
+Most production nodes sit under `INSTANCE` subtrees. Figma uses instance-scoped ids (`I<instanceId>;<innerId>`; nested instances add more `;` segments). The `gotcha-survey` tool adds optional `instanceContext` with `parentInstanceNodeId`, `sourceNodeId`, and (when resolvable) `sourceComponentId` / `sourceComponentName`.
+
+| Property / action | Typical override on instance child? | Notes |
+|-------------------|-------------------------------------|--------|
+| `node.name` | Often yes | Prefer scene node first. |
+| `layoutSizingHorizontal` / `layoutSizingVertical` on the **INSTANCE** root | Yes | Targets the instance node, not deep children. |
+| `annotations` | Often yes | Good fallback when a property cannot be set. |
+| `minWidth`, `maxWidth`, `minHeight`, `maxHeight` | Often **no** | Error text usually mentions instance override — route to **definition** node (`instanceContext.sourceNodeId`) after confirmation. |
+| `layoutMode`, primary layout structure | Often **no** on deep children | Same as above — definition-level change. |
+| `itemSpacing`, padding fields | **Mixed** | Try scene node inside `try/catch`; on failure use definition path after confirmation. |
+
+**Three-tier write policy (Strategy A and compatible parts of D):**
+
+1. **Scene (instance) node** — `await figma.getNodeByIdAsync(question.nodeId)` and apply the write inside `try/catch`. Success → done (local change only). Mark result with ✅.
+2. **Definition (source) node** — If the error indicates the property cannot be overridden in an instance (or closely related wording), load `await figma.getNodeByIdAsync(question.instanceContext.sourceNodeId)`. If that is null, walk from the scene node to the nearest `INSTANCE` parent and use `await instance.getMainComponentAsync()`, then find the matching layer by id or name path inside that component. **Ask the user to confirm** before mutating the definition — changes propagate to **all** instances. Mark result with 🌐.
+3. **Annotation fallback** — If `mainComponent` is null (common for **external published libraries**) or the write still fails, add a `labelMarkdown` annotation on the **scene** node documenting the answer and limitation. Mark result with 📝.
+
+**Shared helper pattern** (adapt per `use_figma` batch — keep each `writeFn` small so a throw does not abort unrelated writes):
+
+```javascript
+async function applyWithInstanceFallback(question, writeFn) {
+  const scene = await figma.getNodeByIdAsync(question.nodeId);
+  if (!scene) return { icon: "📝", label: "missing node" };
+
+  const definitionId = question.instanceContext?.sourceNodeId;
+  const definition = definitionId
+    ? await figma.getNodeByIdAsync(definitionId)
+    : null;
+
+  try {
+    await writeFn(scene);
+    return { icon: "✅", label: "instance/scene" };
+  } catch (e) {
+    const msg = String(e && e.message ? e.message : e);
+    const looksLikeInstanceOverride =
+      /instance/i.test(msg) ||
+      /override/i.test(msg) ||
+      /cannot be overridden/i.test(msg);
+    if (!looksLikeInstanceOverride || !definition) {
+      return { icon: "📝", label: "error: " + msg };
+    }
+    // Orchestrator: pause here, ask user to confirm propagation to all instances, then:
+    await writeFn(definition);
+    return { icon: "🌐", label: "source definition" };
+  }
+}
+```
+
+In the Strategy snippets below, treat `"nodeId"` as `question.nodeId` from the answered gotcha. Prefer `await figma.getNodeByIdAsync(...)` over the sync API. **Wrap property writes** in `applyWithInstanceFallback(question, async (target) => { ... })` (or equivalent) whenever `question.instanceContext` exists or the id starts with `I` and contains `;`.
 
 #### Strategy A: Property Modification — apply directly
 
-These rules have straightforward property changes. Apply without additional confirmation. Parse the user's answer to extract the target values.
+These rules have straightforward property changes. Parse the user's answer to extract target values. **Still use** `applyWithInstanceFallback` when instance children are involved so failed overrides route to definition or annotation instead of failing the whole batch silently.
 
 **`non-semantic-name`** — Rename the node to the answer:
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node) node.name = "hero-section";
+await applyWithInstanceFallback(question, async (target) => {
+  if (target) target.name = "hero-section";
+});
 ```
 
 **`irregular-spacing`** — Fix spacing to the grid-aligned value from the answer:
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node && "itemSpacing" in node) node.itemSpacing = 16;
-// For padding: node.paddingTop = 8; node.paddingBottom = 8; etc.
+await applyWithInstanceFallback(question, async (target) => {
+  if (target && "itemSpacing" in target) target.itemSpacing = 16;
+  // For padding: target.paddingTop = 8; target.paddingBottom = 8; etc.
+});
 ```
 
 **`fixed-size-in-auto-layout`** — Change sizing mode per the answer (FILL, HUG, or FIXED):
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node && "layoutSizingHorizontal" in node) {
-  node.layoutSizingHorizontal = "FILL"; // or "HUG" or "FIXED"
-}
+await applyWithInstanceFallback(question, async (target) => {
+  if (target && "layoutSizingHorizontal" in target) {
+    target.layoutSizingHorizontal = "FILL"; // or "HUG" or "FIXED"
+  }
+});
 ```
 
 **`missing-size-constraint`** — Set min/max constraints from the answer:
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node && "minWidth" in node) {
-  node.minWidth = 320;  // from answer
-  node.maxWidth = 1200; // from answer, if provided
-}
+await applyWithInstanceFallback(question, async (target) => {
+  if (target && "minWidth" in target) {
+    target.minWidth = 320;  // from answer
+    target.maxWidth = 1200; // from answer, if provided
+  }
+});
 ```
 
 **`no-auto-layout`** — Set layout mode, direction, and spacing from the answer:
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node && "layoutMode" in node) {
-  node.layoutMode = "VERTICAL"; // or "HORIZONTAL"
-  node.itemSpacing = 16;
-  // Optionally set padding, alignment from the answer
-}
+await applyWithInstanceFallback(question, async (target) => {
+  if (target && "layoutMode" in target) {
+    target.layoutMode = "VERTICAL"; // or "HORIZONTAL"
+    target.itemSpacing = 16;
+    // Optionally set padding, alignment from the answer
+  }
+});
 ```
 
 #### Strategy B: Structural Modification — confirm with user first
@@ -135,11 +202,12 @@ These rules change the design structure. Show the proposed change and **ask for 
 - Prompt: "I'll convert **{nodeName}** to an Auto Layout frame with {direction} layout and {spacing}px gap. Proceed?"
 - If confirmed:
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node && "layoutMode" in node) {
-  node.layoutMode = "VERTICAL";
-  node.itemSpacing = 12;
-}
+await applyWithInstanceFallback(question, async (target) => {
+  if (target && "layoutMode" in target) {
+    target.layoutMode = "VERTICAL";
+    target.itemSpacing = 12;
+  }
+});
 ```
 
 **`deep-nesting`** — Flatten intermediate wrappers or extract sub-component:
@@ -150,9 +218,9 @@ if (node && "layoutMode" in node) {
 - Prompt: "I'll convert **{nodeName}** to a reusable component. Proceed?"
 - If confirmed:
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node && node.type === "FRAME") {
-  figma.createComponentFromNode(node);
+const scene = await figma.getNodeByIdAsync(question.nodeId);
+if (scene && scene.type === "FRAME") {
+  figma.createComponentFromNode(scene);
 }
 ```
 
@@ -169,15 +237,15 @@ These rules cannot be auto-fixed via Plugin API. Add the gotcha answer as a Figm
 **Rules from gotcha survey**: `absolute-position-in-auto-layout`, `variant-structure-mismatch`
 
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node && "annotations" in node) {
-  node.annotations = [...(node.annotations || []), {
+const scene = await figma.getNodeByIdAsync(question.nodeId);
+if (scene && "annotations" in scene) {
+  scene.annotations = [...(scene.annotations || []), {
     labelMarkdown: "**[canicode] {ruleId}**\n\n**Q:** {question}\n**A:** {answer}"
   }];
 }
 ```
 
-Important: use `labelMarkdown` only — `label` and `labelMarkdown` are mutually exclusive. Preserve existing annotations by spreading `node.annotations`.
+Important: use `labelMarkdown` only — `label` and `labelMarkdown` are mutually exclusive. Preserve existing annotations by spreading `scene.annotations`. Prefer annotating the **scene** instance child so designers see the note where they work; mention in the markdown if the fix belongs on the source component but could not be applied (library/external).
 
 #### Strategy D: Auto-fix lower-severity issues from analysis
 
@@ -187,15 +255,19 @@ The gotcha survey only covers blocking/risk severity (11 rules). The remaining 5
 
 **`non-standard-naming`** — The analysis identifies non-standard state names. Rename to the standard equivalent:
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node) node.name = "Hover"; // standardize from "hover_v1", "on_hover", etc.
+const q = { nodeId: violation.nodeId, instanceContext: undefined };
+await applyWithInstanceFallback(q, async (target) => {
+  if (target) target.name = "Hover"; // standardize from "hover_v1", "on_hover", etc.
+});
 ```
 Standard state names: Default, Hover, Active, Pressed, Selected, Highlighted, Disabled, Enabled, Focus, Focused, Dragged.
 
 **`inconsistent-naming-convention`** — The analysis identifies the dominant convention among siblings. Rename minority nodes to match:
 ```javascript
-const node = figma.getNodeById("nodeId");
-if (node) node.name = "CardTitle"; // convert to dominant convention (e.g., PascalCase)
+const q = { nodeId: violation.nodeId, instanceContext: undefined };
+await applyWithInstanceFallback(q, async (target) => {
+  if (target) target.name = "CardTitle"; // convert to dominant convention (e.g., PascalCase)
+});
 ```
 
 **Annotate** — these require designer judgment, no auto-fix possible:
@@ -232,7 +304,8 @@ After applying, report what was done:
 
 ```
 Applied {N} changes to the Figma design:
-- ✅ {nodeName}: renamed to "hero-section" (non-semantic-name)
+- ✅ {nodeName}: renamed to "hero-section" (non-semantic-name) — scene/instance override
+- 🌐 {nodeName}: minWidth applied on source definition (missing-size-constraint) — propagates to all instances
 - ✅ {nodeName}: itemSpacing → 16px (irregular-spacing)
 - ⏭️ {nodeName}: declined by user, added annotation (deep-nesting)
 - 📝 {nodeName}: annotation added (absolute-position-in-auto-layout)
@@ -295,3 +368,4 @@ Follow the **figma-implement-design** skill workflow to generate code from the F
 - **use_figma call fails for a node**: Report the error for that specific node, continue with other nodes. Failed property modifications become annotations so the context is not lost.
 - **Re-analyze shows new issues**: Only address issues from the original gotcha survey. New issues may appear due to structural changes — report them but do not re-enter the gotcha loop.
 - **Very large design (many gotchas)**: The gotcha survey already deduplicates sibling nodes and filters to blocking/risk severity only. If there are still many questions, ask the user if they want to focus on blocking issues only.
+- **External library components**: When `getMainComponentAsync()` returns `null`, the source lives in a published library this file only references — there is no supported path to edit it from the current file via Plugin API. Use the annotation fallback on the scene node and state that limitation explicitly in `labelMarkdown`.

--- a/src/core/adapters/index.ts
+++ b/src/core/adapters/index.ts
@@ -1,6 +1,7 @@
 // Adapters module - External service integrations (Figma API, etc.)
 
 export * from "./figma-url-parser.js";
+export * from "./instance-id-parser.js";
 export * from "./figma-client.js";
 export * from "./figma-transformer.js";
 export * from "./figma-file-loader.js";

--- a/src/core/adapters/instance-id-parser.test.ts
+++ b/src/core/adapters/instance-id-parser.test.ts
@@ -1,0 +1,56 @@
+import {
+  isInstanceChildNodeId,
+  parseInstanceChildNodeId,
+} from "./instance-id-parser.js";
+
+describe("isInstanceChildNodeId", () => {
+  it("returns false for plain Figma node ids", () => {
+    expect(isInstanceChildNodeId("348:15903")).toBe(false);
+  });
+
+  it("returns false for ids that start with I but have no semicolon", () => {
+    expect(isInstanceChildNodeId("Iceberg")).toBe(false);
+  });
+
+  it("returns true for simple instance-child ids", () => {
+    expect(isInstanceChildNodeId("I348:15903;2153:7840")).toBe(true);
+  });
+
+  it("returns true for nested instance-child ids", () => {
+    expect(isInstanceChildNodeId("I348:15903;1442:7704;2153:7840")).toBe(true);
+  });
+});
+
+describe("parseInstanceChildNodeId", () => {
+  it("returns null for plain Figma node ids", () => {
+    expect(parseInstanceChildNodeId("348:15903")).toBeNull();
+  });
+
+  it("returns null for malformed I-prefixed ids without a semicolon", () => {
+    expect(parseInstanceChildNodeId("I348:15903")).toBeNull();
+  });
+
+  it("splits a simple instance-child id into parent + source", () => {
+    expect(parseInstanceChildNodeId("I348:15903;2153:7840")).toEqual({
+      parentInstanceId: "348:15903",
+      sourceNodeId: "2153:7840",
+    });
+  });
+
+  it("takes the LAST segment as source for nested instance ids", () => {
+    expect(
+      parseInstanceChildNodeId("I348:15903;1442:7704;2153:7840"),
+    ).toEqual({
+      parentInstanceId: "348:15903",
+      sourceNodeId: "2153:7840",
+    });
+  });
+
+  it("returns null when the source segment is empty", () => {
+    expect(parseInstanceChildNodeId("I348:15903;")).toBeNull();
+  });
+
+  it("returns null when the parent segment is empty after stripping I", () => {
+    expect(parseInstanceChildNodeId("I;2153:7840")).toBeNull();
+  });
+});

--- a/src/core/adapters/instance-id-parser.ts
+++ b/src/core/adapters/instance-id-parser.ts
@@ -1,0 +1,40 @@
+/**
+ * Parse Figma instance-child node IDs.
+ *
+ * Nodes inside an instance carry an `I`-prefixed id with semicolon-separated
+ * path segments: `I<parentInstanceId>;<sourceNodeId>`. For nested instances
+ * the format chains further, e.g. `I<parentId>;<midId>;<sourceNodeId>` —
+ * each `;` represents one additional level of instance expansion. The LAST
+ * segment is always the id of the node inside the innermost source component,
+ * which is reachable directly via `figma.getNodeById`.
+ *
+ * Siblings: `figma-url-parser.ts#toCommentableNodeId` handles the same id
+ * format for a different purpose (stripping for the Comments API). That
+ * helper is intentionally left alone — this module owns id parsing for the
+ * apply pipeline.
+ */
+
+export interface InstanceChildIdParts {
+  parentInstanceId: string;
+  sourceNodeId: string;
+}
+
+export function isInstanceChildNodeId(nodeId: string): boolean {
+  return nodeId.startsWith("I") && nodeId.includes(";");
+}
+
+export function parseInstanceChildNodeId(
+  nodeId: string,
+): InstanceChildIdParts | null {
+  if (!isInstanceChildNodeId(nodeId)) return null;
+
+  const segments = nodeId.split(";");
+  if (segments.length < 2) return null;
+
+  const parentInstanceId = segments[0]!.replace(/^I/, "");
+  const sourceNodeId = segments[segments.length - 1]!;
+
+  if (!parentInstanceId || !sourceNodeId) return null;
+
+  return { parentInstanceId, sourceNodeId };
+}

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -3,6 +3,15 @@ import { SeveritySchema } from "./severity.js";
 
 const GradeSchema = z.enum(["S", "A+", "A", "B+", "B", "C+", "C", "D", "F"]);
 
+export const InstanceContextSchema = z.object({
+  parentInstanceNodeId: z.string(),
+  sourceNodeId: z.string(),
+  sourceComponentId: z.string().optional(),
+  sourceComponentName: z.string().optional(),
+});
+
+export type InstanceContext = z.infer<typeof InstanceContextSchema>;
+
 export const GotchaSurveyQuestionSchema = z.object({
   nodeId: z.string(),
   nodeName: z.string(),
@@ -11,6 +20,7 @@ export const GotchaSurveyQuestionSchema = z.object({
   question: z.string(),
   hint: z.string(),
   example: z.string(),
+  instanceContext: InstanceContextSchema.optional(),
 });
 
 export type GotchaSurveyQuestion = z.infer<typeof GotchaSurveyQuestionSchema>;

--- a/src/core/gotcha/resolve-apply-target.test.ts
+++ b/src/core/gotcha/resolve-apply-target.test.ts
@@ -1,0 +1,44 @@
+import { resolveGotchaApplyTarget } from "./resolve-apply-target.js";
+
+describe("resolveGotchaApplyTarget", () => {
+  it("returns plain scene target without definition for normal node ids", () => {
+    const r = resolveGotchaApplyTarget("348:15903", undefined);
+    expect(r).toEqual({
+      sceneNodeId: "348:15903",
+      definitionNodeId: undefined,
+      shouldPreferDefinitionForLayoutProps: false,
+      guidance: "",
+    });
+  });
+
+  it("prefers definition path when instanceContext is present", () => {
+    const r = resolveGotchaApplyTarget("I348:15903;2153:7840", {
+      parentInstanceNodeId: "348:15903",
+      sourceNodeId: "2153:7840",
+      sourceComponentId: "C:1",
+      sourceComponentName: "Card",
+    });
+    expect(r.sceneNodeId).toBe("I348:15903;2153:7840");
+    expect(r.definitionNodeId).toBe("2153:7840");
+    expect(r.shouldPreferDefinitionForLayoutProps).toBe(true);
+    expect(r.guidance).toContain("2153:7840");
+    expect(r.guidance).toContain("Card");
+    expect(r.guidance).toContain("348:15903");
+  });
+
+  it("uses generic component label when sourceComponentName is missing", () => {
+    const r = resolveGotchaApplyTarget("I1:1;2:2", {
+      parentInstanceNodeId: "1:1",
+      sourceNodeId: "2:2",
+    });
+    expect(r.definitionNodeId).toBe("2:2");
+    expect(r.guidance).toContain("the source component");
+  });
+
+  it("detects instance-child ids even without instanceContext", () => {
+    const r = resolveGotchaApplyTarget("I348:15903;2153:7840", undefined);
+    expect(r.definitionNodeId).toBeUndefined();
+    expect(r.shouldPreferDefinitionForLayoutProps).toBe(true);
+    expect(r.guidance).toContain("instanceContext");
+  });
+});

--- a/src/core/gotcha/resolve-apply-target.test.ts
+++ b/src/core/gotcha/resolve-apply-target.test.ts
@@ -6,6 +6,7 @@ describe("resolveGotchaApplyTarget", () => {
     expect(r).toEqual({
       sceneNodeId: "348:15903",
       definitionNodeId: undefined,
+      strategy: "scene-only",
       shouldPreferDefinitionForLayoutProps: false,
       guidance: "",
     });
@@ -20,9 +21,10 @@ describe("resolveGotchaApplyTarget", () => {
     });
     expect(r.sceneNodeId).toBe("I348:15903;2153:7840");
     expect(r.definitionNodeId).toBe("2153:7840");
+    expect(r.strategy).toBe("prefer-definition");
     expect(r.shouldPreferDefinitionForLayoutProps).toBe(true);
     expect(r.guidance).toContain("2153:7840");
-    expect(r.guidance).toContain("Card");
+    expect(r.guidance).toContain("inside component Card");
     expect(r.guidance).toContain("348:15903");
   });
 
@@ -32,12 +34,14 @@ describe("resolveGotchaApplyTarget", () => {
       sourceNodeId: "2:2",
     });
     expect(r.definitionNodeId).toBe("2:2");
-    expect(r.guidance).toContain("the source component");
+    expect(r.strategy).toBe("prefer-definition");
+    expect(r.guidance).toContain("inside the source component");
   });
 
   it("detects instance-child ids even without instanceContext", () => {
     const r = resolveGotchaApplyTarget("I348:15903;2153:7840", undefined);
     expect(r.definitionNodeId).toBeUndefined();
+    expect(r.strategy).toBe("definition-unknown");
     expect(r.shouldPreferDefinitionForLayoutProps).toBe(true);
     expect(r.guidance).toContain("instanceContext");
   });

--- a/src/core/gotcha/resolve-apply-target.ts
+++ b/src/core/gotcha/resolve-apply-target.ts
@@ -1,0 +1,64 @@
+import type { InstanceContext } from "../contracts/gotcha-survey.js";
+import { isInstanceChildNodeId } from "../adapters/instance-id-parser.js";
+
+/**
+ * Resolved targets for applying gotcha fixes in Figma (Plugin API or MCP `use_figma`).
+ *
+ * Survey questions may include `instanceContext` when the violation `nodeId` is an
+ * instance-child id (`I...;...`). Property overrides often fail on those scene nodes;
+ * the definition node id is the usual write target after user confirmation.
+ */
+export type GotchaApplyResolution = {
+  /** Scene node id from the survey (`question.nodeId`). */
+  sceneNodeId: string;
+  /** Source definition node id from `instanceContext.sourceNodeId`, when known. */
+  definitionNodeId: string | undefined;
+  /**
+   * When true, layout and size-constraint style writes should use the definition path
+   * (after explicit user confirmation) because instance overrides are commonly rejected.
+   */
+  shouldPreferDefinitionForLayoutProps: boolean;
+  /** Human-readable note for skills, UI, or logs. */
+  guidance: string;
+};
+
+/**
+ * Resolve which node ids and policy apply for a gotcha survey question.
+ */
+export function resolveGotchaApplyTarget(
+  nodeId: string,
+  instanceContext: InstanceContext | undefined,
+): GotchaApplyResolution {
+  if (instanceContext) {
+    const label = instanceContext.sourceComponentName ?? "the source component";
+    return {
+      sceneNodeId: nodeId,
+      definitionNodeId: instanceContext.sourceNodeId,
+      shouldPreferDefinitionForLayoutProps: true,
+      guidance:
+        `This question targets a node inside an instance. Overrides may fail on the scene node. ` +
+        `For layout and min/max sizing, apply changes on definition node ${instanceContext.sourceNodeId} ` +
+        `in ${label} (parent instance ${instanceContext.parentInstanceNodeId}). ` +
+        `Confirm with the user first — definition edits propagate to every instance of that component in the file.`,
+    };
+  }
+
+  if (isInstanceChildNodeId(nodeId)) {
+    return {
+      sceneNodeId: nodeId,
+      definitionNodeId: undefined,
+      shouldPreferDefinitionForLayoutProps: true,
+      guidance:
+        "The node id looks like a Figma instance child (`I...;...`) but no `instanceContext` was attached. " +
+        "Parse the segment after the last `;` as the source definition id, resolve the parent INSTANCE, " +
+        "and use `getMainComponentAsync()` when `figma.getNodeById(sourceId)` is not enough (e.g. nested instances).",
+    };
+  }
+
+  return {
+    sceneNodeId: nodeId,
+    definitionNodeId: undefined,
+    shouldPreferDefinitionForLayoutProps: false,
+    guidance: "",
+  };
+}

--- a/src/core/gotcha/resolve-apply-target.ts
+++ b/src/core/gotcha/resolve-apply-target.ts
@@ -2,6 +2,21 @@ import type { InstanceContext } from "../contracts/gotcha-survey.js";
 import { isInstanceChildNodeId } from "../adapters/instance-id-parser.js";
 
 /**
+ * Write strategy for a gotcha apply target. Consumers can branch on this enum
+ * without parsing the human-readable `guidance` string.
+ *
+ * - `scene-only`: plain scene node id, no instance handling needed.
+ * - `prefer-definition`: instance-child id + resolved `instanceContext`; layout
+ *   and min/max writes should go to the definition node after user confirmation.
+ * - `definition-unknown`: instance-child id but `instanceContext` is missing;
+ *   caller must resolve the source component at runtime.
+ */
+export type GotchaApplyStrategy =
+  | "scene-only"
+  | "prefer-definition"
+  | "definition-unknown";
+
+/**
  * Resolved targets for applying gotcha fixes in Figma (Plugin API or MCP `use_figma`).
  *
  * Survey questions may include `instanceContext` when the violation `nodeId` is an
@@ -13,12 +28,18 @@ export type GotchaApplyResolution = {
   sceneNodeId: string;
   /** Source definition node id from `instanceContext.sourceNodeId`, when known. */
   definitionNodeId: string | undefined;
+  /** Machine-readable write strategy — branch on this from TS consumers. */
+  strategy: GotchaApplyStrategy;
   /**
    * When true, layout and size-constraint style writes should use the definition path
    * (after explicit user confirmation) because instance overrides are commonly rejected.
    */
   shouldPreferDefinitionForLayoutProps: boolean;
-  /** Human-readable note for skills, UI, or logs. */
+  /**
+   * Human-readable note for skills, UI, or logs. Skill-oriented (may reference
+   * Plugin API calls like `getMainComponentAsync`). TS consumers should branch
+   * on `strategy` instead of parsing this string.
+   */
   guidance: string;
 };
 
@@ -30,15 +51,18 @@ export function resolveGotchaApplyTarget(
   instanceContext: InstanceContext | undefined,
 ): GotchaApplyResolution {
   if (instanceContext) {
-    const label = instanceContext.sourceComponentName ?? "the source component";
+    const componentPhrase = instanceContext.sourceComponentName
+      ? `inside component ${instanceContext.sourceComponentName}`
+      : "inside the source component";
     return {
       sceneNodeId: nodeId,
       definitionNodeId: instanceContext.sourceNodeId,
+      strategy: "prefer-definition",
       shouldPreferDefinitionForLayoutProps: true,
       guidance:
         `This question targets a node inside an instance. Overrides may fail on the scene node. ` +
-        `For layout and min/max sizing, apply changes on definition node ${instanceContext.sourceNodeId} ` +
-        `in ${label} (parent instance ${instanceContext.parentInstanceNodeId}). ` +
+        `For layout and min/max sizing, apply changes on node ${instanceContext.sourceNodeId} ` +
+        `${componentPhrase} (parent instance ${instanceContext.parentInstanceNodeId}). ` +
         `Confirm with the user first — definition edits propagate to every instance of that component in the file.`,
     };
   }
@@ -47,6 +71,7 @@ export function resolveGotchaApplyTarget(
     return {
       sceneNodeId: nodeId,
       definitionNodeId: undefined,
+      strategy: "definition-unknown",
       shouldPreferDefinitionForLayoutProps: true,
       guidance:
         "The node id looks like a Figma instance child (`I...;...`) but no `instanceContext` was attached. " +
@@ -58,6 +83,7 @@ export function resolveGotchaApplyTarget(
   return {
     sceneNodeId: nodeId,
     definitionNodeId: undefined,
+    strategy: "scene-only",
     shouldPreferDefinitionForLayoutProps: false,
     guidance: "",
   };

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -58,8 +58,14 @@ function makeIssue(opts: {
   };
 }
 
-function makeResult(issues: AnalysisIssue[]): AnalysisResult {
-  const doc: AnalysisNode = {
+function makeResult(
+  issues: AnalysisIssue[],
+  fileOverrides?: {
+    document?: AnalysisNode;
+    components?: AnalysisFile["components"];
+  },
+): AnalysisResult {
+  const doc: AnalysisNode = fileOverrides?.document ?? {
     id: "0:1",
     name: "Document",
     type: "DOCUMENT",
@@ -71,7 +77,7 @@ function makeResult(issues: AnalysisIssue[]): AnalysisResult {
     lastModified: "",
     version: "1",
     document: doc,
-    components: {},
+    components: fileOverrides?.components ?? {},
     styles: {},
   };
   return {
@@ -364,6 +370,131 @@ describe("generateGotchaSurvey", () => {
 
     const result = GotchaSurveySchema.safeParse(survey);
     expect(result.success).toBe(true);
+  });
+
+  describe("instanceContext", () => {
+    it("omits instanceContext for non-instance node ids", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "no-auto-layout",
+          category: "pixel-critical",
+          severity: "blocking",
+          nodeId: "1:1",
+          nodePath: "Root > Hero",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.instanceContext).toBeUndefined();
+    });
+
+    it("resolves source component name when parent instance is in tree", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "no-auto-layout",
+          category: "pixel-critical",
+          severity: "blocking",
+          nodeId: "I348:15903;2153:7840",
+          nodePath: "Root > Card > Inner",
+        }),
+      ];
+
+      const document: AnalysisNode = {
+        id: "0:1",
+        name: "Document",
+        type: "DOCUMENT",
+        visible: true,
+        children: [
+          {
+            id: "348:15903",
+            name: "Card Instance",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+        ],
+      };
+      const components = {
+        "C:1": { key: "key1", name: "CardComponent", description: "" },
+      };
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, { document, components }),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.instanceContext).toEqual({
+        parentInstanceNodeId: "348:15903",
+        sourceNodeId: "2153:7840",
+        sourceComponentId: "C:1",
+        sourceComponentName: "CardComponent",
+      });
+    });
+
+    it("falls back to parent/source ids when parent instance not in tree", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "no-auto-layout",
+          category: "pixel-critical",
+          severity: "blocking",
+          nodeId: "I348:15903;2153:7840",
+          nodePath: "Root > Hero",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.instanceContext).toEqual({
+        parentInstanceNodeId: "348:15903",
+        sourceNodeId: "2153:7840",
+      });
+    });
+
+    it("output with instanceContext passes GotchaSurveySchema validation", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "no-auto-layout",
+          category: "pixel-critical",
+          severity: "blocking",
+          nodeId: "I348:15903;2153:7840",
+          nodePath: "Root > Hero",
+        }),
+      ];
+
+      const document: AnalysisNode = {
+        id: "0:1",
+        name: "Document",
+        type: "DOCUMENT",
+        visible: true,
+        children: [
+          {
+            id: "348:15903",
+            name: "Card Instance",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+        ],
+      };
+      const components = {
+        "C:1": { key: "key1", name: "CardComponent", description: "" },
+      };
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, { document, components }),
+        makeScoreReport("D"),
+      );
+
+      const result = GotchaSurveySchema.safeParse(survey);
+      expect(result.success).toBe(true);
+    });
   });
 
   it("sets isReadyForCodeGen based on grade", () => {

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -1,9 +1,15 @@
 import type { AnalysisResult, AnalysisIssue } from "../engine/rule-engine.js";
 import type { ScoreReport } from "../engine/scoring.js";
 import { isReadyForCodeGen } from "../engine/scoring.js";
-import type { GotchaSurvey, GotchaSurveyQuestion } from "../contracts/gotcha-survey.js";
+import type {
+  GotchaSurvey,
+  GotchaSurveyQuestion,
+  InstanceContext,
+} from "../contracts/gotcha-survey.js";
+import type { AnalysisFile, AnalysisNode } from "../contracts/figma-node.js";
 import type { RuleId } from "../contracts/rule.js";
 import { GOTCHA_QUESTIONS } from "../rules/gotcha-questions.js";
+import { parseInstanceChildNodeId } from "../adapters/instance-id-parser.js";
 
 const NODE_PATH_SEPARATOR = " > ";
 
@@ -34,7 +40,7 @@ export function generateGotchaSurvey(
 
   // Step 4: Map to survey questions
   const questions = sorted
-    .map((issue) => mapToQuestion(issue))
+    .map((issue) => mapToQuestion(issue, result.file))
     .filter((q): q is GotchaSurveyQuestion => q !== null);
 
   return {
@@ -109,12 +115,16 @@ function stableSortBySeverity(issues: AnalysisIssue[]): AnalysisIssue[] {
  * Map an AnalysisIssue to a GotchaSurveyQuestion using the GOTCHA_QUESTIONS table.
  * Returns null if no mapping exists for the ruleId.
  */
-function mapToQuestion(issue: AnalysisIssue): GotchaSurveyQuestion | null {
+function mapToQuestion(
+  issue: AnalysisIssue,
+  file: AnalysisFile,
+): GotchaSurveyQuestion | null {
   const ruleId = issue.violation.ruleId as RuleId;
   const template = GOTCHA_QUESTIONS[ruleId];
   if (!template) return null;
 
   const nodeName = getNodeName(issue.violation.nodePath);
+  const instanceContext = buildInstanceContext(issue.violation.nodeId, file);
 
   return {
     nodeId: issue.violation.nodeId,
@@ -124,5 +134,47 @@ function mapToQuestion(issue: AnalysisIssue): GotchaSurveyQuestion | null {
     question: template.question.replace("{nodeName}", nodeName),
     hint: template.hint,
     example: template.example,
+    ...(instanceContext ? { instanceContext } : {}),
   };
+}
+
+/**
+ * Build instance context for a node id when it lives inside an instance.
+ * Resolves source component name via the parent instance's componentId when
+ * the parent is reachable in the analyzed subtree; falls back to the bare
+ * parent/source ids otherwise so the apply pipeline can still resolve the
+ * source component at runtime via `figma.getNodeById`.
+ */
+function buildInstanceContext(
+  nodeId: string,
+  file: AnalysisFile,
+): InstanceContext | null {
+  const parts = parseInstanceChildNodeId(nodeId);
+  if (!parts) return null;
+
+  const parentInstance = findNodeById(file.document, parts.parentInstanceId);
+  const componentId = parentInstance?.componentId;
+  const componentName = componentId ? file.components[componentId]?.name : undefined;
+
+  return {
+    parentInstanceNodeId: parts.parentInstanceId,
+    sourceNodeId: parts.sourceNodeId,
+    ...(componentId ? { sourceComponentId: componentId } : {}),
+    ...(componentName ? { sourceComponentName: componentName } : {}),
+  };
+}
+
+/**
+ * Walk the document tree for a node id (exact match — no `-`/`:` normalization;
+ * instance node ids natively use `:` and the input here is already in that form).
+ */
+function findNodeById(node: AnalysisNode, id: string): AnalysisNode | null {
+  if (node.id === id) return node;
+  if (node.children) {
+    for (const child of node.children) {
+      const found = findNodeById(child, id);
+      if (found) return found;
+    }
+  }
+  return null;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,3 +3,4 @@
 export * from "./engine/rule-engine.js";
 export * from "./engine/scoring.js";
 export * from "./design-tree/index.js";
+export * from "./gotcha/resolve-apply-target.js";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,3 +4,4 @@ export * from "./engine/rule-engine.js";
 export * from "./engine/scoring.js";
 export * from "./design-tree/index.js";
 export * from "./gotcha/resolve-apply-target.js";
+export type { InstanceContext } from "./contracts/gotcha-survey.js";


### PR DESCRIPTION
## Summary

Completes the **#286** develop plan (`logs/develop/286--2026-04-17-0902/plan.json` — local run dir, gitignored):

1. **Instance-child id parser** + tests (`src/core/adapters/instance-id-parser.ts`)
2. **GotchaSurveyQuestion.instanceContext** (Zod + survey generator + tests) — already on branch
3. **`resolveGotchaApplyTarget()`** + tests; exported from `src/core/index.ts`; **`instance-id-parser`** re-exported from adapters barrel
4. **`canicode-roundtrip` SKILL** — overridability matrix, `applyWithInstanceFallback`, user confirmation before definition writes, Step 3 instance note, reporting icons (✅ / 🌐 / 📝), external-library edge case
5. **`canicode-gotchas` SKILL** — optional instance context in saved Q\&A template
6. **ADR-011** — three-tier write policy (scene → definition with confirm → annotate)

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test:run`
- [x] `pnpm build`

## Develop pipeline

Run directory `286--2026-04-17-0902`: `index.json` updated locally to **completed** (plan → verify); artifacts `test-result.json`, `review.json`, `circuit.json`, `implement-log.json`, `pr-url.txt` — same folder, not committed (`logs/` gitignored).

Refs #286