### PR TITLE
refactor: extract deterministic roundtrip logic from SKILL.md

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -89,27 +89,40 @@ Then proceed to **Step 4** to apply answers to the Figma design.
 
 Extract the `fileKey` from the Figma URL (format: `figma.com/design/:fileKey/...`).
 
-For each answered gotcha (skip questions answered with "skip" or "n/a"), determine the apply strategy based on the `ruleId`.
+For each answered gotcha (skip questions answered with "skip" or "n/a"), branch on the pre-computed `question.applyStrategy`. The routing table, target properties, and instance-child resolution are resolved server-side by `canicode` — do NOT re-derive them from the rule id.
 
-Use the **`nodeId` from the answered question** (same as `gotcha-survey` output). When the question includes **`instanceContext`**, treat layout and size-constraint changes as **high impact**: applying them on the source definition affects **every instance** of that component in the file. Ask for explicit user confirmation before writing to the definition node.
+Use the **`nodeId` from the answered question**. When `question.isInstanceChild` is `true`, treat layout and size-constraint changes as **high impact**: applying them on the source definition affects **every instance** of that component in the file. Ask for explicit user confirmation before writing to the definition node.
+
+#### Input shape from canicode
+
+Every gotcha-survey question (and every entry in `analyzeResult.issues[]`) carries these pre-computed fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `applyStrategy` | `"property-mod"` \| `"structural-mod"` \| `"annotation"` \| `"auto-fix"` | Which strategy branch to enter (A/B/C/D). |
+| `targetProperty` | `string` \| `string[]` \| (absent) | Figma Plugin-API property to write. Array when multiple properties move together (e.g. `no-auto-layout` → `["layoutMode", "itemSpacing"]`). Absent for structural/annotation rules. |
+| `suggestedName` | `string` \| (absent) | Naming rules only — pre-capitalized value to write to `node.name` (e.g. `"Hover"`). |
+| `isInstanceChild` | `boolean` | Whether the `nodeId` targets a node inside an INSTANCE subtree. |
+| `sourceChildId` | `string` \| (absent) | Definition node id inside the source component. Use directly with `figma.getNodeByIdAsync`. |
+| `instanceContext` | object \| (absent) | Survey questions only. `{ parentInstanceNodeId, sourceNodeId, sourceComponentId?, sourceComponentName? }` for the Step 3 user-facing note. |
 
 #### Instance-child property overridability (Plugin API)
 
-Most production nodes sit under `INSTANCE` subtrees. Figma uses instance-scoped ids (`I<instanceId>;<innerId>`; nested instances add more `;` segments). The `gotcha-survey` tool adds optional `instanceContext` with `parentInstanceNodeId`, `sourceNodeId`, and (when resolvable) `sourceComponentId` / `sourceComponentName`.
+Most production nodes sit under `INSTANCE` subtrees. `canicode` flags these via `question.isInstanceChild` and, when resolvable, surfaces the definition node id as `question.sourceChildId` plus extra metadata on `question.instanceContext`. You do not need to parse node ids.
 
 | Property / action | Typical override on instance child? | Notes |
 |-------------------|-------------------------------------|--------|
 | `node.name` | Often yes | Prefer scene node first. |
 | `layoutSizingHorizontal` / `layoutSizingVertical` on the **INSTANCE** root | Yes | Targets the instance node, not deep children. |
 | `annotations` | Often yes | Good fallback when a property cannot be set. |
-| `minWidth`, `maxWidth`, `minHeight`, `maxHeight` | Often **no** | Error text usually mentions instance override — route to **definition** node (`instanceContext.sourceNodeId`) after confirmation. |
+| `minWidth`, `maxWidth`, `minHeight`, `maxHeight` | Often **no** | Error text usually mentions instance override — route to definition node (`question.sourceChildId`) after confirmation. |
 | `layoutMode`, primary layout structure | Often **no** on deep children | Same as above — definition-level change. |
 | `itemSpacing`, padding fields | **Mixed** | Try scene node inside `try/catch`; on failure use definition path after confirmation. |
 
-**Three-tier write policy (Strategy A and compatible parts of D):**
+**Three-tier write policy:**
 
 1. **Scene (instance) node** — `await figma.getNodeByIdAsync(question.nodeId)` and apply the write inside `try/catch`. Success → done (local change only). Mark result with ✅.
-2. **Definition (source) node** — If the error indicates the property cannot be overridden in an instance (or closely related wording), load `await figma.getNodeByIdAsync(question.instanceContext.sourceNodeId)`. If that is null, walk from the scene node to the nearest `INSTANCE` parent and use `await instance.getMainComponentAsync()`, then find the matching layer by id or name path inside that component. **Ask the user to confirm** before mutating the definition — changes propagate to **all** instances. Mark result with 🌐.
+2. **Definition (source) node** — If the error indicates the property cannot be overridden in an instance, load `await figma.getNodeByIdAsync(question.sourceChildId)`. If that returns null, walk from the scene node to the nearest `INSTANCE` parent and use `await instance.getMainComponentAsync()`, then find the matching layer inside that component. **Ask the user to confirm** before mutating the definition — changes propagate to **all** instances. Mark result with 🌐.
 3. **Annotation fallback** — If `mainComponent` is null (common for **external published libraries**) or the write still fails, add a `labelMarkdown` annotation on the **scene** node documenting the answer and limitation. Mark result with 📝.
 
 **Shared helper pattern** (adapt per `use_figma` batch — keep each `writeFn` small so a throw does not abort unrelated writes):
