### PR TITLE
feat(develop): fix pipeline orchestration — observability, retry, hooks, planner

### DIFF
--- a/.claude/agents/develop/implementer.md
+++ b/.claude/agents/develop/implementer.md
@@ -57,13 +57,20 @@ Write `$RUN_DIR/implement-log.json` BEFORE committing:
 
 The orchestrator reads `$RUN_DIR/implement-progress.jsonl` on timeout to synthesize a partial `implement-log.json` and decide whether to retry. File writes are tracked automatically by a PostToolUse hook — you do NOT need to log those.
 
-**Do this manually**: at the start of each task (before you read/edit files for that task), append one line to `$RUN_DIR/implement-progress.jsonl`:
+**Do this manually**: at the start of each task, BEFORE you read/edit any files for that task, append ONE line to `$RUN_DIR/implement-progress.jsonl`:
 
 ```
 {"t":"<ISO-timestamp>","taskId":<id>,"event":"task-start"}
 ```
 
-Use the `Bash` tool: `echo '{"t":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","taskId":2,"event":"task-start"}' >> "$RUN_DIR/implement-progress.jsonl"`. One line per task; no line for subtasks. If `$RUN_DIR` is not in env, skip silently (non-pipeline session).
+Use the `Bash` tool: `echo '{"t":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","taskId":2,"event":"task-start"}' >> "$RUN_DIR/implement-progress.jsonl"`.
+
+**Contract the orchestrator depends on** (do not deviate):
+- Emit exactly ONE `task-start` line per plan task, at the moment you begin that task.
+- `taskId` MUST match the numeric `id` field from `plan.json` tasks.
+- Tasks must be emitted in order — the orchestrator treats the LAST `taskId` seen as in-progress and every earlier one as completed. Emitting out-of-order will misattribute completion.
+- No line for subtasks or re-entries; if you revisit a task, do not re-emit.
+- If `$RUN_DIR` is not in env, skip silently (non-pipeline session).
 
 ## Rules
 

--- a/.claude/agents/develop/implementer.md
+++ b/.claude/agents/develop/implementer.md
@@ -53,6 +53,18 @@ Write `$RUN_DIR/implement-log.json` BEFORE committing:
 - `decisions`: The Review agent reads this to understand WHY you wrote code a certain way. Without this, the reviewer may flag intentional choices as bugs.
 - `knownRisks`: The Review agent pays EXTRA attention to these areas. Flag anything you're not confident about — it's better to admit uncertainty than to hide it.
 
+## Progress tracking
+
+The orchestrator reads `$RUN_DIR/implement-progress.jsonl` on timeout to synthesize a partial `implement-log.json` and decide whether to retry. File writes are tracked automatically by a PostToolUse hook — you do NOT need to log those.
+
+**Do this manually**: at the start of each task (before you read/edit files for that task), append one line to `$RUN_DIR/implement-progress.jsonl`:
+
+```
+{"t":"<ISO-timestamp>","taskId":<id>,"event":"task-start"}
+```
+
+Use the `Bash` tool: `echo '{"t":"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'","taskId":2,"event":"task-start"}' >> "$RUN_DIR/implement-progress.jsonl"`. One line per task; no line for subtasks. If `$RUN_DIR` is not in env, skip silently (non-pipeline session).
+
 ## Rules
 
 - Follow CLAUDE.md conventions strictly: ESM, .js extensions, strict TS, kebab-case files, etc.
@@ -61,3 +73,4 @@ Write `$RUN_DIR/implement-log.json` BEFORE committing:
 - Do NOT create a PR — a separate step handles that
 - Do NOT make changes beyond what the plan specifies
 - Every file you touch must be listed in `filesChanged`
+- Emit a `task-start` heartbeat line before beginning each plan task (see above)

--- a/.claude/agents/develop/planner.md
+++ b/.claude/agents/develop/planner.md
@@ -16,13 +16,15 @@ Your prompt includes a "Context" section with:
 
 ## Steps
 
