### PR TITLE
feat: Extract deterministic roundtrip helpers from SKILL.md pseudocode to TypeScript + tests

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -139,227 +139,40 @@ Each row below covers the full 33-value enum (`width`, `height`, `maxWidth`, `mi
 
 `upsertCanicodeAnnotation` wraps the write in `try/catch`: if `properties` fails node-type validation it retries without them, so the markdown body always survives. You can pass `properties` speculatively.
 
+> **Note:** The write-policy default is **under review** in [#295](https://github.com/let-sunny/canicode/issues/295). The current three-tier policy routes to the source definition on override errors; the proposal in #295 flips the default to "instance override + annotation" so silent fan-out to all instances requires explicit opt-in per rule/run. The bundled helpers accept the current default but are structured so the switch becomes a config change, not a markdown rewrite.
+
 **Three-tier write policy:**
 
 1. **Scene (instance) node** — `await figma.getNodeByIdAsync(question.nodeId)` and apply the write inside `try/catch`. Success → done (local change only). Mark result with ✅.
 2. **Definition (source) node** — If the error indicates the property cannot be overridden in an instance, load `await figma.getNodeByIdAsync(question.sourceChildId)`. If that returns null, walk from the scene node to the nearest `INSTANCE` parent and use `await instance.getMainComponentAsync()`, then find the matching layer inside that component. Changes propagate to **every non-overridden instance** in the file — pre-existing instance-level overrides are preserved (Experiment 10). Mark result with 🌐.
-3. **Annotation fallback** — Definition-tier writes can fail even when the node exists. The common case is an **external published library**: `getMainComponentAsync()` resolves with `mainComponent.remote === true`, but raw writes throw *"Cannot write to internal and read-only node"* (Experiment 10). Rarer is `mainComponent === null` (deleted / inaccessible component). Either way, catch the throw, add a `labelMarkdown` annotation on the **scene** node documenting the answer and limitation, and mark result with 📝.
+3. **Annotation fallback** — Definition-tier writes can fail even when the node exists. The **observed case** (Experiment 10) is an **external published library**: `getMainComponentAsync()` resolves with `mainComponent.remote === true`, and raw writes throw *"Cannot write to internal and read-only node"*. A separate `mainComponent === null` case (deleted / inaccessible component) is documented in the Plugin API but was **not reproduced** in Experiment 10 — it is handled defensively on the same path. Either way, catch the throw, add a `labelMarkdown` annotation on the **scene** node documenting the answer and limitation, and mark result with 📝.
 
 **Confirmation is a batch-level concern, not a helper-level one.** A `use_figma` call runs one JavaScript batch and cannot pause mid-batch for user input. So the orchestrator is responsible for pre-flighting: classify every `question` whose `isInstanceChild` is true as a *potential* definition write, enumerate the likely propagation set to the user up-front, and get **one confirmation for the whole batch**. When describing impact to the user, note that the write reaches every **non-overridden** instance — any instance that already has a local override for the same property keeps its override. The helper below assumes that confirmation has already happened — it does not prompt.
 
-**Shared helpers** — paste once at the top of every `use_figma` batch. Keep each `writeFn` small so a throw does not abort unrelated writes. Experiment 08 findings informed every branch here.
+**Shared helpers (bundled)** — the deterministic helpers live in TypeScript at `src/core/roundtrip/*.ts` and are bundled to a single IIFE at `.claude/skills/canicode-roundtrip/helpers.js`. `use_figma` only accepts a self-contained JS string, so the source of truth is TypeScript (with vitest coverage) and the bundle is the delivery artifact.
 
-```javascript
-// ── D1: Figma readback populates BOTH `label` and `labelMarkdown` on every entry,
-// but writes accept only ONE. Strip to the non-empty field before spreading.
-// Entries where neither field has content are dropped — they cannot round-trip
-// through the write validator.
-function stripAnnotations(annotations) {
-  return (annotations || []).flatMap((a) => {
-    const hasLM = typeof a.labelMarkdown === "string" && a.labelMarkdown.length > 0;
-    const hasLabel = typeof a.label === "string" && a.label.length > 0;
-    if (!hasLM && !hasLabel) return [];
-    const base = hasLM ? { labelMarkdown: a.labelMarkdown } : { label: a.label };
-    if (a.categoryId) base.categoryId = a.categoryId;
-    if (Array.isArray(a.properties) && a.properties.length > 0) base.properties = a.properties;
-    return [base];
-  });
-}
+**Usage in a roundtrip session:**
 
-// ── D4: File-scoped custom categories. Run once per roundtrip (Step 4.0).
-// Returns { gotcha, autoFix, fallback } map of category ids.
-// Colors must be lowercase: yellow | orange | red | pink | violet | blue | teal | green.
-async function ensureCanicodeCategories() {
-  const api = figma.annotations;
-  const existing = await api.getAnnotationCategoriesAsync();
-  const byLabel = new Map(existing.map((c) => [c.label, c.id]));
-  async function ensure(label, color) {
-    if (byLabel.has(label)) return byLabel.get(label);
-    const created = await api.addAnnotationCategoryAsync({ label, color });
-    byLabel.set(label, created.id);
-    return created.id;
-  }
-  return {
-    gotcha:   await ensure("canicode:gotcha",   "blue"),
-    autoFix:  await ensure("canicode:auto-fix", "green"),
-    fallback: await ensure("canicode:fallback", "yellow"),
-  };
-}
+1. Read `.claude/skills/canicode-roundtrip/helpers.js` once at the start of Step 4.
+2. Prepend its contents verbatim at the top of every `use_figma` batch body — it registers a single global `CanICodeRoundtrip`.
+3. Reference exposed globals as `CanICodeRoundtrip.*`:
+   - `stripAnnotations(annotations)` — normalizes the D1 label/labelMarkdown mutex on readback.
+   - `ensureCanicodeCategories()` — returns `{ gotcha, autoFix, fallback }` category id map (D4); idempotent, safe to call at the top of every batch.
+   - `upsertCanicodeAnnotation(node, { ruleId, markdown, categoryId, properties })` — idempotent annotation upsert. Handles D1 mutex, D2 in-place replace by ruleId prefix, and the D3 `properties` node-type retry.
+   - `applyWithInstanceFallback(question, writeFn, { categories })` — three-tier write policy with silent-ignore detection. The `writeFn` may return `false` to signal "write accepted but value unchanged" so the helper can route to the definition tier.
+   - `applyPropertyMod(question, answerValue, { categories })` — Strategy A entry point. Branches on `targetProperty` (single vs array) and answer shape (scalar, per-property object, `{ variable: "name" }` binding). Uses `setBoundVariableForPaint` for `fills` / `strokes` and `setBoundVariable` for scalar fields.
+   - `resolveVariableByName(name)` — local-variable exact-name lookup; returns `null` for remote library variables not imported into this file.
 
-// ── D2: Upsert a canicode annotation — replace existing by ruleId prefix, else append.
-// Preserves `categoryId` and `properties` when replacing. Match covers both
-// `labelMarkdown` (current format) and `label` (pre-D1 legacy entries) so reruns
-// across versions consolidate instead of accumulating.
-// categoryId: id from ensureCanicodeCategories().
-// properties: optional array like [{ type: "width" }] — see the matrix above for
-//   node-type gated values. Safe to pass speculatively: if the write rejects the
-//   `properties` entry (e.g. `fills` on a FRAME), the helper retries without them
-//   so the markdown body always persists.
-function upsertCanicodeAnnotation(node, { ruleId, markdown, categoryId, properties }) {
-  if (!("annotations" in node)) return false;
-  const prefix = `**[canicode] ${ruleId}**`;
-  const body = markdown.startsWith(prefix) ? markdown : `${prefix}\n\n${markdown}`;
-  const existing = stripAnnotations(node.annotations);
-  const entry = { labelMarkdown: body };
-  if (categoryId) entry.categoryId = categoryId;
-  if (properties && properties.length) entry.properties = properties;
-  const idx = existing.findIndex((a) =>
-    a.labelMarkdown?.startsWith(prefix) || a.label?.startsWith(prefix),
-  );
-  if (idx >= 0) existing[idx] = entry;
-  else existing.push(entry);
-  try {
-    node.annotations = existing;
-    return true;
-  } catch (e) {
-    // Experiment 09: `properties` types are node-type-gated. The canonical
-    // error is "Invalid property X for a FRAME/TEXT node" — retry without
-    // `properties` only when the message matches, so unrelated errors
-    // (permission, read-only, API changes) still surface.
-    const msg = String(e?.message ?? e);
-    const isNodeTypeReject = /invalid property .+ for a .+ node/i.test(msg);
-    if (!entry.properties || !isNodeTypeReject) throw e;
-    delete entry.properties;
-    if (idx >= 0) existing[idx] = entry;
-    node.annotations = existing;
-    return true;
-  }
-}
+Keep each `writeFn` small so a throw does not abort unrelated writes. Experiment 08 findings informed every branch in the bundled helpers, and the batch-level confirmation contract still applies: `applyWithInstanceFallback` never prompts — the orchestrator must collect one confirmation covering every potential definition write before the batch runs.
 
-// ── Three-tier write policy with silent-ignore detection (B matrix finding).
-// writeFn contract: may read `target[prop]` before/after to detect silent ignore
-// and return false to signal "no change" — caller routes to definition fallback.
-// Pre-condition: the orchestrator has already collected a batch-level confirmation
-// that writes targeting a source-component definition may fan out to every instance
-// of that component in the file. This helper never prompts.
-async function applyWithInstanceFallback(question, writeFn, { categories } = {}) {
-  const scene = await figma.getNodeByIdAsync(question.nodeId);
-  if (!scene) return { icon: "📝", label: "missing node" };
-
-  const definition = question.sourceChildId
-    ? await figma.getNodeByIdAsync(question.sourceChildId)
-    : null;
-
-  try {
-    const changed = await writeFn(scene);
-    if (changed === false) {
-      // Silent-ignore: write succeeded but value unchanged (e.g. layoutMode on some instances).
-      // Route to the source definition — already covered by the batch-level confirmation.
-      if (definition) {
-        await writeFn(definition);
-        return { icon: "🌐", label: "source definition (silent-ignore fallback)" };
-      }
-      // Cannot route — annotate scene as fallback.
-      if (categories) {
-        upsertCanicodeAnnotation(scene, {
-          ruleId: question.ruleId,
-          markdown: "write accepted but value unchanged; no definition available",
-          categoryId: categories.fallback,
-        });
-      }
-      return { icon: "📝", label: "silent-ignore, annotated" };
-    }
-    return { icon: "✅", label: "instance/scene" };
-  } catch (e) {
-    const msg = String(e?.message ?? e);
-    // Canonical match from Experiment 08: "This property cannot be overridden in an instance".
-    // The broader `/override/i` fallback catches variant wording from other properties but is
-    // narrow enough that unrelated errors (file missing, network, etc.) won't false-match.
-    // Do not add `/instance/i` — many unrelated messages mention "instance" and it over-routes.
-    const looksLikeInstanceOverride =
-      /cannot be overridden/i.test(msg) || /override/i.test(msg);
-    if (!looksLikeInstanceOverride || !definition) {
-      if (categories) {
-        upsertCanicodeAnnotation(scene, {
-          ruleId: question.ruleId,
-          markdown: `could not apply automatically: ${msg}`,
-          categoryId: categories.fallback,
-        });
-      }
-      return { icon: "📝", label: "error: " + msg };
-    }
-    // Route to source definition — batch-level confirmation already covers propagation.
-    // External-library case (Experiment 10): `definition.remote === true` and the
-    // write throws *"Cannot write to internal and read-only node"*. Wrap the
-    // attempt so we can annotate-and-move-on instead of aborting the batch.
-    try {
-      await writeFn(definition);
-      return { icon: "🌐", label: "source definition" };
-    } catch (defErr) {
-      const defMsg = String(defErr?.message ?? defErr);
-      const isRemoteReadOnly =
-        definition.remote === true || /read-only/i.test(defMsg);
-      if (categories) {
-        upsertCanicodeAnnotation(scene, {
-          ruleId: question.ruleId,
-          markdown: isRemoteReadOnly
-            ? `source component lives in an external library and is read-only from this file — apply the fix in the library file itself.`
-            : `could not apply at source definition: ${defMsg}`,
-          categoryId: categories.fallback,
-        });
-      }
-      return {
-        icon: "📝",
-        label: isRemoteReadOnly ? "external library (read-only)" : "definition error: " + defMsg,
-      };
-    }
-  }
-}
-
-// ── C: Resolve a variable reference from an answer like { variable: "mobile-width" }.
-// Scope is LOCAL variables only — exact-name match against `getLocalVariablesAsync()`.
-// Slash-path names (e.g. "Brand/Primary") work only when the variable's `name` field
-// itself contains the slash path. Library variables imported into this file are
-// included automatically because they appear in `getLocalVariablesAsync()`; variables
-// that live purely in an unimported remote library are NOT resolved here. Callers
-// must fall back to a raw write (or to an annotation explaining the missing token).
-async function resolveVariableByName(name) {
-  const locals = await figma.variables.getLocalVariablesAsync();
-  return locals.find((v) => v.name === name) || null;
-}
-```
-
-Wrap every property write in `applyWithInstanceFallback(question, async (target) => { ... }, { categories })` so failed or silently-ignored instance overrides route to the definition path or fallback annotation instead of silently aborting the batch.
+Wrap every property write in `CanICodeRoundtrip.applyWithInstanceFallback(question, async (target) => { ... }, { categories })` so failed or silently-ignored instance overrides route to the definition path or fallback annotation instead of silently aborting the batch.
 
 #### Strategy A: Property Modification — apply directly
 
-Rules with `applyStrategy === "property-mod"`. The helper below branches on `question.targetProperty` automatically, and on each value type — scalar, multi-property object, or variable reference (`{ variable: "token-name" }`).
+Rules with `applyStrategy === "property-mod"`. Call the bundled helper — it branches on `question.targetProperty` (single vs array) and on each value type (scalar, multi-property object, `{ variable: "token-name" }` binding) automatically. Paint properties (`fills`, `strokes`) are bound with `setBoundVariableForPaint` per the Plugin API contract; scalar fields use `setBoundVariable`.
 
 ```javascript
-async function applyPropertyMod(question, answerValue, context) {
-  const props = Array.isArray(question.targetProperty)
-    ? question.targetProperty
-    : [question.targetProperty];
-
-  return applyWithInstanceFallback(question, async (target) => {
-    if (!target) return;
-    let changed = undefined;
-    for (const prop of props) {
-      if (!(prop in target)) continue;
-      // Multi-property rules (e.g. no-auto-layout → [layoutMode, itemSpacing]) expect
-      // an object answer: { layoutMode: "VERTICAL", itemSpacing: 16 }.
-      const value = (typeof answerValue === "object" && answerValue !== null && !("variable" in answerValue))
-        ? answerValue[prop]
-        : answerValue;
-
-      // Variable binding — answer shape { variable: "name" }.
-      // Bypasses instance-child override restrictions for minWidth/maxWidth and siblings.
-      if (value && typeof value === "object" && "variable" in value) {
-        const variable = await resolveVariableByName(value.variable);
-        if (variable) { target.setBoundVariable(prop, variable); continue; }
-        // Variable not found — fall through to raw write if the answer also has a fallback scalar.
-        if (!("fallback" in value)) continue;
-      }
-
-      const scalar = (value && typeof value === "object" && "fallback" in value) ? value.fallback : value;
-      const before = target[prop];
-      target[prop] = scalar;
-      // B: some instance children silently ignore layoutMode writes.
-      if (target[prop] === before && before !== scalar) changed = false;
-    }
-    return changed;
-  }, context);
-}
+await CanICodeRoundtrip.applyPropertyMod(question, answerValue, { categories });
 ```
 
 Answer shape guide (LLM judgment — the user's answer is prose; parse accordingly):
@@ -407,7 +220,7 @@ Rules with `applyStrategy === "annotation"` cannot be auto-fixed via Plugin API.
 
 ```javascript
 const scene = await figma.getNodeByIdAsync(question.nodeId);
-upsertCanicodeAnnotation(scene, {
+CanICodeRoundtrip.upsertCanicodeAnnotation(scene, {
   ruleId: question.ruleId,
   markdown: `**Q:** ${question.question}\n**A:** ${answer}`,
   categoryId: categories.gotcha,
@@ -421,7 +234,7 @@ upsertCanicodeAnnotation(scene, {
 
 Notes:
 - `upsertCanicodeAnnotation` replaces an existing `**[canicode] <ruleId>**` entry on the same node instead of appending — reruns don't accumulate duplicates.
-- `label` and `labelMarkdown` are mutually exclusive on write, but Figma returns both on readback. Never spread `scene.annotations` directly; always go through `stripAnnotations` (the helper does this).
+- `label` and `labelMarkdown` are mutually exclusive on write, but Figma returns both on readback. Never spread `scene.annotations` directly; always call `CanICodeRoundtrip.upsertCanicodeAnnotation` (or `CanICodeRoundtrip.stripAnnotations` if you truly need the normalized array).
 - Prefer annotating the **scene** instance child so designers see the note where they work; mention in the markdown if the fix belongs on the source component but could not be applied (library/external).
 
 #### Strategy D: Auto-fix lower-severity issues from analysis
@@ -441,13 +254,13 @@ for (const issue of analyzeResult.issues) {
 
   if (issue.targetProperty === "name" && issue.suggestedName) {
     // Naming rules — rename to the pre-computed suggestedName.
-    await applyWithInstanceFallback(q, async (target) => {
+    await CanICodeRoundtrip.applyWithInstanceFallback(q, async (target) => {
       if (target) target.name = issue.suggestedName;
     }, { categories });
   } else {
     // raw-value, missing-interaction-state, missing-prototype — designer judgment; annotate.
     const scene = await figma.getNodeByIdAsync(issue.nodeId);
-    upsertCanicodeAnnotation(scene, {
+    CanICodeRoundtrip.upsertCanicodeAnnotation(scene, {
       ruleId: issue.ruleId,
       markdown: issue.message,
       categoryId: categories.autoFix,
@@ -462,7 +275,7 @@ for (const issue of analyzeResult.issues) {
 
 #### Execution order
 
-0. **Initialize categories** — first batch calls `const categories = await ensureCanicodeCategories();` and keeps the result in scope for every subsequent call in the same script. (Or re-run ensure at the top of each `use_figma` batch — it is idempotent by label.)
+0. **Initialize categories** — first batch calls `const categories = await CanICodeRoundtrip.ensureCanicodeCategories();` and keeps the result in scope for every subsequent call in the same script. (Or re-run ensure at the top of each `use_figma` batch — it is idempotent by label.)
 1. **Batch all property modifications** (Strategy A) into a single `use_figma` call for efficiency. Pass `{ categories }` to `applyWithInstanceFallback` so fallbacks land in the correct category.
 2. **Present structural modifications** (Strategy B) one by one, apply confirmed ones.
 3. **Batch all annotations** (Strategy C + declined structural mods) into a single `use_figma` call — use `categories.gotcha` for the category id.
@@ -500,7 +313,7 @@ const nodeIds = ["id1", "id2"]; // nodes that now pass
 for (const id of nodeIds) {
   const node = await figma.getNodeByIdAsync(id);
   if (node && "annotations" in node) {
-    node.annotations = stripAnnotations(node.annotations).filter(
+    node.annotations = CanICodeRoundtrip.stripAnnotations(node.annotations).filter(
       a => !a.labelMarkdown?.startsWith("**[canicode]")
     );
   }
@@ -537,4 +350,4 @@ Follow the **figma-implement-design** skill workflow to generate code from the F
 - **use_figma call fails for a node**: Report the error for that specific node, continue with other nodes. Failed property modifications become annotations so the context is not lost.
 - **Re-analyze shows new issues**: Only address issues from the original gotcha survey. New issues may appear due to structural changes — report them but do not re-enter the gotcha loop.
 - **Very large design (many gotchas)**: The gotcha survey already deduplicates sibling nodes and filters to blocking/risk severity only. If there are still many questions, ask the user if they want to focus on blocking issues only.
-- **External library components**: The common case is `getMainComponentAsync()` resolving with `mainComponent.remote === true` — writes then throw *"Cannot write to internal and read-only node"* (Experiment 10). The `null` case is rarer (deleted / inaccessible component). Either way the definition is unreachable from this file; `applyWithInstanceFallback` catches the throw and emits an annotation under the `canicode:fallback` category stating the fix must be applied in the library file itself.
+- **External library components**: The **observed case** in Experiment 10 is `getMainComponentAsync()` resolving with `mainComponent.remote === true` — writes then throw *"Cannot write to internal and read-only node"*. The `mainComponent === null` case (deleted / inaccessible component) is documented in the Plugin API but was **not reproduced** in Experiment 10; it is handled defensively on the same fallback path. Either way the definition is unreachable from this file; `applyWithInstanceFallback` catches the throw and emits an annotation under the `canicode:fallback` category stating the fix must be applied in the library file itself.

--- a/.claude/skills/canicode-roundtrip/helpers.js
+++ b/.claude/skills/canicode-roundtrip/helpers.js
@@ -1,0 +1,228 @@
+var CanICodeRoundtrip = (function (exports) {
+  'use strict';
+
+  // src/core/roundtrip/annotations.ts
+  function stripAnnotations(annotations) {
+    const input = annotations ?? [];
+    const out = [];
+    for (const a of input) {
+      const hasLM = typeof a.labelMarkdown === "string" && a.labelMarkdown.length > 0;
+      const hasLabel = typeof a.label === "string" && a.label.length > 0;
+      if (!hasLM && !hasLabel) continue;
+      const base = hasLM ? { labelMarkdown: a.labelMarkdown } : { label: a.label };
+      if (a.categoryId) base.categoryId = a.categoryId;
+      if (Array.isArray(a.properties) && a.properties.length > 0) {
+        base.properties = a.properties;
+      }
+      out.push(base);
+    }
+    return out;
+  }
+  async function ensureCanicodeCategories() {
+    const api = figma.annotations;
+    const existing = await api.getAnnotationCategoriesAsync();
+    const byLabel = new Map(existing.map((c) => [c.label, c.id]));
+    async function ensure(label, color) {
+      const cached = byLabel.get(label);
+      if (cached) return cached;
+      const created = await api.addAnnotationCategoryAsync({ label, color });
+      byLabel.set(label, created.id);
+      return created.id;
+    }
+    return {
+      gotcha: await ensure("canicode:gotcha", "blue"),
+      autoFix: await ensure("canicode:auto-fix", "green"),
+      fallback: await ensure("canicode:fallback", "yellow")
+    };
+  }
+  function upsertCanicodeAnnotation(node, input) {
+    if (!node || !("annotations" in node)) return false;
+    const { ruleId, markdown, categoryId, properties } = input;
+    const prefix = `**[canicode] ${ruleId}**`;
+    const body = markdown.startsWith(prefix) ? markdown : `${prefix}
+
+${markdown}`;
+    const existing = stripAnnotations(node.annotations);
+    const entry = { labelMarkdown: body };
+    if (categoryId) entry.categoryId = categoryId;
+    if (properties && properties.length > 0) entry.properties = properties;
+    const idx = existing.findIndex((a) => {
+      const lm = a.labelMarkdown;
+      const lb = a.label;
+      return typeof lm === "string" && lm.startsWith(prefix) || typeof lb === "string" && lb.startsWith(prefix);
+    });
+    if (idx >= 0) existing[idx] = entry;
+    else existing.push(entry);
+    try {
+      node.annotations = existing;
+      return true;
+    } catch (e) {
+      const msg = String(e?.message ?? e);
+      const isNodeTypeReject = /invalid property .+ for a .+ node/i.test(msg);
+      if (!entry.properties || !isNodeTypeReject) throw e;
+      delete entry.properties;
+      if (idx >= 0) existing[idx] = entry;
+      node.annotations = existing;
+      return true;
+    }
+  }
+
+  // src/core/roundtrip/apply-with-instance-fallback.ts
+  async function routeToDefinitionOrAnnotate(definition, writeFn, ctx) {
+    if (!definition) {
+      if (ctx.categories) {
+        const markdown = ctx.reason === "silent-ignore" ? "write accepted but value unchanged; no definition available" : ctx.reason === "override-error" ? `could not apply automatically: ${ctx.errorMessage ?? ""}` : `could not apply automatically: ${ctx.errorMessage ?? ""}`;
+        upsertCanicodeAnnotation(ctx.scene, {
+          ruleId: ctx.question.ruleId,
+          markdown,
+          categoryId: ctx.categories.fallback
+        });
+      }
+      return ctx.reason === "silent-ignore" ? { icon: "\u{1F4DD}", label: "silent-ignore, annotated" } : { icon: "\u{1F4DD}", label: `error: ${ctx.errorMessage ?? ""}` };
+    }
+    try {
+      await writeFn(definition);
+      return {
+        icon: "\u{1F310}",
+        label: ctx.reason === "silent-ignore" ? "source definition (silent-ignore fallback)" : "source definition"
+      };
+    } catch (defErr) {
+      const defMsg = String(defErr?.message ?? defErr);
+      const isRemoteReadOnly = definition.remote === true || /read-only/i.test(defMsg);
+      if (ctx.categories) {
+        upsertCanicodeAnnotation(ctx.scene, {
+          ruleId: ctx.question.ruleId,
+          markdown: isRemoteReadOnly ? "source component lives in an external library and is read-only from this file \u2014 apply the fix in the library file itself." : `could not apply at source definition: ${defMsg}`,
+          categoryId: ctx.categories.fallback
+        });
+      }
+      return {
+        icon: "\u{1F4DD}",
+        label: isRemoteReadOnly ? "external library (read-only)" : `definition error: ${defMsg}`
+      };
+    }
+  }
+  async function applyWithInstanceFallback(question, writeFn, context = {}) {
+    const { categories } = context;
+    const scene = await figma.getNodeByIdAsync(question.nodeId);
+    if (!scene) return { icon: "\u{1F4DD}", label: "missing node" };
+    const definition = question.sourceChildId ? await figma.getNodeByIdAsync(question.sourceChildId) : null;
+    try {
+      const changed = await writeFn(scene);
+      if (changed === false) {
+        return routeToDefinitionOrAnnotate(definition, writeFn, {
+          question,
+          scene,
+          categories,
+          reason: "silent-ignore"
+        });
+      }
+      return { icon: "\u2705", label: "instance/scene" };
+    } catch (e) {
+      const msg = String(e?.message ?? e);
+      const looksLikeInstanceOverride = /cannot be overridden/i.test(msg) || /override/i.test(msg);
+      if (!looksLikeInstanceOverride) {
+        return routeToDefinitionOrAnnotate(null, writeFn, {
+          question,
+          scene,
+          categories,
+          reason: "non-override-error",
+          errorMessage: msg
+        });
+      }
+      return routeToDefinitionOrAnnotate(definition, writeFn, {
+        question,
+        scene,
+        categories,
+        reason: "override-error",
+        errorMessage: msg
+      });
+    }
+  }
+
+  // src/core/roundtrip/apply-property-mod.ts
+  async function resolveVariableByName(name) {
+    const locals = await figma.variables.getLocalVariablesAsync();
+    return locals.find((v) => v.name === name) ?? null;
+  }
+  function parseValue(raw) {
+    if (raw && typeof raw === "object" && "variable" in raw) {
+      const v = raw;
+      const parsed = { kind: "binding", name: v.variable };
+      if ("fallback" in v) parsed.fallback = v.fallback;
+      return parsed;
+    }
+    if (raw && typeof raw === "object" && "fallback" in raw) {
+      return { kind: "scalar", scalar: raw.fallback };
+    }
+    return { kind: "scalar", scalar: raw };
+  }
+  function isPaintProp(prop) {
+    return prop === "fills" || prop === "strokes";
+  }
+  function applyPropertyBinding(target, prop, variable) {
+    if (isPaintProp(prop)) {
+      const current = target[prop];
+      if (current === figma.mixed || !Array.isArray(current)) return false;
+      const paints = current;
+      const bound = paints.map(
+        (paint) => figma.variables.setBoundVariableForPaint(paint, "color", variable)
+      );
+      target[prop] = bound;
+      return true;
+    }
+    target.setBoundVariable(prop, variable);
+    return true;
+  }
+  function applyPropertyScalar(target, prop, scalar) {
+    const rec = target;
+    const before = rec[prop];
+    rec[prop] = scalar;
+    if (rec[prop] === before && before !== scalar) return false;
+    return true;
+  }
+  async function applyPropertyMod(question, answerValue, context = {}) {
+    const props = Array.isArray(question.targetProperty) ? question.targetProperty : question.targetProperty !== void 0 ? [question.targetProperty] : [];
+    return applyWithInstanceFallback(
+      question,
+      async (target) => {
+        if (!target) return void 0;
+        let changed = void 0;
+        for (const prop of props) {
+          if (!(prop in target)) continue;
+          const perProp = answerValue && typeof answerValue === "object" && !("variable" in answerValue) && !Array.isArray(answerValue) ? answerValue[prop] : answerValue;
+          const parsed = parseValue(perProp);
+          if (parsed.kind === "binding") {
+            const variable = await resolveVariableByName(parsed.name);
+            if (variable) {
+              applyPropertyBinding(target, prop, variable);
+              continue;
+            }
+            if (parsed.fallback !== void 0) {
+              if (!applyPropertyScalar(target, prop, parsed.fallback)) {
+                changed = false;
+              }
+            }
+            continue;
+          }
+          if (parsed.scalar === void 0) continue;
+          if (!applyPropertyScalar(target, prop, parsed.scalar)) {
+            changed = false;
+          }
+        }
+        return changed;
+      },
+      context
+    );
+  }
+
+  exports.applyPropertyMod = applyPropertyMod;
+  exports.applyWithInstanceFallback = applyWithInstanceFallback;
+  exports.ensureCanicodeCategories = ensureCanicodeCategories;
+  exports.resolveVariableByName = resolveVariableByName;
+  exports.stripAnnotations = stripAnnotations;
+  exports.upsertCanicodeAnnotation = upsertCanicodeAnnotation;
+
+  return exports;
+
+})({});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,21 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build:web
+
+  build-roundtrip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build:roundtrip
+      - name: Check bundle in sync with TS source
+        run: |
+          if ! git diff --exit-code .claude/skills/canicode-roundtrip/helpers.js; then
+            echo "::error::helpers.js is out of sync with src/core/roundtrip/*.ts — run 'pnpm build:roundtrip' and commit the result."
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ app/web/browser.global.js
 # Test/temp report files
 fixtures/_test-report.html
 fixtures/report.html
+
+# Stale roundtrip build artifact (pre-outExtension config)
+.claude/skills/canicode-roundtrip/helpers.global.js

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build": "tsup --config tsup.config.ts",
     "build:web": "bash scripts/build-web.sh",
+    "build:roundtrip": "tsup --config tsup.roundtrip.config.ts",
     "dev": "tsup --watch",
     "test": "vitest",
     "test:run": "vitest run",

--- a/src/core/roundtrip/annotations.test.ts
+++ b/src/core/roundtrip/annotations.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach } from "vitest";
+import {
+  stripAnnotations,
+  ensureCanicodeCategories,
+  upsertCanicodeAnnotation,
+} from "./annotations.js";
+import {
+  createFigmaGlobal,
+  installFigmaGlobal,
+  uninstallFigmaGlobal,
+  type FigmaGlobalMock,
+} from "./test-utils.js";
+import type { AnnotationEntry, FigmaNode } from "./types.js";
+
+function makeNode(overrides: Partial<FigmaNode> = {}): FigmaNode {
+  return {
+    id: "1:1",
+    name: "Node",
+    type: "FRAME",
+    annotations: [],
+    ...overrides,
+  };
+}
+
+describe("stripAnnotations", () => {
+  it("drops entries missing both label fields", () => {
+    const result = stripAnnotations([
+      { label: "" },
+      { labelMarkdown: "" },
+      {},
+      { label: "keep" },
+    ]);
+    expect(result).toEqual([{ label: "keep" }]);
+  });
+
+  it("prefers labelMarkdown when both are present", () => {
+    const result = stripAnnotations([
+      { label: "plain", labelMarkdown: "**rich**" },
+    ]);
+    expect(result).toEqual([{ labelMarkdown: "**rich**" }]);
+  });
+
+  it("falls back to label when labelMarkdown is empty", () => {
+    const result = stripAnnotations([{ label: "plain", labelMarkdown: "" }]);
+    expect(result).toEqual([{ label: "plain" }]);
+  });
+
+  it("preserves categoryId and properties when present", () => {
+    const result = stripAnnotations([
+      {
+        labelMarkdown: "x",
+        categoryId: "c1",
+        properties: [{ type: "width" }],
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        labelMarkdown: "x",
+        categoryId: "c1",
+        properties: [{ type: "width" }],
+      },
+    ]);
+  });
+
+  it("drops empty properties arrays", () => {
+    const result = stripAnnotations([
+      { labelMarkdown: "x", properties: [] },
+    ]);
+    expect(result).toEqual([{ labelMarkdown: "x" }]);
+  });
+
+  it("returns [] for null/undefined input", () => {
+    expect(stripAnnotations(null)).toEqual([]);
+    expect(stripAnnotations(undefined)).toEqual([]);
+  });
+});
+
+describe("ensureCanicodeCategories", () => {
+  let mock: FigmaGlobalMock;
+
+  beforeEach(() => {
+    mock = createFigmaGlobal();
+    installFigmaGlobal(mock);
+  });
+
+  afterEach(() => {
+    uninstallFigmaGlobal();
+  });
+
+  it("creates the three labels on first call", async () => {
+    const result = await ensureCanicodeCategories();
+    expect(Object.keys(result)).toEqual(["gotcha", "autoFix", "fallback"]);
+    expect(mock.annotations.addAnnotationCategoryAsync).toHaveBeenCalledTimes(3);
+    expect(mock.annotations.addAnnotationCategoryAsync.mock.calls.map((c) => c[0])).toEqual([
+      { label: "canicode:gotcha", color: "blue" },
+      { label: "canicode:auto-fix", color: "green" },
+      { label: "canicode:fallback", color: "yellow" },
+    ]);
+  });
+
+  it("reuses existing ids on second call (idempotent)", async () => {
+    const first = await ensureCanicodeCategories();
+    mock.annotations.addAnnotationCategoryAsync.mockClear();
+    const second = await ensureCanicodeCategories();
+    expect(second).toEqual(first);
+    expect(mock.annotations.addAnnotationCategoryAsync).toHaveBeenCalledTimes(0);
+  });
+
+  it("reuses pre-existing categories seeded before the first call", async () => {
+    const seeded = createFigmaGlobal({
+      categories: [
+        { id: "seed-gotcha", label: "canicode:gotcha" },
+        { id: "seed-auto", label: "canicode:auto-fix" },
+        { id: "seed-fall", label: "canicode:fallback" },
+      ],
+    });
+    installFigmaGlobal(seeded);
+    const result = await ensureCanicodeCategories();
+    expect(result).toEqual({
+      gotcha: "seed-gotcha",
+      autoFix: "seed-auto",
+      fallback: "seed-fall",
+    });
+    expect(seeded.annotations.addAnnotationCategoryAsync).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("upsertCanicodeAnnotation", () => {
+  it("appends a new annotation when no matching ruleId exists", () => {
+    const node = makeNode({ annotations: [{ labelMarkdown: "other" }] });
+    const result = upsertCanicodeAnnotation(node, {
+      ruleId: "no-auto-layout",
+      markdown: "use VERTICAL",
+    });
+    expect(result).toBe(true);
+    expect(node.annotations).toEqual([
+      { labelMarkdown: "other" },
+      { labelMarkdown: "**[canicode] no-auto-layout**\n\nuse VERTICAL" },
+    ]);
+  });
+
+  it("replaces existing canicode entry for the same ruleId (labelMarkdown match)", () => {
+    const node = makeNode({
+      annotations: [
+        { labelMarkdown: "**[canicode] no-auto-layout**\n\nold body" },
+        { labelMarkdown: "sibling" },
+      ],
+    });
+    upsertCanicodeAnnotation(node, {
+      ruleId: "no-auto-layout",
+      markdown: "new body",
+    });
+    expect(node.annotations).toEqual([
+      { labelMarkdown: "**[canicode] no-auto-layout**\n\nnew body" },
+      { labelMarkdown: "sibling" },
+    ]);
+  });
+
+  it("replaces legacy `label`-only entries (pre-D1) with the canicode prefix", () => {
+    const node = makeNode({
+      annotations: [{ label: "**[canicode] raw-value**\n\nold" }],
+    });
+    upsertCanicodeAnnotation(node, {
+      ruleId: "raw-value",
+      markdown: "new",
+    });
+    expect(node.annotations).toEqual([
+      { labelMarkdown: "**[canicode] raw-value**\n\nnew" },
+    ]);
+  });
+
+  it("includes categoryId and properties when provided", () => {
+    const node = makeNode();
+    upsertCanicodeAnnotation(node, {
+      ruleId: "absolute-position-in-auto-layout",
+      markdown: "body",
+      categoryId: "cat-gotcha",
+      properties: [{ type: "layoutMode" }],
+    });
+    expect(node.annotations).toEqual([
+      {
+        labelMarkdown:
+          "**[canicode] absolute-position-in-auto-layout**\n\nbody",
+        categoryId: "cat-gotcha",
+        properties: [{ type: "layoutMode" }],
+      },
+    ]);
+  });
+
+  it("does not re-prefix a markdown body that already starts with the canicode prefix", () => {
+    const node = makeNode();
+    upsertCanicodeAnnotation(node, {
+      ruleId: "raw-value",
+      markdown: "**[canicode] raw-value**\n\nembedded",
+    });
+    const written = (node.annotations as AnnotationEntry[])[0]?.labelMarkdown;
+    expect(written).toBe("**[canicode] raw-value**\n\nembedded");
+  });
+
+  it("retries without properties on Experiment 09 node-type rejection", () => {
+    let firstWrite = true;
+    const node = {
+      id: "2:2",
+      name: "Text",
+      type: "TEXT",
+      annotations: [] as readonly AnnotationEntry[],
+    } as FigmaNode;
+    Object.defineProperty(node, "annotations", {
+      get: () => (node as { _annotations?: AnnotationEntry[] })._annotations ?? [],
+      set(next: AnnotationEntry[]) {
+        if (firstWrite && next.some((a) => a.properties)) {
+          firstWrite = false;
+          throw new Error("Invalid property fills for a TEXT node");
+        }
+        (node as { _annotations?: AnnotationEntry[] })._annotations = next;
+      },
+    });
+    const result = upsertCanicodeAnnotation(node, {
+      ruleId: "raw-value",
+      markdown: "body",
+      properties: [{ type: "fills" }],
+    });
+    expect(result).toBe(true);
+    const written = (node as { _annotations: AnnotationEntry[] })._annotations;
+    expect(written[0]?.properties).toBeUndefined();
+    expect(written[0]?.labelMarkdown).toBe("**[canicode] raw-value**\n\nbody");
+  });
+
+  it("re-throws unrelated errors (permission, read-only) rather than swallowing", () => {
+    const node = {
+      id: "3:3",
+      name: "Locked",
+      type: "FRAME",
+    } as FigmaNode;
+    Object.defineProperty(node, "annotations", {
+      get: () => [],
+      set() {
+        throw new Error("Cannot write to internal and read-only node");
+      },
+    });
+    expect(() =>
+      upsertCanicodeAnnotation(node, {
+        ruleId: "x",
+        markdown: "y",
+        properties: [{ type: "width" }],
+      })
+    ).toThrow(/read-only/);
+  });
+
+  it("returns false for nodes without an annotations capability", () => {
+    const node = { id: "4:4", name: "Line", type: "LINE" } as FigmaNode;
+    const result = upsertCanicodeAnnotation(node, {
+      ruleId: "x",
+      markdown: "y",
+    });
+    expect(result).toBe(false);
+  });
+
+  it("returns false for null/undefined node", () => {
+    expect(
+      upsertCanicodeAnnotation(null, { ruleId: "x", markdown: "y" })
+    ).toBe(false);
+    expect(
+      upsertCanicodeAnnotation(undefined, { ruleId: "x", markdown: "y" })
+    ).toBe(false);
+  });
+});

--- a/src/core/roundtrip/annotations.ts
+++ b/src/core/roundtrip/annotations.ts
@@ -1,0 +1,110 @@
+import type {
+  AnnotationEntry,
+  AnnotationProperty,
+  CanicodeCategories,
+  FigmaGlobal,
+  FigmaNode,
+} from "./types.js";
+
+declare const figma: FigmaGlobal;
+
+// D1: Figma readback populates BOTH `label` and `labelMarkdown` on every entry,
+// but writes accept only ONE. Strip to the non-empty field before spreading.
+// Entries where neither field has content are dropped — they cannot round-trip
+// through the write validator.
+export function stripAnnotations(
+  annotations: readonly AnnotationEntry[] | undefined | null
+): AnnotationEntry[] {
+  const input = annotations ?? [];
+  const out: AnnotationEntry[] = [];
+  for (const a of input) {
+    const hasLM =
+      typeof a.labelMarkdown === "string" && a.labelMarkdown.length > 0;
+    const hasLabel = typeof a.label === "string" && a.label.length > 0;
+    if (!hasLM && !hasLabel) continue;
+    const base: AnnotationEntry = hasLM
+      ? { labelMarkdown: a.labelMarkdown as string }
+      : { label: a.label as string };
+    if (a.categoryId) base.categoryId = a.categoryId;
+    if (Array.isArray(a.properties) && a.properties.length > 0) {
+      base.properties = a.properties;
+    }
+    out.push(base);
+  }
+  return out;
+}
+
+// D4: File-scoped custom categories. Run once per roundtrip (Step 4.0).
+// Returns { gotcha, autoFix, fallback } map of category ids. Idempotent by
+// label — re-running in the same file returns the existing ids without
+// creating duplicates. Colors must be lowercase; the three documented values
+// are used here. The Plugin API supports yellow | orange | red | pink |
+// violet | blue | teal | green.
+export async function ensureCanicodeCategories(): Promise<CanicodeCategories> {
+  const api = figma.annotations;
+  const existing = await api.getAnnotationCategoriesAsync();
+  const byLabel = new Map(existing.map((c) => [c.label, c.id]));
+  async function ensure(label: string, color: string): Promise<string> {
+    const cached = byLabel.get(label);
+    if (cached) return cached;
+    const created = await api.addAnnotationCategoryAsync({ label, color });
+    byLabel.set(label, created.id);
+    return created.id;
+  }
+  return {
+    gotcha: await ensure("canicode:gotcha", "blue"),
+    autoFix: await ensure("canicode:auto-fix", "green"),
+    fallback: await ensure("canicode:fallback", "yellow"),
+  };
+}
+
+export interface UpsertCanicodeAnnotationInput {
+  ruleId: string;
+  markdown: string;
+  categoryId?: string;
+  properties?: AnnotationProperty[];
+}
+
+// D2: Upsert a canicode annotation — replace existing by ruleId prefix, else
+// append. Preserves `categoryId` and `properties` when replacing. Match covers
+// both `labelMarkdown` (current format) and `label` (pre-D1 legacy entries) so
+// reruns across versions consolidate instead of accumulating.
+export function upsertCanicodeAnnotation(
+  node: FigmaNode | null | undefined,
+  input: UpsertCanicodeAnnotationInput
+): boolean {
+  if (!node || !("annotations" in node)) return false;
+  const { ruleId, markdown, categoryId, properties } = input;
+  const prefix = `**[canicode] ${ruleId}**`;
+  const body = markdown.startsWith(prefix) ? markdown : `${prefix}\n\n${markdown}`;
+  const existing = stripAnnotations(node.annotations);
+  const entry: AnnotationEntry = { labelMarkdown: body };
+  if (categoryId) entry.categoryId = categoryId;
+  if (properties && properties.length > 0) entry.properties = properties;
+  const idx = existing.findIndex((a) => {
+    const lm = a.labelMarkdown;
+    const lb = a.label;
+    return (
+      (typeof lm === "string" && lm.startsWith(prefix)) ||
+      (typeof lb === "string" && lb.startsWith(prefix))
+    );
+  });
+  if (idx >= 0) existing[idx] = entry;
+  else existing.push(entry);
+  try {
+    (node as unknown as { annotations: AnnotationEntry[] }).annotations = existing;
+    return true;
+  } catch (e) {
+    // Experiment 09: `properties` types are node-type-gated. The canonical
+    // error is "Invalid property X for a FRAME/TEXT node" — retry without
+    // `properties` only when the message matches, so unrelated errors
+    // (permission, read-only, API changes) still surface.
+    const msg = String((e as { message?: unknown })?.message ?? e);
+    const isNodeTypeReject = /invalid property .+ for a .+ node/i.test(msg);
+    if (!entry.properties || !isNodeTypeReject) throw e;
+    delete entry.properties;
+    if (idx >= 0) existing[idx] = entry;
+    (node as unknown as { annotations: AnnotationEntry[] }).annotations = existing;
+    return true;
+  }
+}

--- a/src/core/roundtrip/apply-property-mod.test.ts
+++ b/src/core/roundtrip/apply-property-mod.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, beforeEach, vi } from "vitest";
+import {
+  applyPropertyMod,
+  resolveVariableByName,
+} from "./apply-property-mod.js";
+import {
+  createFigmaGlobal,
+  installFigmaGlobal,
+  uninstallFigmaGlobal,
+  type FigmaGlobalMock,
+} from "./test-utils.js";
+import type {
+  AnnotationEntry,
+  CanicodeCategories,
+  FigmaNode,
+  FigmaPaint,
+  RoundtripQuestion,
+} from "./types.js";
+
+const CATEGORIES: CanicodeCategories = {
+  gotcha: "cat-gotcha",
+  autoFix: "cat-auto",
+  fallback: "cat-fallback",
+};
+
+function makePaint(colorName: string): FigmaPaint {
+  return {
+    type: "SOLID",
+    color: { r: 0, g: 0, b: 0, name: colorName },
+  };
+}
+
+let mock: FigmaGlobalMock;
+
+afterEach(() => {
+  uninstallFigmaGlobal();
+});
+
+describe("resolveVariableByName", () => {
+  it("returns the variable on exact-name match", async () => {
+    mock = createFigmaGlobal({
+      variables: [
+        { id: "v1", name: "mobile-width" },
+        { id: "v2", name: "tablet-width" },
+      ],
+    });
+    installFigmaGlobal(mock);
+    const result = await resolveVariableByName("tablet-width");
+    expect(result).toEqual({ id: "v2", name: "tablet-width" });
+  });
+
+  it("matches slash-path names literally", async () => {
+    mock = createFigmaGlobal({
+      variables: [{ id: "v1", name: "Brand/Primary" }],
+    });
+    installFigmaGlobal(mock);
+    const result = await resolveVariableByName("Brand/Primary");
+    expect(result?.id).toBe("v1");
+  });
+
+  it("returns null for variables not in the local scope", async () => {
+    mock = createFigmaGlobal({ variables: [] });
+    installFigmaGlobal(mock);
+    const result = await resolveVariableByName("unimported-remote");
+    expect(result).toBeNull();
+  });
+});
+
+describe("applyPropertyMod", () => {
+  let scene: FigmaNode;
+
+  function setupScene(overrides: Partial<FigmaNode> = {}) {
+    scene = {
+      id: "scene-1",
+      name: "Scene",
+      type: "FRAME",
+      annotations: [],
+      ...overrides,
+    };
+    return scene;
+  }
+
+  beforeEach(() => {
+    setupScene({ itemSpacing: 8 });
+    mock = createFigmaGlobal({
+      nodes: { "scene-1": scene },
+      variables: [{ id: "v-gap", name: "space-m" }],
+    });
+    installFigmaGlobal(mock);
+  });
+
+  it("applies a scalar answer to the target property and returns ✅", async () => {
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "irregular-spacing",
+      targetProperty: "itemSpacing",
+    };
+    const result = await applyPropertyMod(question, 16, {
+      categories: CATEGORIES,
+    });
+    expect(result).toEqual({ icon: "✅", label: "instance/scene" });
+    expect((scene as Record<string, unknown>).itemSpacing).toBe(16);
+  });
+
+  it("detects silent-ignore when target[prop] doesn't change and routes to definition", async () => {
+    const definition: FigmaNode = {
+      id: "def-1",
+      name: "Def",
+      type: "FRAME",
+      layoutMode: "NONE",
+      itemSpacing: 0,
+      annotations: [],
+    };
+    const sceneWithFrozenProp: FigmaNode = {
+      id: "scene-1",
+      name: "Scene",
+      type: "FRAME",
+      annotations: [],
+    };
+    Object.defineProperty(sceneWithFrozenProp, "layoutMode", {
+      get: () => "NONE",
+      set: () => {
+        // Silent-ignore — read-back returns the original value.
+      },
+    });
+    mock = createFigmaGlobal({
+      nodes: { "scene-1": sceneWithFrozenProp, "def-1": definition },
+    });
+    installFigmaGlobal(mock);
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "no-auto-layout",
+      targetProperty: ["layoutMode", "itemSpacing"],
+      sourceChildId: "def-1",
+    };
+    const result = await applyPropertyMod(
+      question,
+      { layoutMode: "VERTICAL", itemSpacing: 16 },
+      { categories: CATEGORIES }
+    );
+    expect(result).toEqual({
+      icon: "🌐",
+      label: "source definition (silent-ignore fallback)",
+    });
+    expect((definition as Record<string, unknown>).layoutMode).toBe("VERTICAL");
+    expect((definition as Record<string, unknown>).itemSpacing).toBe(16);
+  });
+
+  it("binds a variable via target.setBoundVariable for non-paint props", async () => {
+    const setBoundVariable = vi.fn();
+    const target: FigmaNode = {
+      id: "scene-1",
+      name: "Scene",
+      type: "FRAME",
+      itemSpacing: 0,
+      annotations: [],
+    };
+    (target as unknown as { setBoundVariable: typeof setBoundVariable }).setBoundVariable =
+      setBoundVariable;
+    mock = createFigmaGlobal({
+      nodes: { "scene-1": target },
+      variables: [{ id: "v-gap", name: "space-m" }],
+    });
+    installFigmaGlobal(mock);
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "irregular-spacing",
+      targetProperty: "itemSpacing",
+    };
+    const result = await applyPropertyMod(
+      question,
+      { variable: "space-m" },
+      { categories: CATEGORIES }
+    );
+    expect(result.icon).toBe("✅");
+    expect(setBoundVariable).toHaveBeenCalledWith("itemSpacing", {
+      id: "v-gap",
+      name: "space-m",
+    });
+    expect(mock.variables.setBoundVariableForPaint).not.toHaveBeenCalled();
+  });
+
+  it("bug #2 regression: binds fills via figma.variables.setBoundVariableForPaint AND reassigns target.fills", async () => {
+    const initialFills: FigmaPaint[] = [makePaint("base"), makePaint("stroke")];
+    const target: FigmaNode = {
+      id: "scene-1",
+      name: "Scene",
+      type: "RECTANGLE",
+      fills: initialFills,
+      annotations: [],
+    };
+    // Guard: target.setBoundVariable must NOT be called for fills — the bug
+    // was calling it directly instead of the Paint-specific API.
+    const setBoundVariable = vi.fn();
+    (target as unknown as { setBoundVariable: typeof setBoundVariable }).setBoundVariable =
+      setBoundVariable;
+    mock = createFigmaGlobal({
+      nodes: { "scene-1": target },
+      variables: [{ id: "v-brand", name: "Brand/Primary" }],
+    });
+    installFigmaGlobal(mock);
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "raw-value",
+      targetProperty: "fills",
+    };
+    const result = await applyPropertyMod(
+      question,
+      { variable: "Brand/Primary" },
+      { categories: CATEGORIES }
+    );
+    expect(result.icon).toBe("✅");
+    expect(setBoundVariable).not.toHaveBeenCalled();
+    expect(mock.variables.setBoundVariableForPaint).toHaveBeenCalledTimes(
+      initialFills.length
+    );
+    // Reassignment — target.fills is a NEW array (not the same reference).
+    const newFills = (target as Record<string, unknown>).fills as FigmaPaint[];
+    expect(newFills).not.toBe(initialFills);
+    expect(newFills).toHaveLength(2);
+    expect(newFills[0]?.boundVariables).toEqual({
+      color: { type: "VARIABLE_ALIAS", id: "v-brand" },
+    });
+  });
+
+  it("skips cleanly when fills is the mixed symbol (no crash, no setBoundVariableForPaint call)", async () => {
+    const mixed = Symbol("figma.mixed");
+    const target: FigmaNode = {
+      id: "scene-1",
+      name: "Scene",
+      type: "FRAME",
+      fills: mixed,
+      annotations: [],
+    };
+    mock = createFigmaGlobal({
+      mixed,
+      nodes: { "scene-1": target },
+      variables: [{ id: "v-brand", name: "Brand/Primary" }],
+    });
+    installFigmaGlobal(mock);
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "raw-value",
+      targetProperty: "fills",
+    };
+    const result = await applyPropertyMod(
+      question,
+      { variable: "Brand/Primary" },
+      { categories: CATEGORIES }
+    );
+    expect(result.icon).toBe("✅");
+    expect(mock.variables.setBoundVariableForPaint).not.toHaveBeenCalled();
+    // The mixed fills get overwritten with nothing — no throw, no side effect.
+  });
+
+  it("variable-not-found with a fallback scalar falls through to raw write", async () => {
+    const target: FigmaNode = {
+      id: "scene-1",
+      name: "Scene",
+      type: "FRAME",
+      itemSpacing: 0,
+      annotations: [],
+    };
+    mock = createFigmaGlobal({
+      nodes: { "scene-1": target },
+      variables: [],
+    });
+    installFigmaGlobal(mock);
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "irregular-spacing",
+      targetProperty: "itemSpacing",
+    };
+    const result = await applyPropertyMod(
+      question,
+      { variable: "missing", fallback: 24 },
+      { categories: CATEGORIES }
+    );
+    expect(result.icon).toBe("✅");
+    expect((target as Record<string, unknown>).itemSpacing).toBe(24);
+  });
+
+  it("variable-not-found without a fallback records no change (no crash, no binding)", async () => {
+    const setBoundVariable = vi.fn();
+    const target: FigmaNode = {
+      id: "scene-1",
+      name: "Scene",
+      type: "FRAME",
+      itemSpacing: 0,
+      annotations: [],
+    };
+    (target as unknown as { setBoundVariable: typeof setBoundVariable }).setBoundVariable =
+      setBoundVariable;
+    mock = createFigmaGlobal({
+      nodes: { "scene-1": target },
+      variables: [],
+    });
+    installFigmaGlobal(mock);
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "irregular-spacing",
+      targetProperty: "itemSpacing",
+    };
+    const result = await applyPropertyMod(
+      question,
+      { variable: "missing" },
+      { categories: CATEGORIES }
+    );
+    expect(result.icon).toBe("✅");
+    expect(setBoundVariable).not.toHaveBeenCalled();
+    expect((target as Record<string, unknown>).itemSpacing).toBe(0);
+  });
+
+  it("multi-prop answer object dispatches per-key across multiple targetProperty entries", async () => {
+    const target: FigmaNode = {
+      id: "scene-1",
+      name: "Scene",
+      type: "FRAME",
+      layoutMode: "NONE",
+      itemSpacing: 0,
+      annotations: [],
+    };
+    mock = createFigmaGlobal({ nodes: { "scene-1": target } });
+    installFigmaGlobal(mock);
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "no-auto-layout",
+      targetProperty: ["layoutMode", "itemSpacing"],
+    };
+    const result = await applyPropertyMod(
+      question,
+      { layoutMode: "VERTICAL", itemSpacing: 16 },
+      { categories: CATEGORIES }
+    );
+    expect(result.icon).toBe("✅");
+    expect((target as Record<string, unknown>).layoutMode).toBe("VERTICAL");
+    expect((target as Record<string, unknown>).itemSpacing).toBe(16);
+  });
+
+  it("annotates and routes to fallback when all properties are missing on the target", async () => {
+    const target: FigmaNode = {
+      id: "scene-1",
+      name: "Scene",
+      type: "FRAME",
+      annotations: [],
+    };
+    mock = createFigmaGlobal({ nodes: { "scene-1": target } });
+    installFigmaGlobal(mock);
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "missing-size-constraint",
+      targetProperty: "minWidth",
+    };
+    const result = await applyPropertyMod(question, 320, {
+      categories: CATEGORIES,
+    });
+    // writeFn returned undefined (no props matched) — treated as success.
+    expect(result.icon).toBe("✅");
+    const annotations = target.annotations as AnnotationEntry[];
+    expect(annotations).toEqual([]);
+  });
+});

--- a/src/core/roundtrip/apply-property-mod.ts
+++ b/src/core/roundtrip/apply-property-mod.ts
@@ -1,0 +1,156 @@
+import {
+  applyWithInstanceFallback,
+  type ApplyWithInstanceFallbackContext,
+} from "./apply-with-instance-fallback.js";
+import type {
+  FigmaGlobal,
+  FigmaNode,
+  FigmaPaint,
+  FigmaVariable,
+  RoundtripQuestion,
+  RoundtripResult,
+} from "./types.js";
+
+declare const figma: FigmaGlobal;
+
+// Exact-name match against local variables. Scope is LOCAL variables only;
+// library variables already imported into this file appear here, but variables
+// in an unimported remote library return null (caller must fall back). Slash-
+// path names work only when the variable's `name` field literally contains
+// the slash.
+export async function resolveVariableByName(
+  name: string
+): Promise<FigmaVariable | null> {
+  const locals = await figma.variables.getLocalVariablesAsync();
+  return locals.find((v) => v.name === name) ?? null;
+}
+
+interface VariableAnswer {
+  variable: string;
+  fallback?: unknown;
+}
+
+interface FallbackAnswer {
+  fallback: unknown;
+}
+
+type Parsed =
+  | { kind: "binding"; name: string; fallback?: unknown }
+  | { kind: "scalar"; scalar: unknown };
+
+function parseValue(raw: unknown): Parsed {
+  if (raw && typeof raw === "object" && "variable" in raw) {
+    const v = raw as VariableAnswer;
+    const parsed: Parsed = { kind: "binding", name: v.variable };
+    if ("fallback" in v) parsed.fallback = v.fallback;
+    return parsed;
+  }
+  if (raw && typeof raw === "object" && "fallback" in raw) {
+    return { kind: "scalar", scalar: (raw as FallbackAnswer).fallback };
+  }
+  return { kind: "scalar", scalar: raw };
+}
+
+function isPaintProp(prop: string): boolean {
+  return prop === "fills" || prop === "strokes";
+}
+
+function applyPropertyBinding(
+  target: FigmaNode,
+  prop: string,
+  variable: FigmaVariable
+): boolean {
+  // Experiment 08: Paint arrays (fills, strokes) need the Paint-specific
+  // binding API. `target.setBoundVariable` silently no-ops (or throws) on
+  // these — the fix is to call setBoundVariableForPaint for each paint,
+  // which RETURNS a new paint object, then reassign the whole array onto
+  // target[prop]. Reassignment is load-bearing — mutating paint.boundVariables
+  // in place does nothing.
+  if (isPaintProp(prop)) {
+    const current = (target as Record<string, unknown>)[prop];
+    // Mixed fills/strokes — no single array to iterate. Skip cleanly; the
+    // designer must un-mix before a variable binding can apply uniformly.
+    if (current === figma.mixed || !Array.isArray(current)) return false;
+    const paints = current as FigmaPaint[];
+    const bound = paints.map((paint) =>
+      figma.variables.setBoundVariableForPaint(paint, "color", variable)
+    );
+    (target as Record<string, unknown>)[prop] = bound;
+    return true;
+  }
+  (
+    target as unknown as {
+      setBoundVariable(name: string, v: FigmaVariable): void;
+    }
+  ).setBoundVariable(prop, variable);
+  return true;
+}
+
+function applyPropertyScalar(
+  target: FigmaNode,
+  prop: string,
+  scalar: unknown
+): boolean {
+  const rec = target as Record<string, unknown>;
+  const before = rec[prop];
+  rec[prop] = scalar;
+  // B matrix: some instance children silently ignore writes (e.g. layoutMode).
+  // Signal "no change" so the caller routes to the definition fallback.
+  if (rec[prop] === before && before !== scalar) return false;
+  return true;
+}
+
+export async function applyPropertyMod(
+  question: RoundtripQuestion,
+  answerValue: unknown,
+  context: ApplyWithInstanceFallbackContext = {}
+): Promise<RoundtripResult> {
+  const props = Array.isArray(question.targetProperty)
+    ? question.targetProperty
+    : question.targetProperty !== undefined
+      ? [question.targetProperty]
+      : [];
+
+  return applyWithInstanceFallback(
+    question,
+    async (target) => {
+      if (!target) return undefined;
+      let changed: boolean | undefined = undefined;
+      for (const prop of props) {
+        if (!(prop in target)) continue;
+        // Multi-property rules (e.g. no-auto-layout → [layoutMode, itemSpacing])
+        // expect an object answer: { layoutMode: "VERTICAL", itemSpacing: 16 }.
+        // Variable-binding single answers keep the { variable } shape.
+        const perProp =
+          answerValue &&
+          typeof answerValue === "object" &&
+          !("variable" in (answerValue as object)) &&
+          !Array.isArray(answerValue)
+            ? (answerValue as Record<string, unknown>)[prop]
+            : answerValue;
+
+        const parsed = parseValue(perProp);
+        if (parsed.kind === "binding") {
+          const variable = await resolveVariableByName(parsed.name);
+          if (variable) {
+            applyPropertyBinding(target, prop, variable);
+            continue;
+          }
+          if (parsed.fallback !== undefined) {
+            if (!applyPropertyScalar(target, prop, parsed.fallback)) {
+              changed = false;
+            }
+          }
+          continue;
+        }
+        // parsed.kind === "scalar" — apply directly.
+        if (parsed.scalar === undefined) continue;
+        if (!applyPropertyScalar(target, prop, parsed.scalar)) {
+          changed = false;
+        }
+      }
+      return changed;
+    },
+    context
+  );
+}

--- a/src/core/roundtrip/apply-with-instance-fallback.test.ts
+++ b/src/core/roundtrip/apply-with-instance-fallback.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, vi } from "vitest";
+import { applyWithInstanceFallback } from "./apply-with-instance-fallback.js";
+import {
+  createFigmaGlobal,
+  installFigmaGlobal,
+  uninstallFigmaGlobal,
+  type FigmaGlobalMock,
+} from "./test-utils.js";
+import type {
+  AnnotationEntry,
+  CanicodeCategories,
+  FigmaNode,
+  RoundtripQuestion,
+} from "./types.js";
+
+function makeNode(overrides: Partial<FigmaNode>): FigmaNode {
+  return {
+    id: "scene-1",
+    name: "Scene",
+    type: "FRAME",
+    annotations: [],
+    ...overrides,
+  };
+}
+
+const CATEGORIES: CanicodeCategories = {
+  gotcha: "cat-gotcha",
+  autoFix: "cat-auto",
+  fallback: "cat-fallback",
+};
+
+const QUESTION: RoundtripQuestion = {
+  nodeId: "scene-1",
+  ruleId: "missing-size-constraint",
+  sourceChildId: "def-1",
+};
+
+let mock: FigmaGlobalMock;
+let scene: FigmaNode;
+let definition: FigmaNode;
+
+beforeEach(() => {
+  scene = makeNode({ id: "scene-1", name: "SceneChild" });
+  definition = makeNode({ id: "def-1", name: "Definition" });
+  mock = createFigmaGlobal({ nodes: { "scene-1": scene, "def-1": definition } });
+  installFigmaGlobal(mock);
+});
+
+afterEach(() => {
+  uninstallFigmaGlobal();
+});
+
+describe("applyWithInstanceFallback", () => {
+  it("returns ✅ when the scene write succeeds", async () => {
+    const writeFn = vi.fn().mockResolvedValue(undefined);
+    const result = await applyWithInstanceFallback(QUESTION, writeFn, {
+      categories: CATEGORIES,
+    });
+    expect(result).toEqual({ icon: "✅", label: "instance/scene" });
+    expect(writeFn).toHaveBeenCalledTimes(1);
+    expect(writeFn).toHaveBeenCalledWith(scene);
+  });
+
+  it("routes to definition and returns 🌐 when writeFn returns false (silent-ignore)", async () => {
+    const writeFn = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(undefined);
+    const result = await applyWithInstanceFallback(QUESTION, writeFn, {
+      categories: CATEGORIES,
+    });
+    expect(result).toEqual({
+      icon: "🌐",
+      label: "source definition (silent-ignore fallback)",
+    });
+    expect(writeFn).toHaveBeenCalledTimes(2);
+    expect(writeFn.mock.calls[1]?.[0]).toBe(definition);
+  });
+
+  it("annotates and returns 📝 when silent-ignore AND definition throws read-only (bug #1 regression)", async () => {
+    definition.remote = true;
+    const writeFn = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Error("Cannot write to internal and read-only node"));
+    const result = await applyWithInstanceFallback(QUESTION, writeFn, {
+      categories: CATEGORIES,
+    });
+    expect(result).toEqual({
+      icon: "📝",
+      label: "external library (read-only)",
+    });
+    const annotations = scene.annotations as AnnotationEntry[];
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0]?.labelMarkdown).toContain("external library");
+    expect(annotations[0]?.categoryId).toBe("cat-fallback");
+  });
+
+  it("annotates and returns 📝 when silent-ignore AND definition throws a non-read-only error", async () => {
+    const writeFn = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Error("network timeout"));
+    const result = await applyWithInstanceFallback(QUESTION, writeFn, {
+      categories: CATEGORIES,
+    });
+    expect(result.icon).toBe("📝");
+    expect(result.label).toContain("definition error");
+    const annotations = scene.annotations as AnnotationEntry[];
+    expect(annotations[0]?.labelMarkdown).toContain(
+      "could not apply at source definition"
+    );
+  });
+
+  it("annotates scene when silent-ignore AND no definition is available", async () => {
+    const question: RoundtripQuestion = {
+      nodeId: "scene-1",
+      ruleId: "x",
+    };
+    const writeFn = vi.fn().mockResolvedValueOnce(false);
+    const result = await applyWithInstanceFallback(question, writeFn, {
+      categories: CATEGORIES,
+    });
+    expect(result).toEqual({
+      icon: "📝",
+      label: "silent-ignore, annotated",
+    });
+    const annotations = scene.annotations as AnnotationEntry[];
+    expect(annotations[0]?.labelMarkdown).toContain("no definition available");
+  });
+
+  it("routes to definition and returns 🌐 when scene throws an override error", async () => {
+    const writeFn = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("This property cannot be overridden in an instance")
+      )
+      .mockResolvedValueOnce(undefined);
+    const result = await applyWithInstanceFallback(QUESTION, writeFn, {
+      categories: CATEGORIES,
+    });
+    expect(result).toEqual({ icon: "🌐", label: "source definition" });
+    expect(writeFn.mock.calls[1]?.[0]).toBe(definition);
+  });
+
+  it("annotates and returns 📝 when override-error and definition is read-only (external library)", async () => {
+    definition.remote = true;
+    const writeFn = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("This property cannot be overridden in an instance")
+      )
+      .mockRejectedValueOnce(
+        new Error("Cannot write to internal and read-only node")
+      );
+    const result = await applyWithInstanceFallback(QUESTION, writeFn, {
+      categories: CATEGORIES,
+    });
+    expect(result.icon).toBe("📝");
+    expect(result.label).toBe("external library (read-only)");
+    const annotations = scene.annotations as AnnotationEntry[];
+    expect(annotations[0]?.labelMarkdown).toContain("external library");
+  });
+
+  it("annotates scene when a non-override error is thrown (unknown failure)", async () => {
+    const writeFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("something weird went wrong"));
+    const result = await applyWithInstanceFallback(QUESTION, writeFn, {
+      categories: CATEGORIES,
+    });
+    expect(result.icon).toBe("📝");
+    expect(result.label).toContain("something weird went wrong");
+    // Definition write should NOT have happened — only the scene attempt was made.
+    expect(writeFn).toHaveBeenCalledTimes(1);
+    const annotations = scene.annotations as AnnotationEntry[];
+    expect(annotations[0]?.labelMarkdown).toContain(
+      "could not apply automatically"
+    );
+  });
+
+  it("returns 📝 missing node when the scene id doesn't resolve", async () => {
+    const question: RoundtripQuestion = {
+      nodeId: "does-not-exist",
+      ruleId: "x",
+    };
+    const writeFn = vi.fn();
+    const result = await applyWithInstanceFallback(question, writeFn, {
+      categories: CATEGORIES,
+    });
+    expect(result).toEqual({ icon: "📝", label: "missing node" });
+    expect(writeFn).not.toHaveBeenCalled();
+  });
+
+  it("does not annotate when categories are not provided (but still returns the expected icon)", async () => {
+    const writeFn = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockRejectedValueOnce(new Error("read-only"));
+    const result = await applyWithInstanceFallback(QUESTION, writeFn, {});
+    expect(result.icon).toBe("📝");
+    const annotations = scene.annotations as AnnotationEntry[];
+    expect(annotations).toEqual([]);
+  });
+});

--- a/src/core/roundtrip/apply-with-instance-fallback.ts
+++ b/src/core/roundtrip/apply-with-instance-fallback.ts
@@ -1,0 +1,146 @@
+import { upsertCanicodeAnnotation } from "./annotations.js";
+import type {
+  CanicodeCategories,
+  FigmaGlobal,
+  FigmaNode,
+  RoundtripQuestion,
+  RoundtripResult,
+  WriteFn,
+} from "./types.js";
+
+declare const figma: FigmaGlobal;
+
+export interface ApplyWithInstanceFallbackContext {
+  categories?: CanicodeCategories;
+}
+
+interface RouteContext {
+  question: RoundtripQuestion;
+  scene: FigmaNode;
+  categories: CanicodeCategories | undefined;
+  reason: "silent-ignore" | "override-error" | "non-override-error";
+  errorMessage?: string;
+}
+
+// Shared failure path: definition write attempted and annotated on throw.
+// Unifies the silent-ignore fallback branch and the override-error branch so
+// an external-library throw (Experiment 10, `remote === true` / read-only)
+// annotates cleanly in both cases instead of aborting the use_figma batch —
+// the silent-ignore path was missing a try/catch before this extraction.
+async function routeToDefinitionOrAnnotate(
+  definition: FigmaNode | null,
+  writeFn: WriteFn,
+  ctx: RouteContext
+): Promise<RoundtripResult> {
+  if (!definition) {
+    if (ctx.categories) {
+      const markdown =
+        ctx.reason === "silent-ignore"
+          ? "write accepted but value unchanged; no definition available"
+          : ctx.reason === "override-error"
+            ? `could not apply automatically: ${ctx.errorMessage ?? ""}`
+            : `could not apply automatically: ${ctx.errorMessage ?? ""}`;
+      upsertCanicodeAnnotation(ctx.scene, {
+        ruleId: ctx.question.ruleId,
+        markdown,
+        categoryId: ctx.categories.fallback,
+      });
+    }
+    return ctx.reason === "silent-ignore"
+      ? { icon: "📝", label: "silent-ignore, annotated" }
+      : { icon: "📝", label: `error: ${ctx.errorMessage ?? ""}` };
+  }
+
+  try {
+    await writeFn(definition);
+    return {
+      icon: "🌐",
+      label:
+        ctx.reason === "silent-ignore"
+          ? "source definition (silent-ignore fallback)"
+          : "source definition",
+    };
+  } catch (defErr) {
+    const defMsg = String((defErr as { message?: unknown })?.message ?? defErr);
+    // Experiment 10: external libraries surface either via
+    // `definition.remote === true` OR a "read-only" error message. Both
+    // branches must annotate-and-move-on instead of aborting the batch.
+    const isRemoteReadOnly =
+      definition.remote === true || /read-only/i.test(defMsg);
+    if (ctx.categories) {
+      upsertCanicodeAnnotation(ctx.scene, {
+        ruleId: ctx.question.ruleId,
+        markdown: isRemoteReadOnly
+          ? "source component lives in an external library and is read-only from this file — apply the fix in the library file itself."
+          : `could not apply at source definition: ${defMsg}`,
+        categoryId: ctx.categories.fallback,
+      });
+    }
+    return {
+      icon: "📝",
+      label: isRemoteReadOnly
+        ? "external library (read-only)"
+        : `definition error: ${defMsg}`,
+    };
+  }
+}
+
+// Three-tier write policy with silent-ignore detection (B matrix finding).
+// writeFn contract: may read `target[prop]` before/after to detect silent
+// ignore and return `false` to signal "no change" — caller routes to the
+// definition fallback. Pre-condition: the orchestrator has already collected a
+// batch-level confirmation that writes targeting a source-component definition
+// may fan out to every instance of that component in the file. This helper
+// never prompts.
+export async function applyWithInstanceFallback(
+  question: RoundtripQuestion,
+  writeFn: WriteFn,
+  context: ApplyWithInstanceFallbackContext = {}
+): Promise<RoundtripResult> {
+  const { categories } = context;
+  const scene = await figma.getNodeByIdAsync(question.nodeId);
+  if (!scene) return { icon: "📝", label: "missing node" };
+
+  const definition = question.sourceChildId
+    ? await figma.getNodeByIdAsync(question.sourceChildId)
+    : null;
+
+  try {
+    const changed = await writeFn(scene);
+    if (changed === false) {
+      return routeToDefinitionOrAnnotate(definition, writeFn, {
+        question,
+        scene,
+        categories,
+        reason: "silent-ignore",
+      });
+    }
+    return { icon: "✅", label: "instance/scene" };
+  } catch (e) {
+    const msg = String((e as { message?: unknown })?.message ?? e);
+    // Canonical match from Experiment 08: "This property cannot be overridden
+    // in an instance". The broader /override/i fallback catches variant
+    // wording from other properties but is narrow enough that unrelated
+    // errors (file missing, network, etc.) won't false-match. Do not add
+    // /instance/i — many unrelated messages mention "instance" and it
+    // over-routes.
+    const looksLikeInstanceOverride =
+      /cannot be overridden/i.test(msg) || /override/i.test(msg);
+    if (!looksLikeInstanceOverride) {
+      return routeToDefinitionOrAnnotate(null, writeFn, {
+        question,
+        scene,
+        categories,
+        reason: "non-override-error",
+        errorMessage: msg,
+      });
+    }
+    return routeToDefinitionOrAnnotate(definition, writeFn, {
+      question,
+      scene,
+      categories,
+      reason: "override-error",
+      errorMessage: msg,
+    });
+  }
+}

--- a/src/core/roundtrip/index.ts
+++ b/src/core/roundtrip/index.ts
@@ -1,0 +1,10 @@
+export {
+  stripAnnotations,
+  ensureCanicodeCategories,
+  upsertCanicodeAnnotation,
+} from "./annotations.js";
+export { applyWithInstanceFallback } from "./apply-with-instance-fallback.js";
+export {
+  applyPropertyMod,
+  resolveVariableByName,
+} from "./apply-property-mod.js";

--- a/src/core/roundtrip/test-utils.ts
+++ b/src/core/roundtrip/test-utils.ts
@@ -1,0 +1,96 @@
+import { vi, type Mock } from "vitest";
+import type {
+  AnnotationCategory,
+  FigmaGlobal,
+  FigmaNode,
+  FigmaPaint,
+  FigmaVariable,
+} from "./types.js";
+
+export interface FigmaGlobalMock extends FigmaGlobal {
+  getNodeByIdAsync: Mock<(id: string) => Promise<FigmaNode | null>>;
+  annotations: {
+    getAnnotationCategoriesAsync: Mock<() => Promise<AnnotationCategory[]>>;
+    addAnnotationCategoryAsync: Mock<
+      (input: { label: string; color: string }) => Promise<AnnotationCategory>
+    >;
+  };
+  variables: {
+    getLocalVariablesAsync: Mock<() => Promise<FigmaVariable[]>>;
+    setBoundVariableForPaint: Mock<
+      (
+        paint: FigmaPaint,
+        field: "color",
+        variable: FigmaVariable | null
+      ) => FigmaPaint
+    >;
+  };
+}
+
+export interface CreateFigmaGlobalOptions {
+  nodes?: Record<string, FigmaNode>;
+  categories?: AnnotationCategory[];
+  variables?: FigmaVariable[];
+  mixed?: symbol;
+}
+
+// Builds a vitest-spied mock of the narrow Figma Plugin API surface used by the
+// roundtrip helpers. Tests install it via installFigmaGlobal(mock) and should
+// call uninstallFigmaGlobal() in afterEach so globalThis.figma doesn't leak.
+export function createFigmaGlobal(
+  options: CreateFigmaGlobalOptions = {}
+): FigmaGlobalMock {
+  const nodes = new Map<string, FigmaNode>(
+    Object.entries(options.nodes ?? {})
+  );
+  const categories: AnnotationCategory[] = [...(options.categories ?? [])];
+  const variables: FigmaVariable[] = [...(options.variables ?? [])];
+  const mixed = options.mixed ?? Symbol("figma.mixed");
+
+  return {
+    mixed,
+    getNodeByIdAsync: vi.fn(async (id: string) => nodes.get(id) ?? null),
+    annotations: {
+      getAnnotationCategoriesAsync: vi.fn(async () => [...categories]),
+      addAnnotationCategoryAsync: vi.fn(
+        async (input: { label: string; color: string }) => {
+          const created: AnnotationCategory = {
+            id: `cat-${categories.length + 1}`,
+            label: input.label,
+            color: input.color,
+          };
+          categories.push(created);
+          return created;
+        }
+      ),
+    },
+    variables: {
+      getLocalVariablesAsync: vi.fn(async () => [...variables]),
+      // Real Plugin API returns a NEW paint object with the binding set —
+      // Experiment 08 documented that paint.boundVariables is not mutated in
+      // place; the caller must reassign node[prop]. Mirror that contract here
+      // so tests fail when helper code forgets to reassign.
+      setBoundVariableForPaint: vi.fn(
+        (paint: FigmaPaint, _field: "color", variable: FigmaVariable | null) =>
+          ({
+            ...paint,
+            boundVariables: variable
+              ? { color: { type: "VARIABLE_ALIAS", id: variable.id } }
+              : undefined,
+          }) as FigmaPaint
+      ),
+    },
+  };
+}
+
+const FIGMA_GLOBAL_KEY = "figma";
+
+type FigmaHost = { [FIGMA_GLOBAL_KEY]?: FigmaGlobal };
+
+export function installFigmaGlobal(mock: FigmaGlobal): void {
+  (globalThis as FigmaHost)[FIGMA_GLOBAL_KEY] = mock;
+}
+
+export function uninstallFigmaGlobal(): void {
+  delete (globalThis as FigmaHost)[FIGMA_GLOBAL_KEY];
+}

--- a/src/core/roundtrip/types.ts
+++ b/src/core/roundtrip/types.ts
@@ -1,0 +1,92 @@
+// Narrow, duck-typed interfaces for the slice of the Figma Plugin API that the
+// roundtrip helpers touch. We keep these local instead of pulling
+// `@figma/plugin-typings` into tsconfig `types` because that package works via
+// `declare global` and would leak `figma: PluginAPI` into every file under
+// src/, polluting code that has nothing to do with the Plugin API.
+
+export interface AnnotationProperty {
+  type: string;
+}
+
+export interface AnnotationEntry {
+  label?: string;
+  labelMarkdown?: string;
+  categoryId?: string;
+  properties?: AnnotationProperty[];
+}
+
+export interface AnnotationCategory {
+  id: string;
+  label: string;
+  color?: string;
+}
+
+export interface FigmaNode {
+  id: string;
+  name: string;
+  type: string;
+  remote?: boolean;
+  annotations?: readonly AnnotationEntry[];
+  fills?: unknown;
+  strokes?: unknown;
+  [key: string]: unknown;
+}
+
+export interface FigmaVariable {
+  id: string;
+  name: string;
+}
+
+export interface FigmaPaint {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface FigmaAnnotationsAPI {
+  getAnnotationCategoriesAsync(): Promise<AnnotationCategory[]>;
+  addAnnotationCategoryAsync(input: {
+    label: string;
+    color: string;
+  }): Promise<AnnotationCategory>;
+}
+
+export interface FigmaVariablesAPI {
+  getLocalVariablesAsync(): Promise<FigmaVariable[]>;
+  setBoundVariableForPaint(
+    paint: FigmaPaint,
+    field: "color",
+    variable: FigmaVariable | null
+  ): FigmaPaint;
+}
+
+export interface FigmaGlobal {
+  mixed: symbol;
+  getNodeByIdAsync(id: string): Promise<FigmaNode | null>;
+  annotations: FigmaAnnotationsAPI;
+  variables: FigmaVariablesAPI;
+}
+
+export interface CanicodeCategories {
+  gotcha: string;
+  autoFix: string;
+  fallback: string;
+}
+
+export interface RoundtripQuestion {
+  nodeId: string;
+  ruleId: string;
+  sourceChildId?: string;
+  targetProperty?: string | string[];
+  [key: string]: unknown;
+}
+
+export type RoundtripResultIcon = "✅" | "🌐" | "📝";
+
+export interface RoundtripResult {
+  icon: RoundtripResultIcon;
+  label: string;
+}
+
+export type WriteFn = (
+  target: FigmaNode
+) => Promise<boolean | void> | boolean | void;

--- a/tsup.roundtrip.config.ts
+++ b/tsup.roundtrip.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "tsup";
+
+// IIFE bundle of the deterministic roundtrip helpers. The emitted file is
+// Read by the canicode-roundtrip SKILL and prepended into every `use_figma`
+// JS batch — it runs inside Figma's Plugin sandbox, so the build must be
+// self-contained with no imports and all helpers exposed on a single global
+// (`CanICodeRoundtrip.*`). Not minified: debuggability in the Plugin console
+// matters more than size, and the whole payload is ~1KB which fits easily
+// within use_figma's 50000-char budget.
+export default defineConfig({
+  entry: { helpers: "src/core/roundtrip/index.ts" },
+  format: ["iife"],
+  globalName: "CanICodeRoundtrip",
+  platform: "browser",
+  outDir: ".claude/skills/canicode-roundtrip",
+  dts: false,
+  clean: false,
+  sourcemap: false,
+  splitting: false,
+  treeshake: true,
+  target: "es2020",
+  noExternal: [/.*/],
+  minify: false,
+  outExtension() {
+    return { js: ".js" };
+  },
+});