@@ -119,7 +132,7 @@ async function applyWithInstanceFallback(question, writeFn) {
   const scene = await figma.getNodeByIdAsync(question.nodeId);
   if (!scene) return { icon: "📝", label: "missing node" };
 
-  const definitionId = question.instanceContext?.sourceNodeId;
+  const definitionId = question.sourceChildId;
   const definition = definitionId
     ? await figma.getNodeByIdAsync(definitionId)
     : null;
@@ -143,76 +156,50 @@ async function applyWithInstanceFallback(question, writeFn) {
 }
 ```
 
-In the Strategy snippets below, treat `"nodeId"` as `question.nodeId` from the answered gotcha. Prefer `await figma.getNodeByIdAsync(...)` over the sync API. **Wrap property writes** in `applyWithInstanceFallback(question, async (target) => { ... })` (or equivalent) whenever `question.instanceContext` exists or the id starts with `I` and contains `;`.
+Wrap every property write in `applyWithInstanceFallback(question, async (target) => { ... })` so failed instance overrides route to the definition path or annotation instead of silently aborting the batch.
 
 #### Strategy A: Property Modification — apply directly
 
-These rules have straightforward property changes. Parse the user's answer to extract target values. **Still use** `applyWithInstanceFallback` when instance children are involved so failed overrides route to definition or annotation instead of failing the whole batch silently.
+Rules with `applyStrategy === "property-mod"`. Use the unified helper below; it branches on `question.targetProperty` automatically.
 
-**`non-semantic-name`** — Rename the node to the answer:
 ```javascript
-await applyWithInstanceFallback(question, async (target) => {
-  if (target) target.name = "hero-section";
-});
+async function applyPropertyMod(question, answerValue) {
+  const props = Array.isArray(question.targetProperty)
+    ? question.targetProperty
+    : [question.targetProperty];
+  return applyWithInstanceFallback(question, async (target) => {
+    if (!target) return;
+    for (const prop of props) {
+      if (!(prop in target)) continue;
+      // Multi-property rules (e.g. no-auto-layout → [layoutMode, itemSpacing]) expect
+      // an object answer: { layoutMode: "VERTICAL", itemSpacing: 16 }.
+      // Single-property rules expect a scalar (number, string, enum).
+      target[prop] = (typeof answerValue === "object" && answerValue !== null)
+        ? answerValue[prop]
+        : answerValue;
+    }
+  });
+}
 ```
 
-**`irregular-spacing`** — Fix spacing to the grid-aligned value from the answer:
-```javascript
-await applyWithInstanceFallback(question, async (target) => {
-  if (target && "itemSpacing" in target) target.itemSpacing = 16;
-  // For padding: target.paddingTop = 8; target.paddingBottom = 8; etc.
-});
-```
-
-**`fixed-size-in-auto-layout`** — Change sizing mode per the answer (FILL, HUG, or FIXED):
-```javascript
-await applyWithInstanceFallback(question, async (target) => {
-  if (target && "layoutSizingHorizontal" in target) {
-    target.layoutSizingHorizontal = "FILL"; // or "HUG" or "FIXED"
-  }
-});
-```
-
-**`missing-size-constraint`** — Set min/max constraints from the answer:
-```javascript
-await applyWithInstanceFallback(question, async (target) => {
-  if (target && "minWidth" in target) {
-    target.minWidth = 320;  // from answer
-    target.maxWidth = 1200; // from answer, if provided
-  }
-});
-```
-
-**`no-auto-layout`** — Set layout mode, direction, and spacing from the answer:
-```javascript
-await applyWithInstanceFallback(question, async (target) => {
-  if (target && "layoutMode" in target) {
-    target.layoutMode = "VERTICAL"; // or "HORIZONTAL"
-    target.itemSpacing = 16;
-    // Optionally set padding, alignment from the answer
-  }
-});
-```
+Answer shape guide (LLM judgment — the user's answer is prose; parse accordingly):
+- **`non-semantic-name`**: string — the new node name.
+- **`irregular-spacing`**: number for gap (subType `gap`), or `{ paddingTop, paddingRight, paddingBottom, paddingLeft }` for padding.
+- **`fixed-size-in-auto-layout`**: `"FILL"` \| `"HUG"` \| `"FIXED"` — applied to each axis listed in `targetProperty`.
+- **`missing-size-constraint`**: partial `{ minWidth, maxWidth }` — include only the keys the answer supplied.
+- **`no-auto-layout`**: `{ layoutMode, itemSpacing }`; optionally extend with padding/alignment from the answer.
 
 #### Strategy B: Structural Modification — confirm with user first
 
-These rules change the design structure. Show the proposed change and **ask for user confirmation** before applying.
+Rules with `applyStrategy === "structural-mod"`. Show the proposed change and **ask for user confirmation** before applying.
 
 **`non-layout-container`** — Convert Group/Section to Auto Layout frame:
 - Prompt: "I'll convert **{nodeName}** to an Auto Layout frame with {direction} layout and {spacing}px gap. Proceed?"
-- If confirmed:
-```javascript
-await applyWithInstanceFallback(question, async (target) => {
-  if (target && "layoutMode" in target) {
-    target.layoutMode = "VERTICAL";
-    target.itemSpacing = 12;
-  }
-});
-```
+- If confirmed: `applyPropertyMod(question, { layoutMode: "VERTICAL", itemSpacing: 12 })`.
 
 **`deep-nesting`** — Flatten intermediate wrappers or extract sub-component:
 - Prompt: "I'll flatten **{nodeName}** by {description from answer}. This changes the layer hierarchy. Proceed?"
-- Apply based on the specific answer (remove wrappers, convert padding, etc.)
+- Apply based on the specific answer (remove wrappers, convert padding, etc.).
 
 **`missing-component`** — Convert frame to reusable component:
 - Prompt: "I'll convert **{nodeName}** to a reusable component. Proceed?"
@@ -226,21 +213,19 @@ if (scene && scene.type === "FRAME") {
 
 **`detached-instance`** — Reconnect to original component:
 - Prompt: "I'll reconnect **{nodeName}** to its original component. Any overrides will be preserved. Proceed?"
-- This requires finding the original component — if not identifiable, fall back to annotation.
+- Requires finding the original component — if not identifiable, fall back to annotation.
 
-If user **declines** any structural modification, add an annotation instead (same as Strategy C).
+If the user **declines** any structural modification, add an annotation instead (same as Strategy C).
 
 #### Strategy C: Annotation — record on the design for designer reference
 
-These rules cannot be auto-fixed via Plugin API. Add the gotcha answer as a Figma annotation on the node so designers see it in Dev Mode.
-
-**Rules from gotcha survey**: `absolute-position-in-auto-layout`, `variant-structure-mismatch`
+Rules with `applyStrategy === "annotation"` cannot be auto-fixed via Plugin API. Add the gotcha answer as a Figma annotation so designers see it in Dev Mode.
 
 ```javascript
 const scene = await figma.getNodeByIdAsync(question.nodeId);
 if (scene && "annotations" in scene) {
   scene.annotations = [...(scene.annotations || []), {
-    labelMarkdown: "**[canicode] {ruleId}**\n\n**Q:** {question}\n**A:** {answer}"
+    labelMarkdown: `**[canicode] ${question.ruleId}**\n\n**Q:** ${question.question}\n**A:** ${answer}`
   }];
 }
 ```
@@ -249,49 +234,37 @@ Important: use `labelMarkdown` only — `label` and `labelMarkdown` are mutually
 
 #### Strategy D: Auto-fix lower-severity issues from analysis
 
-The gotcha survey only covers blocking/risk severity (11 rules). The remaining 5 rules appear in the Step 1 analysis `issues` array but not in the survey. Process them directly — no gotcha question needed.
+The gotcha survey covers only blocking/risk severity. Lower-severity rules appear in `analyzeResult.issues[]` without a survey question. Each issue carries the same pre-computed fields (`applyStrategy`, `targetProperty`, `suggestedName`, `isInstanceChild`, `sourceChildId`). Loop over them:
 
-**Auto-fix naming** — apply directly from the analysis issue data:
-
-**`non-standard-naming`** — The analysis identifies non-standard state names. Rename to the standard equivalent:
 ```javascript
-const q = { nodeId: violation.nodeId, instanceContext: undefined };
-await applyWithInstanceFallback(q, async (target) => {
-  if (target) target.name = "Hover"; // standardize from "hover_v1", "on_hover", etc.
-});
-```
-Standard state names: Default, Hover, Active, Pressed, Selected, Highlighted, Disabled, Enabled, Focus, Focused, Dragged.
+for (const issue of analyzeResult.issues) {
+  if (issue.applyStrategy !== "auto-fix") continue;
 
-**`inconsistent-naming-convention`** — The analysis identifies the dominant convention among siblings. Rename minority nodes to match:
-```javascript
-const q = { nodeId: violation.nodeId, instanceContext: undefined };
-await applyWithInstanceFallback(q, async (target) => {
-  if (target) target.name = "CardTitle"; // convert to dominant convention (e.g., PascalCase)
-});
-```
+  // Shape an ad-hoc question-like object so the same helpers apply.
+  const q = {
+    nodeId: issue.nodeId,
+    ruleId: issue.ruleId,
+    ...(issue.sourceChildId ? { sourceChildId: issue.sourceChildId } : {}),
+  };
 
-**Annotate** — these require designer judgment, no auto-fix possible:
-
-**`raw-value`** — Raw colors/fonts/spacing without design tokens. Annotate which values need token binding:
-```javascript
-node.annotations = [...(node.annotations || []), {
-  labelMarkdown: "**[canicode] raw-value**\n\nThis node uses raw values without design tokens.\n**Issue:** {issue message from analysis}"
-}];
-```
-
-**`missing-interaction-state`** — Missing hover/active/disabled variants. Annotate what states are needed:
-```javascript
-node.annotations = [...(node.annotations || []), {
-  labelMarkdown: "**[canicode] missing-interaction-state**\n\nThis component is missing interaction state variants.\n**Missing:** {missing states from analysis}"
-}];
+  if (issue.targetProperty === "name" && issue.suggestedName) {
+    // Naming rules — rename to the pre-computed suggestedName.
+    await applyWithInstanceFallback(q, async (target) => {
+      if (target) target.name = issue.suggestedName;
+    });
+  } else {
+    // raw-value, missing-interaction-state, missing-prototype — designer judgment; annotate.
+    const scene = await figma.getNodeByIdAsync(issue.nodeId);
+    if (scene && "annotations" in scene) {
+      scene.annotations = [...(scene.annotations || []), {
+        labelMarkdown: `**[canicode] ${issue.ruleId}**\n\n${issue.message}`
+      }];
+    }
+  }
+}
 ```
 
-**`missing-prototype`** — Missing prototype interactions (rule currently disabled, include for completeness):
-```javascript
-node.annotations = [...(node.annotations || []), {
-  labelMarkdown: "**[canicode] missing-prototype**\n\nThis interactive element has no prototype interaction defined.\n**Expected:** {expected interaction from analysis}"
-}];
-```
+`suggestedName` is already capitalized for direct Plugin-API use (e.g. `"Hover"`, `"Default"`, `"Pressed"`). Do not transform it further.
 
 #### Execution order
 

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -12,6 +12,22 @@ export const InstanceContextSchema = z.object({
 
 export type InstanceContext = z.infer<typeof InstanceContextSchema>;
 
+/**
+ * Apply-strategy enum surfaced on survey questions and analyze-output issues.
+ * Mirrors `RuleApplyStrategy` in `src/core/gotcha/apply-context.ts` —
+ * declared as a Zod enum here so MCP responses validate end-to-end.
+ */
+export const RuleApplyStrategySchema = z.enum([
+  "property-mod",
+  "structural-mod",
+  "annotation",
+  "auto-fix",
+]);
+
+export type RuleApplyStrategy = z.infer<typeof RuleApplyStrategySchema>;
+
+const TargetPropertySchema = z.union([z.string(), z.array(z.string())]);
+
 export const GotchaSurveyQuestionSchema = z.object({
   nodeId: z.string(),
   nodeName: z.string(),
@@ -21,6 +37,11 @@ export const GotchaSurveyQuestionSchema = z.object({
   hint: z.string(),
   example: z.string(),
   instanceContext: InstanceContextSchema.optional(),
+  applyStrategy: RuleApplyStrategySchema,
+  targetProperty: TargetPropertySchema.optional(),
+  suggestedName: z.string().optional(),
+  isInstanceChild: z.boolean(),
+  sourceChildId: z.string().optional(),
 });
 
 export type GotchaSurveyQuestion = z.infer<typeof GotchaSurveyQuestionSchema>;

--- a/src/core/contracts/rule.ts
+++ b/src/core/contracts/rule.ts
@@ -72,6 +72,14 @@ export interface RuleViolation {
   message: string;
   suggestion: string;
   guide?: string;
+  /**
+   * Pre-computed name to write to `node.name` in Figma — populated by naming
+   * rules whose suggestion is a deterministic function of the node's existing
+   * state (`non-standard-naming`, `inconsistent-naming-convention`).
+   * Capitalized for direct Plugin-API use; the human-readable `suggestion`
+   * string keeps lowercase prose.
+   */
+  suggestedName?: string;
 }
 
 /**

--- a/src/core/engine/scoring.test.ts
+++ b/src/core/engine/scoring.test.ts
@@ -517,6 +517,68 @@ describe("buildResultJson", () => {
 
     expect(json.blockingIssueCount).toBe(0);
   });
+
+  it("enriches each issue with applyStrategy, isInstanceChild, and targetProperty when known", () => {
+    const namingIssue = makeIssue({ ruleId: "non-standard-naming", category: "semantic", severity: "suggestion" });
+    namingIssue.violation.suggestedName = "Hover";
+
+    const rawValueIssue = makeIssue({ ruleId: "raw-value", category: "token-management", severity: "missing-info" });
+    rawValueIssue.violation.subType = "color";
+
+    const sizeIssue = makeIssue({
+      ruleId: "missing-size-constraint",
+      category: "responsive-critical",
+      severity: "risk",
+    });
+    sizeIssue.violation.subType = "wrap";
+
+    const result = makeResult([namingIssue, rawValueIssue, sizeIssue]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+    const issues = json.issues as Array<Record<string, unknown>>;
+
+    expect(issues[0]).toMatchObject({
+      ruleId: "non-standard-naming",
+      applyStrategy: "auto-fix",
+      targetProperty: "name",
+      suggestedName: "Hover",
+      isInstanceChild: false,
+    });
+
+    expect(issues[1]).toMatchObject({
+      ruleId: "raw-value",
+      applyStrategy: "auto-fix",
+      isInstanceChild: false,
+    });
+    expect(issues[1]!["targetProperty"]).toBeUndefined();
+
+    expect(issues[2]).toMatchObject({
+      ruleId: "missing-size-constraint",
+      applyStrategy: "property-mod",
+      targetProperty: "minWidth",
+      isInstanceChild: false,
+    });
+  });
+
+  it("derives isInstanceChild and sourceChildId from instance-child node ids", () => {
+    const issue = makeIssue({
+      ruleId: "missing-size-constraint",
+      category: "responsive-critical",
+      severity: "risk",
+    });
+    issue.violation.nodeId = "I175:8312;2299:23057";
+    issue.violation.subType = "wrap";
+
+    const result = makeResult([issue]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+    const issues = json.issues as Array<Record<string, unknown>>;
+
+    expect(issues[0]).toMatchObject({
+      isInstanceChild: true,
+      sourceChildId: "2299:23057",
+    });
+  });
 });
 
 // ─── isReadyForCodeGen helper ─────────────────────────────────────────────────

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -4,6 +4,7 @@ import type { RuleId, RuleConfig } from "../contracts/rule.js";
 import type { Severity } from "../contracts/severity.js";
 import type { AnalysisResult } from "./rule-engine.js";
 import { RULE_CONFIGS, RULE_ID_CATEGORY } from "../rules/rule-config.js";
+import { computeApplyContext } from "../gotcha/apply-context.js";
 import { version as VERSION } from "../../../package.json";
 
 /**
@@ -407,14 +408,27 @@ export function buildResultJson(
     issuesByRule[id] = (issuesByRule[id] ?? 0) + 1;
   }
 
-  const issues = result.issues.map((issue) => ({
-    ruleId: issue.violation.ruleId,
-    ...(issue.violation.subType && { subType: issue.violation.subType }),
-    severity: issue.config.severity,
-    nodeId: issue.violation.nodeId,
-    nodePath: issue.violation.nodePath,
-    message: issue.violation.message,
-  }));
+  const issues = result.issues.map((issue) => {
+    const applyContext = computeApplyContext(issue.violation);
+    const suggestedName = issue.violation.suggestedName;
+    return {
+      ruleId: issue.violation.ruleId,
+      ...(issue.violation.subType && { subType: issue.violation.subType }),
+      severity: issue.config.severity,
+      nodeId: issue.violation.nodeId,
+      nodePath: issue.violation.nodePath,
+      message: issue.violation.message,
+      applyStrategy: applyContext.applyStrategy,
+      ...(applyContext.targetProperty !== undefined
+        ? { targetProperty: applyContext.targetProperty }
+        : {}),
+      ...(suggestedName !== undefined ? { suggestedName } : {}),
+      isInstanceChild: applyContext.isInstanceChild,
+      ...(applyContext.sourceChildId !== undefined
+        ? { sourceChildId: applyContext.sourceChildId }
+        : {}),
+    };
+  });
 
   const json: Record<string, unknown> = {
     version: VERSION,

--- a/src/core/gotcha/apply-context.test.ts
+++ b/src/core/gotcha/apply-context.test.ts
@@ -1,0 +1,223 @@
+import { computeApplyContext } from "./apply-context.js";
+import type { RuleId, RuleViolation } from "../contracts/rule.js";
+
+function makeViolation(
+  ruleId: RuleId,
+  opts: { nodeId?: string; subType?: string } = {},
+): Pick<RuleViolation, "ruleId" | "subType" | "nodeId"> {
+  return {
+    ruleId,
+    nodeId: opts.nodeId ?? "1:1",
+    ...(opts.subType !== undefined ? { subType: opts.subType } : {}),
+  };
+}
+
+describe("computeApplyContext", () => {
+  describe("applyStrategy table", () => {
+    const propertyMod: RuleId[] = [
+      "no-auto-layout",
+      "fixed-size-in-auto-layout",
+      "missing-size-constraint",
+      "irregular-spacing",
+      "non-semantic-name",
+    ];
+    const structuralMod: RuleId[] = [
+      "non-layout-container",
+      "deep-nesting",
+      "missing-component",
+      "detached-instance",
+    ];
+    const annotation: RuleId[] = [
+      "absolute-position-in-auto-layout",
+      "variant-structure-mismatch",
+    ];
+    const autoFix: RuleId[] = [
+      "non-standard-naming",
+      "inconsistent-naming-convention",
+      "raw-value",
+      "missing-interaction-state",
+      "missing-prototype",
+    ];
+
+    it.each(propertyMod)("%s → property-mod", (ruleId) => {
+      expect(computeApplyContext(makeViolation(ruleId)).applyStrategy).toBe(
+        "property-mod",
+      );
+    });
+
+    it.each(structuralMod)("%s → structural-mod", (ruleId) => {
+      expect(computeApplyContext(makeViolation(ruleId)).applyStrategy).toBe(
+        "structural-mod",
+      );
+    });
+
+    it.each(annotation)("%s → annotation", (ruleId) => {
+      expect(computeApplyContext(makeViolation(ruleId)).applyStrategy).toBe(
+        "annotation",
+      );
+    });
+
+    it.each(autoFix)("%s → auto-fix", (ruleId) => {
+      expect(computeApplyContext(makeViolation(ruleId)).applyStrategy).toBe(
+        "auto-fix",
+      );
+    });
+  });
+
+  describe("targetProperty by subType", () => {
+    it("no-auto-layout → layoutMode + itemSpacing", () => {
+      expect(
+        computeApplyContext(makeViolation("no-auto-layout", { subType: "basic" }))
+          .targetProperty,
+      ).toEqual(["layoutMode", "itemSpacing"]);
+    });
+
+    it("fixed-size-in-auto-layout horizontal → layoutSizingHorizontal", () => {
+      expect(
+        computeApplyContext(
+          makeViolation("fixed-size-in-auto-layout", { subType: "horizontal" }),
+        ).targetProperty,
+      ).toBe("layoutSizingHorizontal");
+    });
+
+    it("fixed-size-in-auto-layout both-axes → layoutSizingHorizontal + layoutSizingVertical", () => {
+      expect(
+        computeApplyContext(
+          makeViolation("fixed-size-in-auto-layout", { subType: "both-axes" }),
+        ).targetProperty,
+      ).toEqual(["layoutSizingHorizontal", "layoutSizingVertical"]);
+    });
+
+    it("missing-size-constraint wrap → minWidth", () => {
+      expect(
+        computeApplyContext(
+          makeViolation("missing-size-constraint", { subType: "wrap" }),
+        ).targetProperty,
+      ).toBe("minWidth");
+    });
+
+    it("missing-size-constraint max-width → maxWidth", () => {
+      expect(
+        computeApplyContext(
+          makeViolation("missing-size-constraint", { subType: "max-width" }),
+        ).targetProperty,
+      ).toBe("maxWidth");
+    });
+
+    it("missing-size-constraint grid → minWidth + maxWidth", () => {
+      expect(
+        computeApplyContext(
+          makeViolation("missing-size-constraint", { subType: "grid" }),
+        ).targetProperty,
+      ).toEqual(["minWidth", "maxWidth"]);
+    });
+
+    it("irregular-spacing gap → itemSpacing", () => {
+      expect(
+        computeApplyContext(
+          makeViolation("irregular-spacing", { subType: "gap" }),
+        ).targetProperty,
+      ).toBe("itemSpacing");
+    });
+
+    it("irregular-spacing padding → all four padding fields", () => {
+      expect(
+        computeApplyContext(
+          makeViolation("irregular-spacing", { subType: "padding" }),
+        ).targetProperty,
+      ).toEqual([
+        "paddingTop",
+        "paddingRight",
+        "paddingBottom",
+        "paddingLeft",
+      ]);
+    });
+
+    it("non-semantic-name → name", () => {
+      expect(
+        computeApplyContext(makeViolation("non-semantic-name")).targetProperty,
+      ).toBe("name");
+    });
+
+    it("non-layout-container → layoutMode", () => {
+      expect(
+        computeApplyContext(makeViolation("non-layout-container", { subType: "group" }))
+          .targetProperty,
+      ).toBe("layoutMode");
+    });
+
+    it("naming auto-fixes → name", () => {
+      expect(
+        computeApplyContext(makeViolation("non-standard-naming")).targetProperty,
+      ).toBe("name");
+      expect(
+        computeApplyContext(makeViolation("inconsistent-naming-convention"))
+          .targetProperty,
+      ).toBe("name");
+    });
+
+    it.each<RuleId>([
+      "deep-nesting",
+      "missing-component",
+      "detached-instance",
+      "absolute-position-in-auto-layout",
+      "variant-structure-mismatch",
+      "raw-value",
+      "missing-interaction-state",
+      "missing-prototype",
+    ])("%s → undefined targetProperty", (ruleId) => {
+      expect(
+        computeApplyContext(makeViolation(ruleId)).targetProperty,
+      ).toBeUndefined();
+    });
+  });
+
+  describe("isInstanceChild / sourceChildId", () => {
+    it("plain scene node id → not an instance child", () => {
+      const ctx = computeApplyContext(
+        makeViolation("no-auto-layout", { nodeId: "348:15903" }),
+      );
+      expect(ctx.isInstanceChild).toBe(false);
+      expect(ctx.sourceChildId).toBeUndefined();
+    });
+
+    it("flat instance-child id → parses sourceChildId from last segment", () => {
+      const ctx = computeApplyContext(
+        makeViolation("no-auto-layout", { nodeId: "I348:15903;2153:7840" }),
+      );
+      expect(ctx.isInstanceChild).toBe(true);
+      expect(ctx.sourceChildId).toBe("2153:7840");
+    });
+
+    it("nested instance-child id → uses last segment as sourceChildId", () => {
+      const ctx = computeApplyContext(
+        makeViolation("no-auto-layout", { nodeId: "I1;I2:3;4:5" }),
+      );
+      expect(ctx.isInstanceChild).toBe(true);
+      expect(ctx.sourceChildId).toBe("4:5");
+    });
+
+    it("explicit instanceContext.sourceNodeId takes precedence", () => {
+      const ctx = computeApplyContext(
+        makeViolation("no-auto-layout", { nodeId: "I348:15903;2153:7840" }),
+        {
+          parentInstanceNodeId: "348:15903",
+          sourceNodeId: "OVERRIDE:1",
+        },
+      );
+      expect(ctx.isInstanceChild).toBe(true);
+      expect(ctx.sourceChildId).toBe("OVERRIDE:1");
+    });
+
+    it("docs example: I175:8312;2299:23057 → sourceChildId 2299:23057", () => {
+      const ctx = computeApplyContext(
+        makeViolation("missing-size-constraint", {
+          nodeId: "I175:8312;2299:23057",
+          subType: "wrap",
+        }),
+      );
+      expect(ctx.isInstanceChild).toBe(true);
+      expect(ctx.sourceChildId).toBe("2299:23057");
+    });
+  });
+});

--- a/src/core/gotcha/apply-context.ts
+++ b/src/core/gotcha/apply-context.ts
@@ -1,0 +1,148 @@
+import type { RuleId, RuleViolation } from "../contracts/rule.js";
+import type { InstanceContext } from "../contracts/gotcha-survey.js";
+import {
+  isInstanceChildNodeId,
+  parseInstanceChildNodeId,
+} from "../adapters/instance-id-parser.js";
+
+/**
+ * Apply strategy for a rule violation. Tells the SKILL.md/`use_figma`
+ * pipeline which Plugin-API path to take.
+ *
+ * - `property-mod`   — Strategy A. Direct property write on the scene/instance node.
+ * - `structural-mod` — Strategy B. Structural change; ask user to confirm before applying.
+ * - `annotation`     — Strategy C. Cannot be auto-fixed; record as a Figma annotation.
+ * - `auto-fix`       — Strategy D. Lower-severity rules from analyze output;
+ *                      may be a property write (naming) or annotation-only.
+ *
+ * Sibling module `resolve-apply-target.ts` solves a different concern
+ * (scene-vs-definition write target). Compose them — do not merge.
+ */
+export type RuleApplyStrategy =
+  | "property-mod"
+  | "structural-mod"
+  | "annotation"
+  | "auto-fix";
+
+/**
+ * Pre-computed apply context attached to gotcha-survey questions and
+ * analyze-output issues. Lets the SKILL.md consume the data directly
+ * instead of re-deriving rule routing on every roundtrip run.
+ *
+ * `targetProperty` is `string` for single-property writes, `string[]`
+ * for rules that require multiple writes (e.g. `irregular-spacing`
+ * subType `padding` → 4 padding fields), and `undefined` for
+ * annotation/structural strategies that have no single property target.
+ */
+export interface ApplyContext {
+  applyStrategy: RuleApplyStrategy;
+  targetProperty?: string | string[];
+  isInstanceChild: boolean;
+  sourceChildId?: string;
+}
+
+const STRATEGY_BY_RULE: Record<RuleId, RuleApplyStrategy> = {
+  // Strategy A — property modification
+  "no-auto-layout": "property-mod",
+  "fixed-size-in-auto-layout": "property-mod",
+  "missing-size-constraint": "property-mod",
+  "irregular-spacing": "property-mod",
+  "non-semantic-name": "property-mod",
+  // Strategy B — structural modification (needs user confirmation)
+  "non-layout-container": "structural-mod",
+  "deep-nesting": "structural-mod",
+  "missing-component": "structural-mod",
+  "detached-instance": "structural-mod",
+  // Strategy C — annotation only
+  "absolute-position-in-auto-layout": "annotation",
+  "variant-structure-mismatch": "annotation",
+  // Strategy D — auto-fix lower-severity issues from analyze output
+  "non-standard-naming": "auto-fix",
+  "inconsistent-naming-convention": "auto-fix",
+  "raw-value": "auto-fix",
+  "missing-interaction-state": "auto-fix",
+  "missing-prototype": "auto-fix",
+};
+
+/**
+ * Resolve the Figma Plugin-API target property (or properties) for a
+ * violation. Returns `undefined` for rules whose strategy does not write
+ * a single property (structural-mod, annotation), or for naming auto-fixes
+ * where the value comes from `violation.suggestedName` rather than a
+ * specific Figma property — except the `name` write itself, which we
+ * surface so SKILL.md can branch uniformly on `targetProperty === 'name'`.
+ */
+function resolveTargetProperty(
+  ruleId: RuleId,
+  subType: string | undefined,
+): string | string[] | undefined {
+  switch (ruleId) {
+    case "no-auto-layout":
+      return ["layoutMode", "itemSpacing"];
+    case "fixed-size-in-auto-layout":
+      if (subType === "horizontal") return "layoutSizingHorizontal";
+      // both-axes — write both axes
+      return ["layoutSizingHorizontal", "layoutSizingVertical"];
+    case "missing-size-constraint":
+      if (subType === "wrap") return "minWidth";
+      if (subType === "max-width") return "maxWidth";
+      // grid — both bounds
+      return ["minWidth", "maxWidth"];
+    case "irregular-spacing":
+      if (subType === "gap") return "itemSpacing";
+      // padding — all four padding fields
+      return ["paddingTop", "paddingRight", "paddingBottom", "paddingLeft"];
+    case "non-semantic-name":
+      return "name";
+    case "non-layout-container":
+      return "layoutMode";
+    case "non-standard-naming":
+    case "inconsistent-naming-convention":
+      return "name";
+    case "deep-nesting":
+    case "missing-component":
+    case "detached-instance":
+    case "absolute-position-in-auto-layout":
+    case "variant-structure-mismatch":
+    case "raw-value":
+    case "missing-interaction-state":
+    case "missing-prototype":
+      return undefined;
+  }
+}
+
+/**
+ * Compute the deterministic apply context for a rule violation.
+ *
+ * - `applyStrategy` and `targetProperty` come from the ruleId/subType tables above.
+ * - `isInstanceChild` and `sourceChildId` are parsed from the violation `nodeId`
+ *   via `parseInstanceChildNodeId` — single source of truth for `I...;...` ids.
+ * - `instanceContext`, when supplied, takes precedence for `sourceChildId` so
+ *   callers that already resolved the source component (gotcha-survey) do not
+ *   re-parse the id.
+ *
+ * Strategy D rules that target scene nodes (analyze output) can pass
+ * `instanceContext: undefined` — the function still returns the parsed
+ * `isInstanceChild`/`sourceChildId` so SKILL.md knows whether to walk the
+ * instance fallback.
+ */
+export function computeApplyContext(
+  violation: Pick<RuleViolation, "ruleId" | "subType" | "nodeId">,
+  instanceContext?: InstanceContext,
+): ApplyContext {
+  const ruleId = violation.ruleId as RuleId;
+  const applyStrategy = STRATEGY_BY_RULE[ruleId] ?? "annotation";
+  const targetProperty = resolveTargetProperty(ruleId, violation.subType);
+
+  const parsed = parseInstanceChildNodeId(violation.nodeId);
+  const isInstanceChild =
+    parsed !== null || isInstanceChildNodeId(violation.nodeId);
+  const sourceChildId = instanceContext?.sourceNodeId ?? parsed?.sourceNodeId;
+
+  return {
+    applyStrategy,
+    ...(targetProperty !== undefined ? { targetProperty } : {}),
+    isInstanceChild,
+    ...(sourceChildId !== undefined ? { sourceChildId } : {}),
+  };
+}

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -32,8 +32,9 @@ function makeViolation(
   ruleId: string,
   nodeId: string,
   nodePath: string,
+  extra: Partial<RuleViolation> = {},
 ): RuleViolation {
-  return { ruleId, nodeId, nodePath, message: "test", suggestion: "" };
+  return { ruleId, nodeId, nodePath, message: "test", suggestion: "", ...extra };
 }
 
 function makeIssue(opts: {
@@ -43,12 +44,18 @@ function makeIssue(opts: {
   nodeId?: string;
   nodePath?: string;
   score?: number;
+  subType?: string;
+  suggestedName?: string;
 }): AnalysisIssue {
+  const extra: Partial<RuleViolation> = {};
+  if (opts.subType !== undefined) extra.subType = opts.subType;
+  if (opts.suggestedName !== undefined) extra.suggestedName = opts.suggestedName;
   return {
     violation: makeViolation(
       opts.ruleId,
       opts.nodeId ?? "1:1",
       opts.nodePath ?? "Root > Node",
+      extra,
     ),
     rule: makeRule({ id: opts.ruleId, category: opts.category }),
     config: makeConfig(opts.severity, opts.score ?? -5),
@@ -495,6 +502,134 @@ describe("generateGotchaSurvey", () => {
       const result = GotchaSurveySchema.safeParse(survey);
       expect(result.success).toBe(true);
     });
+  });
+
+  describe("applyStrategy and targetProperty", () => {
+    it("property-mod rule carries strategy and target property", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "1:1",
+          nodePath: "Root > Banner",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.applyStrategy).toBe("property-mod");
+      expect(survey.questions[0]!.targetProperty).toBe("minWidth");
+    });
+
+    it("structural-mod rule carries strategy without targetProperty for deep-nesting", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "deep-nesting",
+          category: "code-quality",
+          severity: "risk",
+          nodeId: "1:1",
+          nodePath: "Root > DeepWrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.applyStrategy).toBe("structural-mod");
+      expect(survey.questions[0]!.targetProperty).toBeUndefined();
+    });
+
+    it("annotation rule carries annotation strategy", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "absolute-position-in-auto-layout",
+          category: "pixel-critical",
+          severity: "risk",
+          nodeId: "1:1",
+          nodePath: "Root > Float",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.applyStrategy).toBe("annotation");
+      expect(survey.questions[0]!.targetProperty).toBeUndefined();
+    });
+  });
+
+  describe("isInstanceChild and sourceChildId", () => {
+    it("flat instance-child id derives sourceChildId from last segment", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I175:8312;2299:23057",
+          nodePath: "Root > Card > Inner",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.isInstanceChild).toBe(true);
+      expect(survey.questions[0]!.sourceChildId).toBe("2299:23057");
+    });
+
+    it("plain scene id sets isInstanceChild=false and omits sourceChildId", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "no-auto-layout",
+          category: "pixel-critical",
+          severity: "blocking",
+          nodeId: "1:1",
+          nodePath: "Root > Hero",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.isInstanceChild).toBe(false);
+      expect(survey.questions[0]!.sourceChildId).toBeUndefined();
+    });
+  });
+
+  it("passes suggestedName through to the survey question", () => {
+    // Survey only covers blocking/risk rules — naming rules are semantic suggestion
+    // so exercise the pass-through with a semantic rule elevated to risk severity.
+    const issues = [
+      makeIssue({
+        ruleId: "non-semantic-name",
+        category: "semantic",
+        severity: "risk",
+        nodeId: "1:1",
+        nodePath: "Root > Frame 1",
+        suggestedName: "HeroSection",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("D"),
+    );
+
+    expect(survey.questions[0]!.suggestedName).toBe("HeroSection");
   });
 
   it("sets isReadyForCodeGen based on grade", () => {

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -10,6 +10,7 @@ import type { AnalysisFile, AnalysisNode } from "../contracts/figma-node.js";
 import type { RuleId } from "../contracts/rule.js";
 import { GOTCHA_QUESTIONS } from "../rules/gotcha-questions.js";
 import { parseInstanceChildNodeId } from "../adapters/instance-id-parser.js";
+import { computeApplyContext } from "./apply-context.js";
 
 const NODE_PATH_SEPARATOR = " > ";
 
@@ -125,6 +126,11 @@ function mapToQuestion(
 
   const nodeName = getNodeName(issue.violation.nodePath);
   const instanceContext = buildInstanceContext(issue.violation.nodeId, file);
+  const applyContext = computeApplyContext(
+    issue.violation,
+    instanceContext ?? undefined,
+  );
+  const suggestedName = issue.violation.suggestedName;
 
   return {
     nodeId: issue.violation.nodeId,
@@ -135,6 +141,15 @@ function mapToQuestion(
     hint: template.hint,
     example: template.example,
     ...(instanceContext ? { instanceContext } : {}),
+    applyStrategy: applyContext.applyStrategy,
+    ...(applyContext.targetProperty !== undefined
+      ? { targetProperty: applyContext.targetProperty }
+      : {}),
+    ...(suggestedName !== undefined ? { suggestedName } : {}),
+    isInstanceChild: applyContext.isInstanceChild,
+    ...(applyContext.sourceChildId !== undefined
+      ? { sourceChildId: applyContext.sourceChildId }
+      : {}),
   };
 }
 

--- a/src/core/rules/naming/inconsistent-naming-convention.test.ts
+++ b/src/core/rules/naming/inconsistent-naming-convention.test.ts
@@ -110,6 +110,7 @@ describe("inconsistent-naming-convention", () => {
     const result = inconsistentNamingConvention.check(node, makeContext({ siblings }));
     expect(result).not.toBeNull();
     expect(result!.suggestion).toContain('"my-url-parser"');
+    expect(result!.suggestedName).toBe("my-url-parser");
   });
 
   it("still flags multi-word PascalCase in Title Case context", () => {

--- a/src/core/rules/naming/index.ts
+++ b/src/core/rules/naming/index.ts
@@ -3,6 +3,11 @@ import { defineRule } from "../rule-registry.js";
 import { getDefaultNameSubType, nonSemanticNameMsg, inconsistentNamingMsg, nonStandardNamingMsg } from "../rule-messages.js";
 import { isExcludedName, isDefaultName, isNonSemanticName, STANDARD_STATE_NAMES, STATE_NAME_SUGGESTIONS, STATE_LIKE_PATTERN } from "../node-semantics.js";
 
+function capitalize(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 function detectNamingConvention(name: string): string | null {
   if (/^[a-z]+(-[a-z]+)*$/.test(name)) return "kebab-case";
   if (/^[a-z]+(_[a-z]+)*$/.test(name)) return "snake_case";
@@ -176,6 +181,7 @@ const inconsistentNamingConventionCheck: RuleCheckFn = (node, context) => {
       ruleId: inconsistentNamingConventionDef.id,
       nodeId: node.id,
       nodePath: context.path.join(" > "),
+      suggestedName: suggested,
       ...inconsistentNamingMsg(node.name, nodeConvention, dominantConvention, suggested),
     };
   }
@@ -228,6 +234,7 @@ const nonStandardNamingCheck: RuleCheckFn = (node, context) => {
             subType: "state-name" as const,
             nodeId: node.id,
             nodePath: context.path.join(" > "),
+            suggestedName: capitalize(suggestion),
             ...nonStandardNamingMsg.stateName(node.name, opt, suggestion),
           };
         }

--- a/src/core/rules/naming/non-standard-naming.test.ts
+++ b/src/core/rules/naming/non-standard-naming.test.ts
@@ -24,6 +24,8 @@ describe("non-standard-naming", () => {
     expect(result!.subType).toBe("state-name");
     expect(result!.message).toContain("Clicked");
     expect(result!.suggestion).toContain("pressed");
+    // suggestion stays lowercase for human prose; suggestedName is capitalized for Plugin API
+    expect(result!.suggestedName).toBe("Pressed");
   });
 
   it("flags 'On' → suggests 'active'", () => {


### PR DESCRIPTION
## Summary

Implements the #288 plan: move deterministic logic (I-prefix id parsing, ruleId → strategy routing, ruleId → target property, hardcoded standard state names, dominant-convention suggested names) out of `.claude/skills/canicode-roundtrip/SKILL.md` into pre-computed fields on the `analyze` and `gotcha-survey` outputs. The SKILL.md consumes the fields directly — the LLM no longer re-derives them per run.

### What moved to code

| From SKILL.md (prose / inline code) | To |
|---|---|
| `I<parentId>;<sourceChildId>` parsing prose | `src/core/adapters/instance-id-parser.ts` + surfaced as `question.sourceChildId` |
| ruleId → Strategy A/B/C/D mapping table | `src/core/gotcha/apply-context.ts` → `question.applyStrategy` |
| ruleId/subType → target Figma property | `computeApplyContext` → `question.targetProperty` (string or string[]) |
| Hardcoded standard state names ("Default, Hover, Active, ...") | Naming rules now set `violation.suggestedName` server-side → `question.suggestedName` |
| Dominant-convention suggestion for siblings | Same — `inconsistent-naming-convention` rule populates `suggestedName` during evaluation |

### What stayed in SKILL.md (by plan)

- `applyWithInstanceFallback` helper — runtime `try/catch` on Plugin API, cannot be unit-tested server-side
- Strategy B user-confirmation prompts — require LLM judgment
- Strategy A answer-parsing guide — converts the user's prose answer to scalar/object values
- Annotation preservation pattern (`labelMarkdown` vs `label`)
- ✅/🌐/📝 reporting icons

### Changes

- New module `src/core/gotcha/apply-context.ts` — single source of truth for rule routing + target property, with unit tests
- `RuleViolation.suggestedName` on `src/core/contracts/rule.ts`; populated by naming rules in `src/core/rules/naming/`
- `GotchaSurveyQuestion` extended with `applyStrategy`, `targetProperty`, `suggestedName`, `isInstanceChild`, `sourceChildId` (Zod schema + survey generator tests)
- `analyzeResult.issues[]` carries the same fields via `buildResultJson` in `src/core/engine/scoring.ts`
- SKILL.md Step 4 rewritten to consume fields; new "Input shape from canicode" table documents the contract; Strategy A unified into `applyPropertyMod`; Strategy D converted to a single loop using `issue.suggestedName` / `issue.targetProperty`

### Commit series

- `1132517` wip(gotcha): extract apply-context (tasks 1-4) — checkpoint after develop-implementer timed out before committing
- `d001dc9` refactor(skill): consume pre-computed apply fields in canicode-roundtrip — task 5 (SKILL.md slim)

Note on process: the develop pipeline's implementer agent hit its 10-minute timeout on the initial run (plan had 5 max-size tasks, task 5 being a whole SKILL.md rewrite). Tasks 1-4 were committed manually as a WIP checkpoint; task 5 was implemented directly after two retry attempts with the agent produced no new commits. Full pipeline artifacts live in `logs/develop/288--2026-04-17-1725/` (gitignored).

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test:run` (46 files, 759 tests)
- [x] `pnpm build`
- [ ] Manual: re-run `/canicode-roundtrip` on an existing fixture and confirm the slimmer SKILL.md still drives the same Plugin-API writes via the new fields