### PR TITLE
feat: experiment: Experiment 08 — validate instance-child write paths in Plugin API

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -114,6 +114,7 @@ Every gotcha-survey question (and every entry in `analyzeResult.issues[]`) carri
 |-------|------|---------|
 | `applyStrategy` | `"property-mod"` \| `"structural-mod"` \| `"annotation"` \| `"auto-fix"` | Which strategy branch to enter (A/B/C/D). |
 | `targetProperty` | `string` \| `string[]` \| (absent) | Figma Plugin-API property to write. Array when multiple properties move together (e.g. `no-auto-layout` → `["layoutMode", "itemSpacing"]`). Absent for structural/annotation rules. |
+| `annotationProperties` | `Array<{ type: string }>` \| (absent) | Pre-computed Dev Mode annotation `properties` hint for the ruleId (+ subType). Pass directly to `upsertCanicodeAnnotation`. Absent when the rule has no mapping. See the annotation matrix below for the enum + node-type filtering (enforced by the helper's retry path). |
 | `suggestedName` | `string` \| (absent) | Naming rules only — pre-capitalized value to write to `node.name` (e.g. `"Hover"`). |
 | `isInstanceChild` | `boolean` | Whether the `nodeId` targets a node inside an INSTANCE subtree. |
 | `sourceChildId` | `string` \| (absent) | Definition node id inside the source component. Use directly with `figma.getNodeByIdAsync`. |
@@ -239,9 +240,7 @@ CanICodeRoundtrip.upsertCanicodeAnnotation(scene, {
   categoryId: categories.gotcha,
   // Optional: surface live property values in Dev Mode alongside the note.
   // Only include types the node supports (FRAME vs TEXT — see matrix above).
-  properties: question.ruleId === "absolute-position-in-auto-layout"
-    ? [{ type: "layoutMode" }]
-    : undefined,
+  properties: question.annotationProperties,
 });
 ```
 
@@ -252,7 +251,7 @@ Notes:
 
 #### Strategy D: Auto-fix lower-severity issues from analysis
 
-The gotcha survey covers only blocking/risk severity. Lower-severity rules appear in `analyzeResult.issues[]` without a survey question. Each issue carries the same pre-computed fields (`applyStrategy`, `targetProperty`, `suggestedName`, `isInstanceChild`, `sourceChildId`). Loop over them:
+The gotcha survey covers only blocking/risk severity. Lower-severity rules appear in `analyzeResult.issues[]` without a survey question. Each issue carries the same pre-computed fields (`applyStrategy`, `targetProperty`, `annotationProperties`, `suggestedName`, `isInstanceChild`, `sourceChildId`). Loop over them:
 
 ```javascript
 for (const issue of analyzeResult.issues) {
@@ -278,7 +277,7 @@ for (const issue of analyzeResult.issues) {
       markdown: issue.message,
       categoryId: categories.autoFix,
       // Optional: surface the live value for the affected property in Dev Mode.
-      properties: issue.ruleId === "raw-value" ? [{ type: "fills" }] : undefined,
+      properties: issue.annotationProperties,
     });
   }
 }

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -28,6 +28,13 @@ export type RuleApplyStrategy = z.infer<typeof RuleApplyStrategySchema>;
 
 const TargetPropertySchema = z.union([z.string(), z.array(z.string())]);
 