-1. Read the issue carefully — understand WHAT is needed and WHY
-2. Read CLAUDE.md conventions (especially Project Structure, Code Style, TypeScript sections)
-3. Read `.claude/docs/ADR.md`, `.claude/docs/ARCHITECTURE.md`, `.claude/docs/DESIGN-TREE.md`, `.claude/docs/CALIBRATION.md` — understand architecture decisions and constraints
-4. Explore the codebase: use Glob to find relevant files, Grep to search for related code, Read to understand existing patterns
-4. Identify which files need to be created or modified
-5. Break down the work into ordered tasks
-6. Document your design decisions — WHY this approach, not just what
+1. Read the issue carefully — understand WHAT is needed and WHY. Note any `### Affected areas` / `### Files` sections: these are author hints about scope.
+2. Read CLAUDE.md conventions (especially Project Structure, Code Style, TypeScript sections).
+3. Read `.claude/docs/ADR.md`, `.claude/docs/ARCHITECTURE.md`, `.claude/docs/DESIGN-TREE.md`, `.claude/docs/CALIBRATION.md`. **Treat these as a map** — they list directories, modules, and subsystems by purpose. Extract the set of candidate paths relevant to the issue from these docs BEFORE doing any codebase search.
+4. Scoped exploration: Read the candidate files from step 3 to understand existing patterns. Only fall back to Glob/Grep when the docs don't resolve a specific question (e.g. "which file owns X"). Do NOT re-explore the whole repo — the docs are curated for this purpose.
+5. Identify which files need to be created or modified.
+6. Break down the work into ordered tasks.
+7. Document your design decisions — WHY this approach, not just what.
+
+The docs-first rule exists because unbounded Glob/Grep is the dominant cost of a plan run (#301). If step 3 lists `src/core/engine/` as the relevant subtree, go read those files directly instead of Grepping across the repo.
 
 ## Output
 
@@ -48,18 +50,24 @@ Write `$RUN_DIR/plan.json`:
   "testStrategy": "How to verify the implementation works",
   "risks": ["Known unknowns, potential edge cases, areas of uncertainty"],
   "split": false,
-  "remainingDescription": null
+  "remainingDescription": null,
+  "splitReason": null
 }
 ```
 
-## Issue Splitting
+## Split gates
 
-If the issue requires **more than 5 tasks**, the scope is too large for one PR. In this case:
-- Set `"split": true`
-- Include only the first 5 tasks (the most foundational ones)
-- Set `"remainingDescription"` to a description of the remaining work for a follow-up issue
+Set `"split": true` if ANY of these gates fires. When you set `split: true`, populate `splitReason` with the specific gate that fired (e.g. `"14 distinct files across plan exceeds 12-file budget"`).
 
-The orchestration script will automatically create a follow-up GitHub issue with the remaining work.
+1. **Task count**: more than 5 tasks.
+2. **File count**: ≥ 12 distinct `files` entries across the plan.
+3. **New directory + new build dep**: any task creates a new top-level directory (e.g. `src/core/roundtrip/`) AND introduces a new build-pipeline dependency (esbuild, rollup, webpack, tsup, swc, bun — any bundler/transpiler).
+4. **Skill/ADR doc + code**: any task rewrites a skill or ADR doc (`.claude/skills/**/SKILL.md`, `.claude/docs/ADR.md`, `.claude/docs/ARCHITECTURE.md`) AND ships TypeScript code in the same task.
+5. **Approach length**: any task's `approach` field exceeds ~2500 characters — proxy for under-decomposition.
+
+When splitting: include only the first 5 tasks (or fewer if another gate fires earlier) as the most foundational ones. Put the rest in `remainingDescription` for the auto-created follow-up issue. `splitReason` is REQUIRED when `split: true`.
+
+Gates are triggers, not mandates — if tasks are truly cohesive (e.g. 11 files that share a single seam) you may keep them unified. But err toward splitting: a retry round is more expensive than an extra PR.
 
 ## Rules
 
@@ -67,7 +75,7 @@ The orchestration script will automatically create a follow-up GitHub issue with
 - Each task must have concrete `files` — no vague "update relevant files"
 - Reference existing code patterns: "Follow the pattern in src/core/engine/X.ts"
 - Keep tasks ordered by dependency — task 2 may depend on task 1's output
-- **Max 5 tasks per plan** — split if more are needed
+- Apply the split gates above; set `splitReason` when splitting.
 - Do NOT write any code — only plan
 - Do NOT commit anything
 - Print a one-line summary to stdout when done

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -80,9 +80,13 @@ Registered in `src/cli/index.ts` (lines 71–77) + docs command (line 101). Inte
 - Flow: Plan (agent) → Implement (agent) → Test (cli, retry loop) → Review (agent) → Fix (agent) → Verify (cli) → PR (cli)
 - State tracked in `logs/develop/<issue>--<timestamp>/index.json`
 - Test/Verify steps have internal fix retry loops (max 3 retries with fix agent)
+- Implementer timeout scales with plan size: `max(600s, files * 120s)` capped at 60 min. Up to 2 attempts; the retry stops if attempt 2 wrote the identical file set as attempt 1 (stuck, not flaky). Each attempt writes `implement-attempts/<n>.json`.
+- On Implementer timeout the orchestrator synthesizes a partial `implement-log.json` from the PostToolUse heartbeat (`implement-progress.jsonl`), saves the stderr tail to `implement-err.txt`, and stashes uncommitted work so `--resume --from implement` starts from a clean tree.
+- Planner applies five split gates (task count >5, file count ≥12, new-dir + new-bundler, skill/ADR doc + TS code, approach >2500 chars) and sets `splitReason` in `plan.json` when a gate fires. See `.claude/agents/develop/planner.md` §Split gates.
+- Sub-agent sessions receive `DEVELOP_SUBAGENT=1` so the `.claude/settings.json` Stop hook short-circuits and doesn't flood the user channel with pnpm lint/build output on every agent stop.
 - JSON handoff chain: `plan.json` (designDecisions) → `implement-log.json` (decisions, knownRisks) → `review.json` (implementIntent, intentConflict) → `fix-log.json` (resolution, skipped reasons)
 - Each `claude -p` agent receives previous step JSONs so it understands why, not just what
-- See: issue #247
+- See: issues #247 and #301
 
 ### CLI Commands (Internal)
 
@@ -156,12 +160,16 @@ logs/calibration/REPORT.md                  # Cross-run aggregate report
 logs/develop/                               # Development pipeline runs
 logs/develop/<issue>--<timestamp>/          # One development run = one folder
   ├── index.json                            #   Pipeline state (per-step status, resume point)
-  ├── plan.json                             #   Implementation plan (tasks, designDecisions, risks)
-  ├── implement-log.json                    #   Decisions + knownRisks (context chain for Review/Fix)
+  ├── plan.json                             #   Implementation plan (tasks, designDecisions, splitReason)
+  ├── implement-log.json                    #   Decisions + knownRisks; status=timeout + completedTasks on timeout
   ├── implement-output.txt                  #   Implementer agent raw output
+  ├── implement-progress.jsonl              #   PostToolUse heartbeat (one line per Edit/Write + task-start markers)
+  ├── implement-attempts/<n>.json           #   Per-attempt record (status, filesWritten, lastTaskId) — stall detection input
+  ├── implement-err.txt                     #   Stderr+stdout tail (last 2KB) on Implementer failure
   ├── test-result.json                      #   Test pass/fail + error details
   ├── review.json                           #   Self-review (implementIntent, intentConflict flags)
   ├── fix-log.json                          #   What was fixed/skipped and why
+  ├── circuit.json                          #   Verify retry circuit state (attempt count, error counts)
   └── pr-url.txt                            #   Created PR URL
 logs/activity/                              # Nightly orchestration logs
 ```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm lint 2>&1 && pnpm build 2>&1"
