### PR TITLE
feat: refactor: unify MCP and CLI access — gotcha-survey CLI command + user flow mapping

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -21,14 +21,14 @@
 
 **3a. Claude Code Skill (`/canicode-gotchas`)**
 - Location: `.claude/skills/canicode-gotchas/SKILL.md` (copy to any project)
-- Data source: `gotcha-survey` MCP tool (requires canicode MCP server)
+- Data source: `gotcha-survey` MCP tool OR `npx canicode gotcha-survey --json` CLI fallback (canicode MCP server is optional)
 - Workflow: calls gotcha-survey → presents questions to user → collects answers → writes `.claude/skills/canicode-gotchas/SKILL.md` in the user's project
 - Output: skill file with design gotcha Q&A pairs (nodeId, ruleId, severity, question, answer)
 - **Code generation delivery**: Auto-discovery of a separate skill file cannot reach `figma-implement-design` (Figma skills only support explicit cross-references). The `canicode-roundtrip` orchestration skill (#277) connects analyze → gotcha survey → code generation in a single flow (ADR-009).
 
 **3b. Claude Code Skill (`/canicode-roundtrip`)**
 - Location: `.claude/skills/canicode-roundtrip/SKILL.md` (copy to any project)
-- Data source: `analyze` + `gotcha-survey` MCP tools (canicode MCP server) + Figma MCP tools (`get_design_context`, `get_screenshot`, `use_figma`)
+- Data source: `analyze` + `gotcha-survey` MCP tools OR `npx canicode analyze/gotcha-survey --json` CLI fallback (canicode MCP server is optional). Figma MCP (`get_design_context`, `get_screenshot`, `use_figma`) is still REQUIRED — there is no CLI fallback for `use_figma`.
 - Workflow: analyze → gate on `isReadyForCodeGen` → gotcha survey (if needed) → **apply fixes to Figma via `use_figma`** → re-analyze → code generation
 - True roundtrip: gotcha answers are applied back to the Figma design (property modification, structural modification with confirmation, or annotations for unfixable issues) so the design itself improves
 - Requires Figma Full seat + file edit permission for `use_figma`; falls back to one-way flow (gotcha as code gen context) if no edit permission
@@ -46,11 +46,14 @@
 
 ### CLI Commands (User-Facing)
 
-Registered in `src/cli/index.ts` (lines 71–77) + docs command (line 101). Internal commands are filtered from `--help` via the `INTERNAL_COMMANDS` array.
+Registered in `src/cli/index.ts` (lines 71–79) + docs command (line 102). Internal commands are filtered from `--help` via the `INTERNAL_COMMANDS` array.
+
+User-facing CLI commands mirror the MCP tool surface — call whichever channel is already set up. `analyze` and `gotcha-survey` return the same JSON (with `--json`) as their MCP counterparts.
 
 | Command | Description |
 |---------|-------------|
 | `analyze <input>` | Analyze a Figma file or JSON fixture |
+| `gotcha-survey <input>` | Generate a gotcha survey (same shape as the MCP `gotcha-survey` tool) |
 | `design-tree <input>` | Generate a DOM-like design tree from a Figma file or fixture |
 | `visual-compare <codePath>` | Compare rendered code against Figma screenshot (pixel-level similarity) |
 | `init` | Set up canicode with Figma API token |

--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -9,20 +9,27 @@ Run a gotcha survey on a Figma design to identify implementation pitfalls, colle
 
 ## Prerequisites
 
-- **canicode MCP server** installed: `claude mcp add canicode -e FIGMA_TOKEN=figd_xxx -- npx -y -p canicode canicode-mcp`
+- **canicode MCP server** (preferred): `claude mcp add canicode -e FIGMA_TOKEN=figd_xxx -- npx -y -p canicode canicode-mcp`
+- **Without canicode MCP** (fallback): the `canicode gotcha-survey --json` CLI produces the same response shape — no MCP installation required.
 - **FIGMA_TOKEN** configured for live Figma URLs
 
 ## Workflow
 
 ### Step 1: Run the gotcha survey
 
-Call the `gotcha-survey` MCP tool with the user's Figma URL:
+If the `gotcha-survey` MCP tool is available, call it with the user's Figma URL:
 
 ```
 gotcha-survey({ input: "<figma-url-or-fixture-path>" })
 ```
 
-The tool returns:
+**Without canicode MCP** — shell out to the CLI. The `--json` output parses identically:
+
+```bash
+npx canicode gotcha-survey "<figma-url-or-fixture-path>" --json
+```
+
+Either channel returns:
 - `designGrade`: overall grade (S, A+, A, B+, B, C+, C, D, F)
 - `isReadyForCodeGen`: whether the design can be implemented without gotchas
 - `questions`: array of gotcha questions (may be empty)
@@ -127,5 +134,5 @@ This ensures the code generation agent knows the gotcha exists even if no answer
 
 - **No questions returned**: The design is ready for code generation. Inform the user and stop (Step 2).
 - **User wants to re-run**: Always overwrite the existing file. No merge or append — fresh output each time.
-- **MCP tool not available**: If the `gotcha-survey` tool is not found, tell the user to install the canicode MCP server (see Prerequisites).
+- **MCP tool not available**: Fall back to `npx canicode gotcha-survey <input> --json` — the CLI returns the same `GotchaSurvey` shape. If the CLI is also unavailable (e.g. no node runtime), tell the user to install the canicode MCP server or the `canicode` npm package (see Prerequisites).
 - **Partial answers**: If the user stops mid-survey, write the file with answers collected so far. Mark remaining questions as _(skipped)_.

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -10,8 +10,9 @@ Orchestrate the full design-to-code roundtrip: analyze a Figma design for readin
 
 ## Prerequisites
 
-- **Figma MCP server** installed (provides `get_design_context`, `get_screenshot`, `use_figma`, and other Figma tools)
-- **canicode MCP server** installed: `claude mcp add canicode -e FIGMA_TOKEN=figd_xxx -- npx -y -p canicode canicode-mcp`
+- **Figma MCP server** installed (provides `get_design_context`, `get_screenshot`, `use_figma`, and other Figma tools) — REQUIRED, there is no CLI fallback for `use_figma`
+- **canicode MCP server** (preferred): `claude mcp add canicode -e FIGMA_TOKEN=figd_xxx -- npx -y -p canicode canicode-mcp`
+- **Without canicode MCP** (fallback): Steps 1 (analyze) and 3 (gotcha-survey) shell out to `npx canicode <command> --json` — same JSON shape as the MCP tools. Step 4 (apply to Figma) still requires Figma MCP `use_figma`.
 - **FIGMA_TOKEN** configured for live Figma URLs
 - **Figma Full seat + file edit permission** (required for `use_figma` to modify the design)
 
@@ -19,10 +20,16 @@ Orchestrate the full design-to-code roundtrip: analyze a Figma design for readin
 
 ### Step 1: Analyze the design
 
-Call the `analyze` MCP tool with the user's Figma URL:
+If the `analyze` MCP tool is available, call it with the user's Figma URL:
 
 ```
 analyze({ input: "<figma-url>" })
+```
+
+**Without canicode MCP** — shell out to the CLI (same JSON shape):
+
+```bash
+npx canicode analyze "<figma-url>" --json
 ```
 
 The response includes:
@@ -49,10 +56,16 @@ If `isReadyForCodeGen` is `false` (grade B+ or below):
 
 ### Step 3: Run gotcha survey and collect answers
 
-Call the `gotcha-survey` MCP tool:
+If the `gotcha-survey` MCP tool is available, call it:
 
 ```
 gotcha-survey({ input: "<figma-url>" })
+```
+
+**Without canicode MCP** — shell out to the CLI (same JSON shape):
+
+```bash
+npx canicode gotcha-survey "<figma-url>" --json
 ```
 
 If `questions` is empty, skip to **Step 6**.
@@ -341,7 +354,7 @@ Follow the **figma-implement-design** skill workflow to generate code from the F
 
 ## Edge Cases
 
-- **No canicode MCP server**: If the `analyze` tool is not found, tell the user to install the canicode MCP server (see Prerequisites). The Figma MCP tools alone are not sufficient for this workflow.
+- **No canicode MCP server**: Fall back to `npx canicode analyze --json` and `npx canicode gotcha-survey --json` — both CLI commands return the same shape as the MCP tools. The Figma MCP is still required for `use_figma` in Step 4; there is no CLI fallback for Figma design edits.
 - **No Figma MCP server**: If `get_design_context` or `use_figma` is not found, tell the user to set up the Figma MCP server. Without it, the apply and code generation phases cannot proceed.
 - **No edit permission**: If `use_figma` fails with a permission error, tell the user they need Full seat + file edit permission. Fall back to the one-way flow: skip Steps 4-5 and proceed directly to Step 6 with gotcha answers as code generation context.
 - **User wants analysis only**: Suggest using `/canicode` instead — it runs analysis without the code generation phase.

--- a/.claude/skills/canicode/SKILL.md
+++ b/.claude/skills/canicode/SKILL.md
@@ -9,7 +9,7 @@ Analyze Figma design files to score how development-friendly and AI-friendly the
 
 ## Prerequisites
 
-This skill uses the CLI. Requires either:
+This skill works with either channel — the CLI or the canicode MCP server. Both return the same analysis; pick whichever is already set up. Requires either:
 - A **saved fixture** (from `canicode calibrate-save-fixture`)
 - A **FIGMA_TOKEN** for live Figma URLs
 
@@ -55,6 +55,16 @@ npx canicode analyze <input> --config ./my-config.json
 ```bash
 npx canicode analyze <input> --json
 ```
+
+### Via MCP (when `canicode-mcp` is installed)
+
+If the user has the canicode MCP server installed, prefer the MCP tool — it avoids the `npx` spawn overhead and reuses a warm Figma client:
+
+```
+analyze({ input: "<figma-url-or-fixture-path>" })
+```
+
+Options mirror the CLI: `preset`, `token`, `config`, `targetNodeId`, `json`. The `json` response field matches `npx canicode analyze --json` byte-for-byte, so downstream code can parse either source.
 
 ## What It Reports
 

--- a/src/cli/commands/gotcha-survey.test.ts
+++ b/src/cli/commands/gotcha-survey.test.ts
@@ -1,0 +1,34 @@
+import { runGotchaSurvey } from "./gotcha-survey.js";
+import { GotchaSurveySchema } from "../../core/contracts/gotcha-survey.js";
+
+const FIXTURE = "fixtures/done/desktop-about";
+
+describe("runGotchaSurvey", () => {
+  it("returns a valid GotchaSurvey for a fixture input", async () => {
+    const survey = await runGotchaSurvey(FIXTURE, { json: true });
+
+    // Same JSON shape as the MCP `gotcha-survey` tool response
+    const parsed = GotchaSurveySchema.parse(survey);
+    expect(parsed.designGrade).toMatch(/^(S|A\+|A|B\+|B|C\+|C|D|F)$/);
+    expect(typeof parsed.isReadyForCodeGen).toBe("boolean");
+    expect(Array.isArray(parsed.questions)).toBe(true);
+
+    // Each question must have the required keys the skills consume
+    for (const q of parsed.questions) {
+      expect(q).toHaveProperty("nodeId");
+      expect(q).toHaveProperty("ruleId");
+      expect(q).toHaveProperty("severity");
+      expect(q).toHaveProperty("question");
+      expect(q).toHaveProperty("applyStrategy");
+    }
+  });
+
+  it("respects --preset by picking up different configs", async () => {
+    const strict = await runGotchaSurvey(FIXTURE, { preset: "strict", json: true });
+    const relaxed = await runGotchaSurvey(FIXTURE, { preset: "relaxed", json: true });
+
+    // Both channels produce valid surveys; preset should not crash the pipeline
+    expect(GotchaSurveySchema.safeParse(strict).success).toBe(true);
+    expect(GotchaSurveySchema.safeParse(relaxed).success).toBe(true);
+  });
+});

--- a/src/cli/commands/gotcha-survey.ts
+++ b/src/cli/commands/gotcha-survey.ts
@@ -1,0 +1,131 @@
+import type { CAC } from "cac";
+import { z } from "zod";
+
+import type { RuleConfig, RuleId } from "../../core/contracts/rule.js";
+import type { GotchaSurvey } from "../../core/contracts/gotcha-survey.js";
+import { analyzeFile } from "../../core/engine/rule-engine.js";
+import { loadFile, isJsonFile, isFixtureDir } from "../../core/engine/loader.js";
+import { getFigmaToken } from "../../core/engine/config-store.js";
+import { calculateScores } from "../../core/engine/scoring.js";
+import { generateGotchaSurvey } from "../../core/gotcha/survey-generator.js";
+import { getConfigsWithPreset, RULE_CONFIGS } from "../../core/rules/rule-config.js";
+import { loadConfigFile, mergeConfigs } from "../../core/rules/config-loader.js";
+import { trackEvent, trackError, EVENTS } from "../../core/monitoring/index.js";
+
+const GotchaSurveyOptionsSchema = z.object({
+  preset: z.enum(["relaxed", "dev-friendly", "ai-ready", "strict"]).optional(),
+  token: z.string().optional(),
+  config: z.string().optional(),
+  targetNodeId: z.string().optional(),
+  json: z.boolean().optional(),
+});
+
+export type GotchaSurveyOptions = z.infer<typeof GotchaSurveyOptionsSchema>;
+
+/**
+ * Run the gotcha-survey pipeline against a Figma URL or fixture and return
+ * the survey JSON. Mirrors the MCP `gotcha-survey` tool call sequence so both
+ * channels produce the same `GotchaSurvey` object.
+ */
+export async function runGotchaSurvey(
+  input: string,
+  options: GotchaSurveyOptions,
+): Promise<GotchaSurvey> {
+  const { file, nodeId } = await loadFile(input, options.token);
+  const effectiveNodeId = options.targetNodeId ?? nodeId;
+
+  let configs: Record<string, RuleConfig> = options.preset
+    ? { ...getConfigsWithPreset(options.preset) }
+    : { ...RULE_CONFIGS };
+
+  if (options.config) {
+    const configFile = await loadConfigFile(options.config);
+    configs = mergeConfigs(configs, configFile);
+  }
+
+  const result = analyzeFile(file, {
+    configs: configs as Record<RuleId, RuleConfig>,
+    ...(effectiveNodeId ? { targetNodeId: effectiveNodeId } : {}),
+  });
+
+  const scores = calculateScores(result, configs as Record<RuleId, RuleConfig>);
+  return generateGotchaSurvey(result, scores);
+}
+
+function formatHumanSummary(survey: GotchaSurvey): string {
+  const lines = [
+    `Design grade: ${survey.designGrade}`,
+    `Ready for code generation: ${survey.isReadyForCodeGen ? "yes" : "no"}`,
+    `Questions: ${survey.questions.length}`,
+  ];
+  if (survey.questions.length > 0) {
+    lines.push("");
+    lines.push("Use --json to get the full GotchaSurvey JSON for programmatic use.");
+  }
+  return lines.join("\n");
+}
+
+export function registerGotchaSurvey(cli: CAC): void {
+  cli
+    .command("gotcha-survey <input>", "Generate a gotcha survey from a Figma design analysis")
+    .option("--preset <preset>", "Analysis preset (relaxed | dev-friendly | ai-ready | strict)")
+    .option("--token <token>", "Figma API token (or use FIGMA_TOKEN env var)")
+    .option("--config <path>", "Path to config JSON file (override rule scores/settings)")
+    .option("--target-node-id <id>", "Scope analysis to a specific node ID")
+    .option("--json", "Output GotchaSurvey JSON to stdout (same format as MCP)")
+    .example("  canicode gotcha-survey https://www.figma.com/design/ABC123/MyDesign --json")
+    .example("  canicode gotcha-survey ./fixtures/my-design --json")
+    .action(async (input: string, rawOptions: Record<string, unknown>) => {
+      const parseResult = GotchaSurveyOptionsSchema.safeParse(rawOptions);
+      if (!parseResult.success) {
+        const msg = parseResult.error.issues.map(i => `--${i.path.join(".")}: ${i.message}`).join("\n");
+        console.error(`\nInvalid options:\n${msg}`);
+        process.exit(1);
+      }
+      const options = parseResult.data;
+      const analysisStart = Date.now();
+      trackEvent(EVENTS.ANALYSIS_STARTED, {
+        source: isJsonFile(input) || isFixtureDir(input) ? "fixture" : "figma",
+        tool: "gotcha-survey",
+      });
+
+      try {
+        if (!options.token && !getFigmaToken() && !isJsonFile(input) && !isFixtureDir(input)) {
+          throw new Error(
+            "canicode is not configured. Run 'canicode init --token YOUR_TOKEN' first.",
+          );
+        }
+
+        const survey = await runGotchaSurvey(input, options);
+
+        if (options.json) {
+          console.log(JSON.stringify(survey, null, 2));
+        } else {
+          console.log(formatHumanSummary(survey));
+        }
+
+        trackEvent(EVENTS.ANALYSIS_COMPLETED, {
+          grade: survey.designGrade,
+          questionCount: survey.questions.length,
+          isReadyForCodeGen: survey.isReadyForCodeGen,
+          duration: Date.now() - analysisStart,
+          tool: "gotcha-survey",
+        });
+      } catch (error) {
+        trackError(
+          error instanceof Error ? error : new Error(String(error)),
+          { command: "gotcha-survey", input },
+        );
+        trackEvent(EVENTS.ANALYSIS_FAILED, {
+          error: error instanceof Error ? error.message : String(error),
+          duration: Date.now() - analysisStart,
+          tool: "gotcha-survey",
+        });
+        console.error(
+          "\nError:",
+          error instanceof Error ? error.message : String(error),
+        );
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/cli/commands/gotcha-survey.ts
+++ b/src/cli/commands/gotcha-survey.ts
@@ -88,6 +88,8 @@ export function registerGotchaSurvey(cli: CAC): void {
         source: isJsonFile(input) || isFixtureDir(input) ? "fixture" : "figma",
         tool: "gotcha-survey",
       });
+      // In --json mode, send progress messages to stderr so stdout contains only valid JSON
+      const log = options.json ? console.error.bind(console) : console.log.bind(console);
 
       try {
         if (!options.token && !getFigmaToken() && !isJsonFile(input) && !isFixtureDir(input)) {
@@ -101,7 +103,7 @@ export function registerGotchaSurvey(cli: CAC): void {
         if (options.json) {
           console.log(JSON.stringify(survey, null, 2));
         } else {
-          console.log(formatHumanSummary(survey));
+          log(formatHumanSummary(survey));
         }
 
         trackEvent(EVENTS.ANALYSIS_COMPLETED, {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,7 @@ import "../core/rules/index.js";
 
 // User-facing commands
 import { registerAnalyze } from "./commands/analyze.js";
+import { registerGotchaSurvey } from "./commands/gotcha-survey.js";
 import { registerDesignTree } from "./commands/design-tree.js";
 import { registerVisualCompare } from "./commands/visual-compare.js";
 import { registerInit } from "./commands/init.js";
@@ -69,6 +70,7 @@ process.on("beforeExit", () => {
 // User-facing commands
 // ============================================
 registerAnalyze(cli);
+registerGotchaSurvey(cli);
 registerDesignTree(cli);
 registerVisualCompare(cli);
 registerInit(cli);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -138,6 +138,7 @@ cli.help((sections) => {
         `  $ canicode analyze "https://www.figma.com/design/..." --api`,
         `  $ canicode analyze "https://www.figma.com/design/..." --preset strict`,
         `  $ canicode analyze "https://www.figma.com/design/..." --config ./my-config.json`,
+        `  $ canicode gotcha-survey "https://www.figma.com/design/..." --json`,
       ].join("\n"),
     },
     {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -309,7 +309,18 @@ Get your token: Figma → Settings → Security → Personal access tokens → G
 claude mcp add canicode -e FIGMA_TOKEN=figd_xxxxxxxxxxxxx -- npx -y -p canicode canicode-mcp
 \`\`\`
 
-Requires FIGMA_TOKEN for live Figma URL analysis.`,
+Requires FIGMA_TOKEN for live Figma URL analysis.
+
+## CLI only (no MCP server)
+
+User-facing MCP tools have CLI equivalents with the same JSON shape, so skills and scripts can run without installing the canicode MCP server:
+
+\`\`\`bash
+npx canicode analyze <input>
+npx canicode gotcha-survey <input> --json
+\`\`\`
+
+The CLI spawns per call (slower than the long-running MCP server) but needs no extra setup beyond \`FIGMA_TOKEN\`.`,
 
       "visual-compare": `# Visual Compare
 


### PR DESCRIPTION
## Summary

Issue #285 establishes CLI/MCP parity by adding a missing `gotcha-survey` CLI command, then teaches the canicode skills to fall back from MCP tools to `npx canicode <command> --json` when the canicode MCP server is not installed. The goal is to remove the current channel-inconsistency (survey is MCP-only) so (a) skills can run without the canicode MCP server — lowering the barrier for community-resources contributions that currently must assume Figma MCP only — and (b) the CLI and MCP become functionally equivalent for user-facing capabilities. Wiki user-flow diagrams and community-resources dependency strategy are listed as sub-tasks in the issue but are follow-up design work, not code changes; they are deferred out of this PR.

## Tasks

- Add `gotcha-survey` CLI command with --json output
- Document MCP → CLI fallback in all three canicode skills
- Reflect CLI/MCP parity in ARCHITECTURE.md and MCP docs tool

## Self-review

Task 1 (the new CLI command) is implemented well — code matches the MCP call sequence at src/mcp/server.ts:157-179 byte-for-byte, the test covers fixture + preset paths, telemetry adds the `tool: 'gotcha-survey'` discriminator, and the new file follows the established `analyze.ts` shape. However, Task 2 (skill MCP→CLI fallback docs) and most of Task 3 (ARCHITECTURE.md updates) were NOT completed — the implementer's log lists them under knownRisks as blocked by `.claude/settings.local.json` permissions. The plan explicitly listed these as required, and without them the parity goal in issue #285 (skills usable without canicode MCP) is only half-delivered. The remaining doc/skill edits must be made before this PR can satisfy the issue.
- Verdict: request-changes
- Errors: 2, Warnings: 2, Total: 7

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #285

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))