### PR DESCRIPTION
## Summary

Extracts the six deterministic helpers that were living as ~180 lines of pseudocode in `.claude/skills/canicode-roundtrip/SKILL.md` into `src/core/roundtrip/*.ts` with full vitest coverage, bundles them to a single IIFE at `.claude/skills/canicode-roundtrip/helpers.js`, and rewrites SKILL.md to reference the bundle via `CanICodeRoundtrip.*` globals instead of inlining buggy pseudocode.

Closes #300.

## What's in here

**TypeScript source + tests** (`src/core/roundtrip/`):
- `annotations.ts` — `stripAnnotations`, `ensureCanicodeCategories`, `upsertCanicodeAnnotation` (D1/D2/D3/D4)
- `apply-with-instance-fallback.ts` — three-tier write policy; factored `routeToDefinitionOrAnnotate` so silent-ignore and override-error paths share one read-only/external-library guard
- `apply-property-mod.ts` — Strategy A entry point; `applyPropertyBinding` branches paint-vs-scalar so `fills`/`strokes` use `setBoundVariableForPaint` + paint array reassignment, everything else uses `setBoundVariable`
- `test-utils.ts` — mock `figma` global for vitest

**Bugs fixed as part of the extraction** (both were live in production pseudocode):
1. Silent-ignore branch wrote to `definition` without a `try/catch` → a single external-library read-only throw would abort the whole `use_figma` batch. Now routed through the same read-only/remote-library guard as the override-error branch.
2. Variable-binding for `fills`/`strokes` used `target.setBoundVariable(prop, variable)` instead of `figma.variables.setBoundVariableForPaint(paint, "color", variable)` with a paint-array reassignment, so color tokens silently failed to bind. Now uses the correct API.

