### PR TITLE
docs: link ADR-012 to implementation follow-up #305

### DIFF
--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -107,4 +107,4 @@ Core decisions that shape every session. For full history see [GitHub Wiki Decis
 - Rename or demote `resolveGotchaApplyTarget.shouldPreferDefinitionForLayoutProps` to reflect opt-in semantics.
 - Add telemetry counter for skipped definition writes.
 
-**References**: ADR-010, ADR-011, #290 (Experiments 08/09/10), #286. See #295 for the full question list and design discussion.
+**References**: ADR-010, ADR-011, #290 (Experiments 08/09/10), #286, #305 (implementation follow-up). See #295 for the full question list and design discussion.


### PR DESCRIPTION
## Summary

- One-line docs patch — adds `#305` to ADR-012's **References** line so the ADR points to its implementation follow-up issue.
- ADR-012 landed docs-only in PR #304 with four deferred follow-up items (`allowDefinitionWrite` flag, SKILL.md prose flip, `resolveGotchaApplyTarget` rename/demote, telemetry counter). #305 tracks that implementation work; this PR makes the ADR → issue link browsable.
- Does not close #295. #295 will be closed manually after #305 ships (the full design + implementation together satisfy #295).

## Test plan

- [ ] ADR-012 References line now contains \`#305 (implementation follow-up)\`
- [ ] No other file changed; no code paths touched