+/**
+ * Mirrors the `AnnotationProperty` interface in `src/core/roundtrip/types.ts`.
+ * Declared here per the project's Zod convention (schemas live in contracts/)
+ * so MCP responses validate end-to-end.
+ */
+export const AnnotationPropertySchema = z.object({ type: z.string() });
+
 export const GotchaSurveyQuestionSchema = z.object({
   nodeId: z.string(),
   nodeName: z.string(),
@@ -39,6 +46,7 @@ export const GotchaSurveyQuestionSchema = z.object({
   instanceContext: InstanceContextSchema.optional(),
   applyStrategy: RuleApplyStrategySchema,
   targetProperty: TargetPropertySchema.optional(),
+  annotationProperties: z.array(AnnotationPropertySchema).optional(),
   suggestedName: z.string().optional(),
   isInstanceChild: z.boolean(),
   sourceChildId: z.string().optional(),

--- a/src/core/engine/scoring.test.ts
+++ b/src/core/engine/scoring.test.ts
@@ -549,6 +549,7 @@ describe("buildResultJson", () => {
       ruleId: "raw-value",
       applyStrategy: "auto-fix",
       isInstanceChild: false,
+      annotationProperties: [{ type: "fills" }],
     });
     expect(issues[1]!["targetProperty"]).toBeUndefined();
 

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -422,6 +422,9 @@ export function buildResultJson(
       ...(applyContext.targetProperty !== undefined
         ? { targetProperty: applyContext.targetProperty }
         : {}),
+      ...(applyContext.annotationProperties !== undefined
+        ? { annotationProperties: applyContext.annotationProperties }
+        : {}),
       ...(suggestedName !== undefined ? { suggestedName } : {}),
       isInstanceChild: applyContext.isInstanceChild,
       ...(applyContext.sourceChildId !== undefined

--- a/src/core/gotcha/apply-context.test.ts
+++ b/src/core/gotcha/apply-context.test.ts
@@ -172,6 +172,44 @@ describe("computeApplyContext", () => {
     });
   });
 
+  describe("annotationProperties", () => {
+    it("irregular-spacing gap → itemSpacing hint (subType match)", () => {
+      const ctx = computeApplyContext(
+        makeViolation("irregular-spacing", { subType: "gap" }),
+      );
+      expect(ctx.annotationProperties).toEqual([{ type: "itemSpacing" }]);
+    });
+
+    it("missing-size-constraint wrap → default hint (subType falls back)", () => {
+      const ctx = computeApplyContext(
+        makeViolation("missing-size-constraint", { subType: "wrap" }),
+      );
+      expect(ctx.annotationProperties).toEqual([
+        { type: "width" },
+        { type: "height" },
+      ]);
+    });
+
+    it("absolute-position-in-auto-layout → layoutMode hint", () => {
+      const ctx = computeApplyContext(
+        makeViolation("absolute-position-in-auto-layout"),
+      );
+      expect(ctx.annotationProperties).toEqual([{ type: "layoutMode" }]);
+    });
+
+    it("rule without mapping omits annotationProperties entirely", () => {
+      const ctx = computeApplyContext(makeViolation("deep-nesting"));
+      expect("annotationProperties" in ctx).toBe(false);
+    });
+
+    it("rule with subType-only mapping and unknown subType omits field", () => {
+      const ctx = computeApplyContext(
+        makeViolation("irregular-spacing", { subType: "unknown-subtype" }),
+      );
+      expect("annotationProperties" in ctx).toBe(false);
+    });
+  });
+
   describe("isInstanceChild / sourceChildId", () => {
     it("plain scene node id → not an instance child", () => {
       const ctx = computeApplyContext(

--- a/src/core/gotcha/apply-context.ts
+++ b/src/core/gotcha/apply-context.ts
@@ -1,9 +1,11 @@
 import type { RuleId, RuleViolation } from "../contracts/rule.js";
 import type { InstanceContext } from "../contracts/gotcha-survey.js";
+import type { AnnotationProperty } from "../roundtrip/types.js";
 import {
   isInstanceChildNodeId,
   parseInstanceChildNodeId,
 } from "../adapters/instance-id-parser.js";
+import { getAnnotationProperties } from "../rules/rule-config.js";
 
 /**
  * Apply strategy for a rule violation. Tells the SKILL.md/`use_figma`
@@ -37,6 +39,7 @@ export type RuleApplyStrategy =
 export interface ApplyContext {
   applyStrategy: RuleApplyStrategy;
   targetProperty?: string | string[];
+  annotationProperties?: AnnotationProperty[];
   isInstanceChild: boolean;
   sourceChildId?: string;
 }
@@ -133,6 +136,10 @@ export function computeApplyContext(
   const ruleId = violation.ruleId as RuleId;
   const applyStrategy = STRATEGY_BY_RULE[ruleId] ?? "annotation";
   const targetProperty = resolveTargetProperty(ruleId, violation.subType);
+  const annotationProperties = getAnnotationProperties(
+    ruleId,
+    violation.subType,
+  );
 
   const parsed = parseInstanceChildNodeId(violation.nodeId);
   const isInstanceChild =
@@ -142,6 +149,7 @@ export function computeApplyContext(
   return {
     applyStrategy,
     ...(targetProperty !== undefined ? { targetProperty } : {}),
+    ...(annotationProperties !== undefined ? { annotationProperties } : {}),
     isInstanceChild,
     ...(sourceChildId !== undefined ? { sourceChildId } : {}),
   };

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -567,6 +567,73 @@ describe("generateGotchaSurvey", () => {
     });
   });
 
+  describe("annotationProperties", () => {
+    it("carries subType-aware hint for irregular-spacing gap → itemSpacing", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "irregular-spacing",
+          category: "token-management",
+          severity: "risk",
+          nodeId: "1:1",
+          nodePath: "Root > Row",
+          subType: "gap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.annotationProperties).toEqual([
+        { type: "itemSpacing" },
+      ]);
+    });
+
+    it("carries default hint for missing-size-constraint with any subType", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "1:1",
+          nodePath: "Root > Banner",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions[0]!.annotationProperties).toEqual([
+        { type: "width" },
+        { type: "height" },
+      ]);
+    });
+
+    it("omits annotationProperties for rules with no mapping", () => {
+      // deep-nesting has no annotation-properties entry.
+      const issues = [
+        makeIssue({
+          ruleId: "deep-nesting",
+          category: "code-quality",
+          severity: "risk",
+          nodeId: "1:1",
+          nodePath: "Root > DeepWrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      expect("annotationProperties" in survey.questions[0]!).toBe(false);
+    });
+  });
+
   describe("isInstanceChild and sourceChildId", () => {
     it("flat instance-child id derives sourceChildId from last segment", () => {
       const issues = [

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -145,6 +145,9 @@ function mapToQuestion(
     ...(applyContext.targetProperty !== undefined
       ? { targetProperty: applyContext.targetProperty }
       : {}),
+    ...(applyContext.annotationProperties !== undefined
+      ? { annotationProperties: applyContext.annotationProperties }
+      : {}),
     ...(suggestedName !== undefined ? { suggestedName } : {}),
     isInstanceChild: applyContext.isInstanceChild,
     ...(applyContext.sourceChildId !== undefined

--- a/src/core/rules/rule-config.test.ts
+++ b/src/core/rules/rule-config.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { RULE_CONFIGS } from "./rule-config.js";
+import { RULE_CONFIGS, getAnnotationProperties } from "./rule-config.js";
 import { ruleRegistry } from "./rule-registry.js";
 import type { RuleId } from "../contracts/rule.js";
 
@@ -69,6 +69,67 @@ describe("rule-config sync", () => {
       for (const rule of ruleRegistry.getAll()) {
         expect(RULE_CONFIGS[rule.definition.id as RuleId]).toBeDefined();
       }
+    });
+  });
+
+  describe("getAnnotationProperties", () => {
+    it("returns bySubType match when present", () => {
+      expect(getAnnotationProperties("irregular-spacing", "gap")).toEqual([
+        { type: "itemSpacing" },
+      ]);
+      expect(getAnnotationProperties("irregular-spacing", "padding")).toEqual([
+        { type: "padding" },
+      ]);
+    });
+
+    it("falls back to default when subType has no bySubType entry", () => {
+      // missing-size-constraint has only a default — any subType resolves to it.
+      expect(
+        getAnnotationProperties("missing-size-constraint", "wrap")
+      ).toEqual([{ type: "width" }, { type: "height" }]);
+      expect(
+        getAnnotationProperties("missing-size-constraint")
+      ).toEqual([{ type: "width" }, { type: "height" }]);
+    });
+
+    it("returns undefined when subType does not match bySubType and no default exists", () => {
+      // irregular-spacing has no default — an unknown subType must return undefined.
+      expect(
+        getAnnotationProperties("irregular-spacing", "unknown")
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for rules with no mapping", () => {
+      expect(getAnnotationProperties("deep-nesting")).toBeUndefined();
+      expect(getAnnotationProperties("non-semantic-name")).toBeUndefined();
+    });
+
+    it("raw-value subTypes: color → fills, font → font fields, spacing → itemSpacing+padding", () => {
+      expect(getAnnotationProperties("raw-value", "color")).toEqual([
+        { type: "fills" },
+      ]);
+      expect(getAnnotationProperties("raw-value", "font")).toEqual([
+        { type: "fontSize" },
+        { type: "fontFamily" },
+        { type: "fontWeight" },
+        { type: "lineHeight" },
+      ]);
+      expect(getAnnotationProperties("raw-value", "spacing")).toEqual([
+        { type: "itemSpacing" },
+        { type: "padding" },
+      ]);
+    });
+
+    it("absolute-position-in-auto-layout → layoutMode", () => {
+      expect(
+        getAnnotationProperties("absolute-position-in-auto-layout")
+      ).toEqual([{ type: "layoutMode" }]);
+    });
+
+    it("fixed-size-in-auto-layout → width, height, layoutMode", () => {
+      expect(
+        getAnnotationProperties("fixed-size-in-auto-layout", "horizontal")
+      ).toEqual([{ type: "width" }, { type: "height" }, { type: "layoutMode" }]);
     });
   });
 

--- a/src/core/rules/rule-config.ts
+++ b/src/core/rules/rule-config.ts
@@ -1,5 +1,6 @@
 import type { Category } from "../contracts/category.js";
 import type { RuleConfig, RuleId } from "../contracts/rule.js";
+import type { AnnotationProperty } from "../roundtrip/types.js";
 
 /**
  * Maps each rule ID to its category.
@@ -219,6 +220,72 @@ export function getConfigsWithPreset(
   }
 
   return configs;
+}
+
+/**
+ * Per-rule annotation `properties` hints surfaced in Dev Mode. Kept as a
+ * sibling map rather than a field on `RuleConfig` so the existing
+ * `RuleConfigSchema` Zod contract and preset helpers stay untouched.
+ *
+ * `bySubType` takes precedence over `default` — mirrors the ruleId+subType
+ * resolution pattern already used for `targetProperty` in apply-context.ts.
+ * The Experiment 09 node-type matrix is enforced at write time by
+ * `upsertCanicodeAnnotation`'s retry path, so hints can be passed
+ * speculatively without server-side filtering.
+ */
+export const RULE_ANNOTATION_PROPERTIES: Partial<
+  Record<
+    RuleId,
+    {
+      default?: AnnotationProperty[];
+      bySubType?: Record<string, AnnotationProperty[]>;
+    }
+  >
+> = {
+  "missing-size-constraint": {
+    default: [{ type: "width" }, { type: "height" }],
+  },
+  "irregular-spacing": {
+    bySubType: {
+      gap: [{ type: "itemSpacing" }],
+      padding: [{ type: "padding" }],
+    },
+  },
+  "fixed-size-in-auto-layout": {
+    default: [{ type: "width" }, { type: "height" }, { type: "layoutMode" }],
+  },
+  "raw-value": {
+    bySubType: {
+      color: [{ type: "fills" }],
+      font: [
+        { type: "fontSize" },
+        { type: "fontFamily" },
+        { type: "fontWeight" },
+        { type: "lineHeight" },
+      ],
+      spacing: [{ type: "itemSpacing" }, { type: "padding" }],
+    },
+  },
+  "absolute-position-in-auto-layout": {
+    default: [{ type: "layoutMode" }],
+  },
+};
+
+/**
+ * Resolve the annotation `properties` hint for a ruleId (+ subType).
+ * Returns `undefined` for rules with no entry.
+ */
+export function getAnnotationProperties(
+  ruleId: RuleId,
+  subType?: string
+): AnnotationProperty[] | undefined {
+  const entry = RULE_ANNOTATION_PROPERTIES[ruleId];
+  if (!entry) return undefined;
+  if (subType !== undefined && entry.bySubType) {
+    const match = entry.bySubType[subType];
+    if (match) return match;
+  }
+  return entry.default;
 }
 
 /**


### PR DESCRIPTION
## Summary

Issue #290 is Experiment 08 — validate instance-child write paths in Plugin API. The 2026-04-17 and 2026-04-18 comments converted the experiment into a concrete 11-item work list for a single PR. Most items have already landed on develop: #292 applied Experiment 08 findings to SKILL + ADR, #293 added Experiment 09 scene re-measurement, #294 added Experiment 10 external-library + propagation, #303 extracted the roundtrip helpers to TypeScript + vitest, #304/#307 flipped the write default and shipped the `allowDefinitionWrite` opt-in + telemetry (ADR-012). External-library fixture probing and multi-instance propagation screenshots have been split off into #309 and #310 per the user's decision. What is still outstanding is item 6 of the 2026-04-18 list: annotation `properties` hints are hardcoded inside SKILL.md (`question.ruleId === "absolute-position-in-auto-layout" ? [{ type: "layoutMode" }] : undefined` etc.) instead of being sourced from the rule metadata hub. This plan centralizes those hints in `rule-config.ts`, surfaces them on the pre-computed `ApplyContext` so gotcha-survey questions carry them end-to-end, updates `survey-generator` + the Zod schema to pass them through, and flips the two hardcoded call-sites in SKILL.md to read the field. The retry path already in `upsertCanicodeAnnotation` (Experiment 09: `invalid property X for a FRAME/TEXT node` → strip and retry) means hints can stay speculative — no per-node-type filtering is introduced.

## Tasks

- Add annotation properties hints to rule-config.ts
- Thread annotationProperties through ApplyContext
- Surface annotationProperties on survey questions (Zod + generator)
- Update SKILL.md and rebuild helpers to consume the new field

## Self-review

Core change (centralizing per-rule annotation properties hints into a sibling RULE_ANNOTATION_PROPERTIES map + getAnnotationProperties helper, threading through ApplyContext, surfacing on GotchaSurveyQuestion via Zod) is clean, minimal, well-tested, and matches the plan scope. All three new test suites cover the subType/default/no-mapping branches, and the conditional-spread pattern for exactOptionalPropertyTypes is used consistently. One real issue: the SKILL.md Strategy D edit at line 280 now reads `issue.annotationProperties`, but `buildResultJson` in src/core/engine/scoring.ts (the shared CLI --json / MCP analyze-tool emitter) does NOT emit that field — so Strategy D's `properties` ends up undefined for every analyze-path issue, which is a small behavioral regression vs the previous raw-value hardcode. The plan design decision #8 justified skipping this by claiming `applyStrategy`/`sourceChildId` also aren't emitted on analyze output, but that premise is factually wrong (scoring.ts:421-429 emits them). Fixing it is a three-line addition next to the existing `targetProperty` spread.
- Verdict: request-changes
- Errors: 0, Warnings: 1, Total: 1

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #290

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))