+            "command": "[ \"$DEVELOP_SUBAGENT\" = \"1\" ] && exit 0; OUT=$({ pnpm lint && pnpm build; } 2>&1); [ $? -eq 0 ] || { echo '[stop-hook] pnpm lint/build FAILED'; echo \"$OUT\"; exit 1; }"
           }
         ]
       }
@@ -35,6 +35,10 @@
             "type": "command",
             "command": "npx tsx scripts/sync-rule-docs.ts",
             "if": "Write(**/src/core/rules/**)"
+          },
+          {
+            "type": "command",
+            "command": "bash scripts/develop-heartbeat.sh"
           }
         ]
       }

--- a/scripts/develop-heartbeat.sh
+++ b/scripts/develop-heartbeat.sh
@@ -12,11 +12,22 @@ set +e
 
 [ -n "$DEVELOP_RUN_DIR" ] || exit 0
 
-FILE=$(node -e 'let s=""; process.stdin.on("data",c=>s+=c); process.stdin.on("end",()=>{try{const d=JSON.parse(s);process.stdout.write(d.file_path||"")}catch{}})' <<< "$TOOL_INPUT" 2>/dev/null)
-
-[ -n "$FILE" ] || exit 0
-
-TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-printf '{"t":"%s","file":"%s"}\n' "$TS" "$FILE" >> "$DEVELOP_RUN_DIR/implement-progress.jsonl" 2>/dev/null
+node -e '
+let s = "";
+process.stdin.on("data", (c) => (s += c));
+process.stdin.on("end", () => {
+  try {
+    const d = JSON.parse(s);
+    if (typeof d.file_path !== "string" || d.file_path.length === 0) return;
+    const line = JSON.stringify({
+      t: new Date().toISOString(),
+      file: d.file_path,
+    }) + "\n";
+    require("fs").appendFileSync(
+      require("path").join(process.env.DEVELOP_RUN_DIR, "implement-progress.jsonl"),
+      line,
+    );
+  } catch {}
+})' <<< "$TOOL_INPUT" 2>/dev/null
 
 exit 0

--- a/scripts/develop-heartbeat.sh
+++ b/scripts/develop-heartbeat.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PostToolUse hook — writes a heartbeat line to implement-progress.jsonl when
+# running inside a /develop Implementer sub-agent.
+#
+# Guarded by $DEVELOP_RUN_DIR: short-circuits to no-op in any other session.
+# Hook failures never block the tool call (always exits 0).
+#
+# The orchestrator (scripts/develop.ts) reads this file on timeout via
+# parseHeartbeat() to synthesize a partial implement-log.json.
+
+set +e
+
+[ -n "$DEVELOP_RUN_DIR" ] || exit 0
+
+FILE=$(node -e 'let s=""; process.stdin.on("data",c=>s+=c); process.stdin.on("end",()=>{try{const d=JSON.parse(s);process.stdout.write(d.file_path||"")}catch{}})' <<< "$TOOL_INPUT" 2>/dev/null)
+
+[ -n "$FILE" ] || exit 0
+
+TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+printf '{"t":"%s","file":"%s"}\n' "$TS" "$FILE" >> "$DEVELOP_RUN_DIR/implement-progress.jsonl" 2>/dev/null
+
+exit 0

--- a/scripts/develop.ts
+++ b/scripts/develop.ts
@@ -20,6 +20,8 @@ import {
   writeFileSync,
   existsSync,
   unlinkSync,
+  mkdirSync,
+  rmSync,
 } from "node:fs";
 import { resolve, join } from "node:path";
 import { parseArgs } from "node:util";
@@ -31,6 +33,7 @@ import {
   DEV_STEP_NAMES,
   DEV_STEP_ORDER,
   type DevelopRunIndex,
+  type ImplementAttempt,
   type StepRecord,
 } from "../src/core/contracts/develop-run.js";
 import { createDevelopRunDir } from "../src/agents/run-directory.js";
@@ -40,7 +43,12 @@ import { createDevelopRunDir } from "../src/agents/run-directory.js";
 // ---------------------------------------------------------------------------
 
 const MAX_FIX_ROUNDS = 3;