**Bundle** (`.claude/skills/canicode-roundtrip/helpers.js`):
- New `tsup.roundtrip.config.ts` — IIFE format, `globalName: "CanICodeRoundtrip"`, `outExtension` override for a clean `helpers.js` filename
- `pnpm build:roundtrip` script
- CI job `build-roundtrip` runs the bundler and fails if the committed `helpers.js` drifts from the TS source

**SKILL.md migration**:
- Drops 180 lines of pseudocode fences
- New "Shared helpers (bundled)" section documents the `CanICodeRoundtrip.*` globals and tells the LLM to prepend `helpers.js` into every `use_figma` batch
- Strategy A / C / D and Step 0 / Step 5 cleanup snippets rewritten to call `CanICodeRoundtrip.*`
- Added `#295` policy-under-review banner above the three-tier write policy
- Rephrased the external-library description to distinguish the Exp-10 **observed** case (`mainComponent.remote === true`) from the **not-reproduced** `mainComponent === null` case

## Out of scope

- #295 policy flip (instance-override default) — this PR keeps the current three-tier default; banner makes the review status visible
- Re-running a live roundtrip on Simple Design System to re-measure the score delta — left as a follow-up

## Test plan

- [x] `pnpm lint && pnpm test:run && pnpm build` pass locally
- [x] `pnpm build:roundtrip` produces `helpers.js` that matches the committed file (CI guards this going forward)
- [x] vitest covers: D1 mutex, in-place ruleId upsert, properties node-type retry, silent-ignore fallback, override-error definition write, external-library annotation fallback, Paint vs scalar variable binding, mixed-fills skip
- [ ] Live roundtrip on Simple Design System to confirm score delta (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)