-const AGENT_TIMEOUT = 600_000; // 10 minutes
+const DEFAULT_AGENT_TIMEOUT = 600_000; // 10 minutes — floor and default for all agents
+// Implementer timeout scales with plan size: max(floor, files * per-file).
+// 120s/file is a first-pass coefficient (issue #301) — tune with run data.
+const IMPLEMENT_TIMEOUT_PER_FILE_MS = 120_000;
+const MAX_IMPLEMENT_TIMEOUT = 3_600_000; // 60 minutes — safety ceiling
+const MAX_IMPLEMENTER_ATTEMPTS = 2; // initial + 1 retry
 const PROJECT_ROOT = resolve(import.meta.dirname ?? ".", "..");
 
 // ---------------------------------------------------------------------------
@@ -150,8 +158,24 @@ function runCli(command: string, label: string): string {
   }
 }
 
+interface RunAgentOptions {
+  timeout?: number;
+  env?: Record<string, string>;
+}
+
+interface AgentError extends Error {
+  isTimeout: boolean;
+  stderr: string;
+  stdout: string;
+}
+
 /** Run a `claude -p` agent with prompt via stdin. Returns stdout. */
-function runAgent(prompt: string, label: string): string {
+function runAgent(
+  prompt: string,
+  label: string,
+  opts: RunAgentOptions = {},
+): string {
+  const timeout = opts.timeout ?? DEFAULT_AGENT_TIMEOUT;
   console.log(`  [agent] ${label}`);
   try {
     return execSync(
@@ -160,14 +184,28 @@ function runAgent(prompt: string, label: string): string {
         input: prompt,
         encoding: "utf-8",
         maxBuffer: 50 * 1024 * 1024,
-        timeout: AGENT_TIMEOUT,
+        timeout,
         cwd: PROJECT_ROOT,
+        env: { ...process.env, ...(opts.env ?? {}) },
       },
     );
   } catch (err) {
-    const execErr = err as SpawnSyncReturns<string>;
+    const execErr = err as SpawnSyncReturns<string> & {
+      signal?: NodeJS.Signals | null;
+      code?: string | number;
+    };
     const stderr = execErr.stderr ?? "";
-    throw new Error(`Agent failed: ${label}\n${stderr}`.trim());
+    const stdout = execErr.stdout ?? "";
+    const isTimeout =
+      execErr.signal === "SIGTERM" || execErr.code === "ETIMEDOUT";
+    const prefix = isTimeout
+      ? `Agent timeout after ${Math.round(timeout / 1000)}s: ${label}`
+      : `Agent failed: ${label}`;
+    const wrapped = new Error(`${prefix}\n${stderr}\n${stdout}`.trim()) as AgentError;
+    wrapped.isTimeout = isTimeout;
+    wrapped.stderr = stderr;
+    wrapped.stdout = stdout;
+    throw wrapped;
   }
 }
 
@@ -191,15 +229,25 @@ function resolveFromStep(from: string): string {
   process.exit(1);
 }
 
-/** Artifacts produced by each step — deleted on resetFrom to avoid stale state. */
+/** Artifacts (files) produced by each step — deleted on resetFrom to avoid stale state. */
 const STEP_ARTIFACTS: Record<string, string[]> = {
   [DEV_STEP_NAMES.PLAN]: ["plan.json"],
-  [DEV_STEP_NAMES.IMPLEMENT]: ["implement-log.json", "implement-output.txt"],
+  [DEV_STEP_NAMES.IMPLEMENT]: [
+    "implement-log.json",
+    "implement-output.txt",
+    "implement-progress.jsonl",
+    "implement-err.txt",
+  ],
   [DEV_STEP_NAMES.TEST]: ["test-result.json"],
   [DEV_STEP_NAMES.REVIEW]: ["review.json", "review-raw.txt"],
   [DEV_STEP_NAMES.FIX]: ["fix-log.json"],
   [DEV_STEP_NAMES.VERIFY]: ["circuit.json"],
   [DEV_STEP_NAMES.PR]: ["pr-url.txt"],
+};
+
+/** Artifact directories produced by each step — recursively removed on resetFrom. */
+const STEP_ARTIFACT_DIRS: Record<string, string[]> = {
+  [DEV_STEP_NAMES.IMPLEMENT]: ["implement-attempts"],
 };
 
 /** Reset a step and all subsequent steps to pending, removing stale artifacts. */
@@ -214,7 +262,7 @@ function resetFrom(index: DevelopRunIndex, fromStep: string): void {
       step.completedAt = undefined;
       step.durationMs = undefined;
 
-      // Delete artifacts produced by this step
+      // Delete file artifacts produced by this step
       const artifacts = STEP_ARTIFACTS[step.name];
       if (artifacts) {
         for (const file of artifacts) {
@@ -222,9 +270,173 @@ function resetFrom(index: DevelopRunIndex, fromStep: string): void {
           if (existsSync(filePath)) unlinkSync(filePath);
         }
       }
+
+      // Recursively remove directory artifacts
+      const artifactDirs = STEP_ARTIFACT_DIRS[step.name];
+      if (artifactDirs) {
+        for (const dir of artifactDirs) {
+          const dirPath = join(index.runDir, dir);
+          if (existsSync(dirPath)) rmSync(dirPath, { recursive: true, force: true });
+        }
+      }
     }
   }
   saveIndex(index);
+}
+
+// ---------------------------------------------------------------------------
+// Implementer observability helpers (#301)
+// ---------------------------------------------------------------------------
+
+interface HeartbeatSummary {
+  filesWritten: string[];
+  completedTasks: number[];
+  lastTaskId: number | undefined;
+}
+
+/**
+ * Parse `implement-progress.jsonl` — returns unique files written and task progression.
+ * Missing or empty file → empty arrays. Malformed lines are ignored.
+ *
+ * The file is written by a PostToolUse hook (one line per Edit/Write) plus
+ * `task-start` markers emitted by the Implementer agent when it begins each task.
+ * Files come from hook lines; task IDs come from agent markers.
+ */
+function parseHeartbeat(runDir: string): HeartbeatSummary {
+  const path = join(runDir, "implement-progress.jsonl");
+  if (!existsSync(path)) {
+    return { filesWritten: [], completedTasks: [], lastTaskId: undefined };
+  }
+  const files = new Set<string>();
+  const tasksSeen: number[] = [];
+  for (const line of readFileSync(path, "utf-8").split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line) as {
+        file?: string;
+        taskId?: number;
+        event?: string;
+      };
+      if (typeof entry.file === "string" && entry.file.length > 0) {
+        files.add(entry.file);
+      }
+      if (typeof entry.taskId === "number") tasksSeen.push(entry.taskId);
+    } catch {
+      // Ignore malformed line — heartbeat is best-effort.
+    }
+  }
+  const lastTaskId = tasksSeen.length > 0 ? tasksSeen[tasksSeen.length - 1] : undefined;
+  // All task IDs except the final one (which was in-progress when the agent stopped)
+  // are considered completed. Deduplicate while preserving insertion order.
+  const completedSet = new Set<number>();
+  for (const id of tasksSeen) {
+    if (id !== lastTaskId) completedSet.add(id);
+  }
+  const completedTasks = [...completedSet];
+  return lastTaskId === undefined
+    ? { filesWritten: [...files], completedTasks, lastTaskId: undefined }
+    : { filesWritten: [...files], completedTasks, lastTaskId };
+}
+
+/** Count unique files across a plan's tasks — used to scale the Implementer timeout. */
+function countPlanFiles(runDir: string): number {
+  const path = join(runDir, "plan.json");
+  if (!existsSync(path)) return 0;
+  try {
+    const plan = readJson<{ tasks?: Array<{ files?: string[] }> }>(path);
+    const set = new Set<string>();
+    for (const task of plan.tasks ?? []) {
+      for (const f of task.files ?? []) set.add(f);
+    }
+    return set.size;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Synthesize a partial `implement-log.json` on timeout and capture stderr tail.
+ * Also stashes uncommitted files so `--resume --from implement` starts from a clean tree.
+ */
+function finalizeImplementerTimeout(
+  runDir: string,
+  attempt: number,
+  err: AgentError,
+): HeartbeatSummary {
+  const summary = parseHeartbeat(runDir);
+
+  const logPath = join(runDir, "implement-log.json");
+  let existing: Record<string, unknown> = {};
+  if (existsSync(logPath)) {
+    try {
+      existing = readJson<Record<string, unknown>>(logPath);
+    } catch {
+      // Malformed partial log — overwrite.
+    }
+  }
+  const commits = Array.isArray(existing.commits) ? (existing.commits as string[]) : [];
+  const decisions = Array.isArray(existing.decisions)
+    ? (existing.decisions as string[])
+    : [];
+  const knownRisks = Array.isArray(existing.knownRisks)
+    ? (existing.knownRisks as string[])
+    : [];
+  const partial = {
+    ...existing,
+    filesChanged: summary.filesWritten,
+    commits,
+    decisions,
+    knownRisks,
+    status: "timeout" as const,
+    completedTasks: summary.completedTasks,
+    timedOutAt: new Date().toISOString(),
+  };
+  writeFileSync(logPath, JSON.stringify(partial, null, 2) + "\n");
+
+  // stderr + stdout tail (last 2KB) for diagnostics
+  const tail = (err.stderr + err.stdout).slice(-2048);
+  writeFileSync(join(runDir, "implement-err.txt"), tail);
+
+  // Stash uncommitted work onto a named stash so resume finds a clean tree.
+  try {
+    const status = execSync("git status --porcelain", {
+      encoding: "utf-8",
+      cwd: PROJECT_ROOT,
+    }).trim();
+    if (status) {
+      const stashMsg = `develop/partial-attempt-${attempt}-${Date.now()}`;
+      execSync(`git stash push -u -m ${shellEscape(stashMsg)}`, {
+        encoding: "utf-8",
+        cwd: PROJECT_ROOT,
+      });
+      console.log(`  [implement] Stashed uncommitted work: ${stashMsg}`);
+    }
+  } catch (stashErr) {
+    console.warn(
+      `  [implement] Warning: failed to stash uncommitted work: ${stashErr instanceof Error ? stashErr.message : String(stashErr)}`,
+    );
+  }
+
+  return summary;
+}
+
+/** Persist a per-attempt record to `implement-attempts/<n>.json`. */
+function writeAttemptLog(
+  attemptsDir: string,
+  attempt: ImplementAttempt,
+): void {
+  writeFileSync(
+    join(attemptsDir, `${attempt.attempt}.json`),
+    JSON.stringify(attempt, null, 2) + "\n",
+  );
+}
+
+/** Set-equal comparison of two filesWritten arrays — used for stall detection. */
+function sameFileSet(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const setA = new Set(a);
+  for (const f of b) if (!setA.has(f)) return false;
+  return true;
 }
 
 /** Abort if the working tree has staged or unstaged changes. */
@@ -453,13 +665,18 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
         }
       }
 
-      const plan = readJson<{ tasks: unknown[]; split?: boolean; remainingDescription?: string }>(join(runDir, "plan.json"));
+      const plan = readJson<{
+        tasks: unknown[];
+        split?: boolean;
+        remainingDescription?: string;
+        splitReason?: string | null;
+      }>(join(runDir, "plan.json"));
 
       // Handle issue splitting
       if (plan.split && plan.remainingDescription) {
         console.log(`  [split] Issue too large — creating follow-up issue...`);
         try {
-          const followUpBody = `## Follow-up from #${issue.number}\n\n${plan.remainingDescription}\n\n---\nAuto-created by \`scripts/develop.ts\` (issue splitting)`;
+          const followUpBody = `## Follow-up from #${issue.number}\n\nSplit reason: ${plan.splitReason ?? "not provided"}\n\n${plan.remainingDescription}\n\n---\nAuto-created by \`scripts/develop.ts\` (issue splitting)`;
           const ghOutput = execSync(
             `gh issue create --title ${shellEscape(`feat: ${issue.title} (part 2)`)} --body ${shellEscape(followUpBody)}`,
             { encoding: "utf-8", cwd: PROJECT_ROOT },
@@ -471,7 +688,7 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
       }
 
       markCompleted(index, DEV_STEP_NAMES.PLAN, {
-        summary: `${plan.tasks.length} tasks planned${plan.split ? " (split)" : ""}`,
+        summary: `${plan.tasks.length} tasks planned${plan.split ? ` (split: ${plan.splitReason ?? "unspecified"})` : ""}`,
         outputs: ["plan.json"],
       });
     } catch (err) {
@@ -481,6 +698,8 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
   }
 
   // ─── Step 2: Implement (agent) ─────────────────────────────────────
+  // Retry loop with dynamic timeout (scaled by plan file count), per-attempt
+  // logging (`implement-attempts/<n>.json`), and stall detection.
   if (shouldRun(DEV_STEP_NAMES.IMPLEMENT)) {
     markRunning(index, DEV_STEP_NAMES.IMPLEMENT);
     try {
@@ -489,22 +708,110 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
       const context = buildContext(issue, runDir, { "plan.json": plan });
       const implementPrompt = `${agentDef}\n\n${context}`;
 
-      // Capture HEAD before run to detect new commits (avoids false positive on resume)
-      const headBefore = execSync("git rev-parse HEAD", {
-        encoding: "utf-8",
-        cwd: PROJECT_ROOT,
-      }).trim();
+      const fileCount = countPlanFiles(runDir);
+      const implementTimeout = Math.min(
+        MAX_IMPLEMENT_TIMEOUT,
+        Math.max(DEFAULT_AGENT_TIMEOUT, fileCount * IMPLEMENT_TIMEOUT_PER_FILE_MS),
+      );
+      console.log(
+        `  [implement] files=${fileCount} timeout=${Math.round(implementTimeout / 1000)}s max-attempts=${MAX_IMPLEMENTER_ATTEMPTS}`,
+      );
 
-      const implOutput = runAgent(implementPrompt, "Implementer");
+      const attemptsDir = join(runDir, "implement-attempts");
+      mkdirSync(attemptsDir, { recursive: true });
 
-      // Check that the implementer created new commits this round
-      const headAfter = execSync("git rev-parse HEAD", {
-        encoding: "utf-8",
-        cwd: PROJECT_ROOT,
-      }).trim();
-      if (headAfter === headBefore) {
-        throw new Error("Implementer did not create any commits");
+      const implementEnv = {
+        DEVELOP_RUN_DIR: runDir,
+        DEVELOP_SUBAGENT: "1",
+      };
+
+      let implOutput = "";
+      let headBefore = "";
+      let previousFilesWritten: string[] | null = null;
+      let lastErr: Error | null = null;
+      let succeeded = false;
+
+      for (let attempt = 1; attempt <= MAX_IMPLEMENTER_ATTEMPTS; attempt++) {
+        headBefore = execSync("git rev-parse HEAD", {
+          encoding: "utf-8",
+          cwd: PROJECT_ROOT,
+        }).trim();
+        const startedAt = new Date().toISOString();
+
+        try {
+          implOutput = runAgent(implementPrompt, `Implementer (attempt ${attempt})`, {
+            timeout: implementTimeout,
+            env: implementEnv,
+          });
+
+          const headAfter = execSync("git rev-parse HEAD", {
+            encoding: "utf-8",
+            cwd: PROJECT_ROOT,
+          }).trim();
+          if (headAfter === headBefore) {
+            throw new Error("Implementer did not create any commits");
+          }
+
+          writeAttemptLog(attemptsDir, {
+            attempt,
+            startedAt,
+            endedAt: new Date().toISOString(),
+            status: "success",
+            filesWritten: parseHeartbeat(runDir).filesWritten,
+          });
+          succeeded = true;
+          break;
+        } catch (err) {
+          const endedAt = new Date().toISOString();
+          const agentErr = err as Partial<AgentError> & Error;
+          const isTimeout = agentErr.isTimeout === true;
+          const summary = parseHeartbeat(runDir);
+
+          if (isTimeout) {
+            finalizeImplementerTimeout(runDir, attempt, agentErr as AgentError);
+          }
+
+          writeAttemptLog(attemptsDir, {
+            attempt,
+            startedAt,
+            endedAt,
+            status: isTimeout ? "timeout" : "error",
+            failureReason: isTimeout
+              ? `timeout after ${Math.round(implementTimeout / 1000)}s`
+              : agentErr.message.slice(0, 500),
+            filesWritten: summary.filesWritten,
+            ...(summary.lastTaskId !== undefined
+              ? { lastTaskId: summary.lastTaskId }
+              : {}),
+            ...(agentErr.stderr || agentErr.stdout
+              ? { err: ((agentErr.stderr ?? "") + (agentErr.stdout ?? "")).slice(-2048) }
+              : {}),
+          });
+
+          lastErr = agentErr;
+
+          if (
+            previousFilesWritten !== null &&
+            sameFileSet(previousFilesWritten, summary.filesWritten)
+          ) {
+            throw new Error(
+              `Implementer stuck: attempt ${attempt} wrote identical files to attempt ${attempt - 1}. ` +
+                `See ${join(runDir, "implement-attempts")}/ and implement-err.txt.`,
+            );
+          }
+          previousFilesWritten = summary.filesWritten;
+        }
       }
+
+      if (!succeeded) {
+        const baseMsg = lastErr?.message ?? "Implementer failed";
+        throw new Error(
+          `${baseMsg}\n` +
+            `Exhausted ${MAX_IMPLEMENTER_ATTEMPTS} attempts. ` +
+            `See ${join(runDir, "implement-attempts")}/ and implement-err.txt for diagnostics.`,
+        );
+      }
+
       const diffStat = execSync(`git diff --stat ${headBefore}..HEAD`, {
         encoding: "utf-8",
         cwd: PROJECT_ROOT,
@@ -524,7 +831,7 @@ async function runPipeline(index: DevelopRunIndex, issue: IssueData): Promise<vo
 
       markCompleted(index, DEV_STEP_NAMES.IMPLEMENT, {
         summary: diffStat.split("\n").pop() ?? "Changes committed",
-        outputs: ["implement-output.txt", "implement-log.json"],
+        outputs: ["implement-output.txt", "implement-log.json", "implement-attempts"],
       });
     } catch (err) {
       markFailed(index, DEV_STEP_NAMES.IMPLEMENT, err instanceof Error ? err.message : String(err));

--- a/src/core/contracts/develop-run.test.ts
+++ b/src/core/contracts/develop-run.test.ts
@@ -1,0 +1,98 @@
+import {
+  ImplementAttemptSchema,
+  ImplementLogSchema,
+  createDevRunIndex,
+  findDevResumePoint,
+} from "./develop-run.js";
+
+describe("ImplementAttemptSchema", () => {
+  const baseAttempt = {
+    attempt: 1,
+    startedAt: "2026-04-18T00:00:00Z",
+    endedAt: "2026-04-18T00:05:00Z",
+    status: "success" as const,
+    filesWritten: ["scripts/develop.ts"],
+  };
+
+  it("accepts a valid success attempt", () => {
+    expect(() => ImplementAttemptSchema.parse(baseAttempt)).not.toThrow();
+  });
+
+  it("accepts timeout with failureReason and lastTaskId", () => {
+    const parsed = ImplementAttemptSchema.parse({
+      ...baseAttempt,
+      status: "timeout",
+      failureReason: "timeout after 600s",
+      lastTaskId: 3,
+      err: "stderr tail",
+    });
+    expect(parsed.status).toBe("timeout");
+    expect(parsed.lastTaskId).toBe(3);
+  });
+
+  it("rejects when startedAt is missing", () => {
+    const { startedAt: _startedAt, ...rest } = baseAttempt;
+    expect(() => ImplementAttemptSchema.parse(rest)).toThrow();
+  });
+
+  it("preserves unknown keys via passthrough", () => {
+    const parsed = ImplementAttemptSchema.parse({
+      ...baseAttempt,
+      custom: "extra",
+    }) as typeof baseAttempt & { custom?: string };
+    expect(parsed.custom).toBe("extra");
+  });
+});
+
+describe("ImplementLogSchema", () => {
+  const baseLog = {
+    filesChanged: ["scripts/develop.ts"],
+    commits: ["feat: add X"],
+    decisions: ["Chose A over B"],
+    knownRisks: [],
+  };
+
+  it("accepts a minimal success log", () => {
+    expect(() => ImplementLogSchema.parse(baseLog)).not.toThrow();
+  });
+
+  it("accepts a timeout log with completedTasks and timedOutAt", () => {
+    const parsed = ImplementLogSchema.parse({
+      ...baseLog,
+      status: "timeout",
+      completedTasks: [1, 2],
+      timedOutAt: "2026-04-18T00:10:00Z",
+    });
+    expect(parsed.status).toBe("timeout");
+    expect(parsed.completedTasks).toEqual([1, 2]);
+  });
+
+  it("rejects when filesChanged is missing", () => {
+    const { filesChanged: _filesChanged, ...rest } = baseLog;
+    expect(() => ImplementLogSchema.parse(rest)).toThrow();
+  });
+});
+
+describe("findDevResumePoint", () => {
+  it("returns the first non-terminal step", () => {
+    const index = createDevRunIndex(42, "test", "develop/42", "/tmp/42");
+    index.steps[0]!.status = "completed";
+    index.steps[1]!.status = "running";
+    expect(findDevResumePoint(index)).toBe("implement");
+  });
+
+  it("returns null when all steps are completed or skipped", () => {
+    const index = createDevRunIndex(42, "test", "develop/42", "/tmp/42");
+    for (const step of index.steps) step.status = "completed";
+    expect(findDevResumePoint(index)).toBeNull();
+  });
+
+  it("skips completed + skipped to find the first pending", () => {
+    const index = createDevRunIndex(42, "test", "develop/42", "/tmp/42");
+    index.steps[0]!.status = "completed";
+    index.steps[1]!.status = "completed";
+    index.steps[2]!.status = "skipped";
+    index.steps[3]!.status = "pending";
+    expect(findDevResumePoint(index)).toBe("review");
+  });
+});

--- a/src/core/contracts/develop-run.ts
+++ b/src/core/contracts/develop-run.ts
@@ -106,3 +106,40 @@ export function findDevResumePoint(index: DevelopRunIndex): string | null {
   }
   return null;
 }
+
+// --- Implementer artifacts ---
+
+/**
+ * Schema for `implement-log.json` produced by the Implementer agent.
+ * Kept `.passthrough()` so the agent can include extra context without failing validation.
+ */
+export const ImplementLogSchema = z
+  .object({
+    filesChanged: z.array(z.string()),
+    commits: z.array(z.string()),
+    decisions: z.array(z.string()),
+    knownRisks: z.array(z.string()),
+    status: z.enum(["success", "timeout"]).optional(),
+    completedTasks: z.array(z.number()).optional(),
+    timedOutAt: z.string().optional(),
+  })
+  .passthrough();
+export type ImplementLog = z.infer<typeof ImplementLogSchema>;
+
+/**
+ * Schema for `implement-attempts/<n>.json` — one record per Implementer attempt.
+ * Used by the retry loop to detect stalled agents (identical filesWritten across attempts).
+ */
+export const ImplementAttemptSchema = z
+  .object({
+    attempt: z.number(),
+    startedAt: z.string(),
+    endedAt: z.string(),
+    status: z.enum(["success", "timeout", "error"]),
+    failureReason: z.string().optional(),
+    filesWritten: z.array(z.string()),
+    lastTaskId: z.number().optional(),
+    err: z.string().optional(),
+  })
+  .passthrough();
+export type ImplementAttempt = z.infer<typeof ImplementAttemptSchema>;


### PR DESCRIPTION
## Summary

Closes the 6 gaps in `/develop` pipeline orchestration documented in #301 (plus one planner-efficiency concern raised in review). Addresses the chicken-and-egg problem where #300 timed out because the size-aware gating and observability that would have caught it did not yet exist.

## What changed

**Implementer (gaps #2, #3, #4, #6)** — `scripts/develop.ts`, `src/core/contracts/develop-run.ts`, `.claude/agents/develop/implementer.md`
- Timeout scales with plan size: `max(600s, files * 120s)` capped at 60 min
- Up to 2 attempts; retry stops if attempt 2 writes the identical file set as attempt 1
- Each attempt writes `implement-attempts/<n>.json` with `{startedAt, endedAt, status, failureReason, filesWritten, lastTaskId, err}`
- On timeout: partial `implement-log.json` synthesized from heartbeat, stderr tail saved to `implement-err.txt`, uncommitted work stashed so `--resume --from implement` starts clean
- `runAgent` distinguishes SIGTERM/ETIMEDOUT from other failures and exposes stderr/stdout on the error object
- Implementer prompt emits `task-start` heartbeat line per plan task

**Hooks (gap #5)** — `.claude/settings.json`, `scripts/develop-heartbeat.sh`
- Stop hook short-circuits when `DEVELOP_SUBAGENT=1` (set by orchestrator), so sub-agent stops don't flood chat
- Top-level Stop hook emits only on failure — captures lint/build output in a variable and re-emits on non-zero exit
- New PostToolUse heartbeat script writes one JSONL line per Edit/Write to `$DEVELOP_RUN_DIR/implement-progress.jsonl`; guarded so it no-ops outside `/develop` sessions

**Planner (gap #1 + docs-first)** — `.claude/agents/develop/planner.md`
- Docs-first exploration: treat `.claude/docs/*.md` as a map, extract candidate paths from it, fall back to Glob/Grep only to resolve specific gaps
- Five explicit split gates (task count >5, file count ≥12, new-dir + new-bundler, skill/ADR doc + TS code, approach >2500 chars) with required `splitReason` when any fires

**Contracts + tests** — `src/core/contracts/develop-run.ts` + `develop-run.test.ts`
- `ImplementLogSchema` + `ImplementAttemptSchema` (both `.passthrough()`)
- 10 new tests cover valid parse, required-field rejection, passthrough, and `findDevResumePoint` edge cases

**Docs** — `.claude/docs/ARCHITECTURE.md`
- New artifacts in the file output block
- Timeout formula, stall-detection rule, split gates, `DEVELOP_SUBAGENT` contract in the `scripts/develop.ts` section

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (769 tests, 47 files)
- [x] `pnpm build` passes
- [x] Heartbeat script unit-tested locally (guards + json extraction + append)
- [x] Stop-hook short-circuit verified with `DEVELOP_SUBAGENT=1`
- [ ] Real `/develop` run on a small issue confirms new artifacts appear (post-merge, against a fresh issue)

## Not in scope

- Per-task Implementer dispatch (YAGNI per issue priority list — dynamic timeout + heartbeat covers the #300 failure mode; revisit only if timeouts recur after landing)

Closes #301

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>