### PR TITLE
docs: ADR-013 — scope boundary (Figma augmentation; code-gen via figma-implement-design)

### DIFF
--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -6,7 +6,7 @@ Core decisions that shape every session. ADRs are listed by ADR number; chronolo
 
 **Decision**: Use curated design-tree format for AI/codegen inputs. Do not feed raw Figma JSON into AI/codegen. Ingestion pipelines (loader, FigmaFileLoader) accept raw JSON and transform it into design-tree before any codegen use.
 **Why**: design-tree 94% vs raw 79% pixel accuracy with 5x fewer tokens. Information curation > information abundance.
-**Impact**: Downstream consumers of analysis output (calibration Converter, ablation experiments, and any external code-generation skill that picks up canicode's results — e.g. `figma-implement-design` after a `canicode-roundtrip` pass per ADR-013) consume design-tree, never raw Figma JSON. Raw JSON is only for ingestion/transformation inside canicode itself.
+**Impact**: Downstream consumers (calibration Converter, ablation experiments, and external code-generation skills like `figma-implement-design`) consume design-tree, never raw Figma JSON. The handoff to `figma-implement-design` happens after a `canicode-roundtrip` pass (ADR-013). Raw JSON stays inside canicode — only for ingestion and transformation.
 
 ## ADR-002: Ablation + visual-compare for calibration, not LLM self-report
 

--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records
 
-Core decisions that shape every session. For full history see [GitHub Wiki Decision Log](https://github.com/let-sunny/canicode/wiki/Decision-Log).
+Core decisions that shape every session. ADRs are listed by ADR number; chronology lives in the [GitHub Wiki Decision Log](https://github.com/let-sunny/canicode/wiki/Decision-Log).
 
 ## ADR-001: design-tree > raw Figma JSON
 
@@ -44,11 +44,17 @@ Core decisions that shape every session. For full history see [GitHub Wiki Decis
 **Why**: Ensures provenance, consistent build environment, and review gate.
 **Impact**: Local `npm publish` is blocked by safety hooks.
 
+## ADR-008: Calibration pipeline — explicit claude -p orchestration
+
+**Decision**: Replace single-session delegated orchestrator with TypeScript script (`scripts/calibrate.ts`) that explicitly calls CLI commands for deterministic steps and `claude -p` for judgment steps (converter, gap-analyzer, critic, arbitrator). Strip ablation runs 7 parallel sessions. Delete `orchestrator.ts`.
+**Why**: Delegated orchestration accumulates context pressure, can't retry individual steps, and hides flow logic in Claude's head. Explicit orchestration is transparent, debuggable, and gives fresh context per step.
+**Impact**: Calibration flow is script-controlled. Each step produces artifacts in run directory with `index.json` state tracking. Agents are judgment-only, CLI handles computation. See #245.
+
 ## ADR-009: Gotcha delivery via orchestration skill
 
-**Decision**: Deliver gotcha answers to code generation via an orchestration skill (`canicode-roundtrip`), not via auto-discovery of a separate skill file.
-**Why**: Analysis of all 7 official Figma skills shows cross-skill references are **explicit links** (`[figma-use](../figma-use/SKILL.md)`), not auto-discovery. `figma-implement-design` is a built-in skill that cannot be modified to reference `canicode-gotchas`. Therefore, a single orchestration skill handles the full flow: analyze → gotcha survey → code generation with gotcha context. This follows the established pattern: `figma-generate-design` builds on `figma-use`, and community skill `bridge-ds` orchestrates 6 skills + a knowledge-base with a recipe system. See #277.
-**Impact**: `canicode-gotchas` (standalone survey) is preserved, but code generation delivery is handled by `canicode-roundtrip`. Do not rely on auto-discovery to connect separate skill files — Figma skills only support explicit references.
+**Decision**: Deliver gotcha answers via an orchestration skill (`canicode-roundtrip`), not via auto-discovery of a separate skill file. The downstream code-generation stage runs in `figma-implement-design` (see ADR-013); canicode's orchestration ends once the design re-analyzes clean.
+**Why**: Analysis of all 7 official Figma skills shows cross-skill references are **explicit links** (`[figma-use](../figma-use/SKILL.md)`), not auto-discovery. `figma-implement-design` is a built-in skill that cannot be modified to reference `canicode-gotchas`. Therefore, a single orchestration skill handles canicode's full augmentation flow (analyze → gotcha survey → apply to Figma → re-analyze) and then the user invokes `figma-implement-design` for code generation. This follows the established pattern: `figma-generate-design` builds on `figma-use`, and community skill `bridge-ds` orchestrates 6 skills + a knowledge-base with a recipe system. See #277.
+**Impact**: `canicode-gotchas` (standalone survey) is preserved, but the augmentation handoff (analyze + gotcha + apply) is handled by `canicode-roundtrip`. Code generation itself is downstream and not part of canicode (ADR-013). Do not rely on auto-discovery to connect separate skill files — Figma skills only support explicit references.
 **References**:
 - [Figma skills for MCP](https://help.figma.com/hc/en-us/articles/39166810751895-Figma-skills-for-MCP) — official skill structure
 - [Figma community skills](https://www.figma.com/community/skills) — third-party skill ecosystem
@@ -60,8 +66,8 @@ Core decisions that shape every session. For full history see [GitHub Wiki Decis
 ## ADR-010: Roundtrip — gotcha answers applied back to Figma design
 
 **Decision**: Apply gotcha answers back to the Figma design via `use_figma` (Plugin API), not just pass them as code generation context. Three strategies by rule type: (1) property modification for 8 rules (naming, spacing, sizing, variables), (2) structural modification for 4 rules (nesting, components) with user confirmation, (3) annotations for 4 rules that cannot be auto-fixed (absolute positioning, variant structure, interaction states, prototypes).
-**Why**: One-way flow (analyze → gotcha → code gen) is not a true roundtrip. Applying answers to the design means the next analysis passes without gotchas — the design itself improves. PoC confirmed all three strategies work via Figma Plugin API: `node.name`, `itemSpacing`, `setBoundVariable()`, `layoutSizingHorizontal`, `node.annotations`. Annotations enable designer communication for issues that require manual judgment.
-**Impact**: `canicode-roundtrip` becomes a true roundtrip: analyze → gotcha → apply to Figma → re-analyze → pass → code gen. All 16 rules are covered (modify or annotate). Requires Full seat + file edit permission. See #281.
+**Why**: One-way flow (analyze → gotcha → forward as context) is not a true roundtrip. Applying answers to the design means the next analysis passes without gotchas — the design itself improves, which is what the downstream `figma-implement-design` consumes. PoC confirmed all three strategies work via Figma Plugin API: `node.name`, `itemSpacing`, `setBoundVariable()`, `layoutSizingHorizontal`, `node.annotations`. Annotations enable designer communication for issues that require manual judgment.
+**Impact**: `canicode-roundtrip` becomes a true roundtrip: analyze → gotcha → apply to Figma → re-analyze → pass. The downstream code-generation stage runs in `figma-implement-design` (ADR-013); canicode hands off once the design re-analyzes clean. All 16 rules are covered (modify or annotate). Requires Full seat + file edit permission. See #281.
 
 ## ADR-011: Instance-child writes — try scene, then source definition, then annotate
 
@@ -72,12 +78,6 @@ Core decisions that shape every session. For full history see [GitHub Wiki Decis
 **Verification (Experiment 09, #290 follow-up)**: Re-measured the full 33-value annotation `properties` enum on a scene FRAME (`3077:9894`) and scene TEXT (`3077:9963`) in the same fixture. The acceptance gate is **node-type, not scene-vs-instance** — FRAMEs reject `fills`/`cornerRadius`/`opacity`/`maxWidth`/`effects`/`strokes` in every context, not because of instance-override rules. Instance children additionally lose `minWidth`/`minHeight`/`alignItems` on FRAMEs, which scene FRAMEs do accept; that subset is the only true scene-vs-instance delta for annotations. Two TEXT enum values surprised — `textAlignHorizontal` and `letterSpacing` — and are rejected on scene TEXT even though they apply to TEXT nodes semantically. `upsertCanicodeAnnotation` now wraps the write in `try/catch` and retries without `properties` on validation failure, so callers can pass the hint speculatively.
 **Verification (Experiment 10, #290 follow-up)**: Closed the two remaining follow-up items by seeding the Simple Design System fixture with an imported external library instance (`3215:7842`, "Sub Title") and probing one local component with six instances (`7768:19968`, "State=Default"). **External library**: `getMainComponentAsync()` did not return `null` — it resolved with `mainComponent.remote === true`, and any property write on that remote definition threw *"Cannot write to internal and read-only node. Are you trying to modify a remote style or component?"*. `applyWithInstanceFallback` now wraps the definition-tier write in a nested `try/catch` that treats this (and any `read-only` match on the definition-side error) as the annotation fallback instead of aborting the batch; scene-level writes on the external instance itself still succeed normally. **Propagation**: setting `paddingTop` on the source COMPONENT from `8` to `99` was reflected on all six instances in a single readback cycle, and the restore step brought all six back to `8` — definition writes do fan out to the full instance set in one pass. **Override precedence**: pre-setting `paddingTop: 42` on one instance before changing the definition kept that instance at `42` while the other five moved to `99`, so the batch-level confirmation message must describe impact as "every non-overridden instance" rather than "every instance". SKILL.md updates the three-tier policy prose and the external-library edge case accordingly.
 **References**: [InstanceNode#mainComponent](https://www.figma.com/plugin-docs/api/InstanceNode/#maincomponent)
-
-## ADR-008: Calibration pipeline — explicit claude -p orchestration
-
-**Decision**: Replace single-session delegated orchestrator with TypeScript script (`scripts/calibrate.ts`) that explicitly calls CLI commands for deterministic steps and `claude -p` for judgment steps (converter, gap-analyzer, critic, arbitrator). Strip ablation runs 7 parallel sessions. Delete `orchestrator.ts`.
-**Why**: Delegated orchestration accumulates context pressure, can't retry individual steps, and hides flow logic in Claude's head. Explicit orchestration is transparent, debuggable, and gives fresh context per step.
-**Impact**: Calibration flow is script-controlled. Each step produces artifacts in run directory with `index.json` state tracking. Agents are judgment-only, CLI handles computation. See #245.
 
 ## ADR-012: Safer write default — instance override + annotation by default, definition write opt-in
 
@@ -108,3 +108,25 @@ Core decisions that shape every session. For full history see [GitHub Wiki Decis
 - Add telemetry counter for skipped definition writes.
 
 **References**: ADR-010, ADR-011, #290 (Experiments 08/09/10), #286. See #295 for the full question list and design discussion.
+
+## ADR-013: Scope boundary — canicode is Figma augmentation; code generation belongs to `figma-implement-design`
+
+**Decision**: canicode's responsibility ends at **Figma augmentation** — diagnose (`analyze`), elicit gotchas (`gotcha-survey`), and apply answers back to the design (`canicode-roundtrip`). The downstream **code-generation** step is not part of canicode; users invoke Figma's official `figma-implement-design` skill once the design re-analyzes clean. The three external-facing surfaces that previously offered a code-generation packaging path (`canicode-implement` skill, `canicode prompt` CLI, `.claude/skills/design-to-code/PROMPT.md`) are removed from the user surface; the prompt itself is retained as a calibration-internal artifact (controlled variable for Converter / ablation experiments).
+
+**Why**: Figma now ships a native code-generation workflow (Claude Code + Figma MCP + `figma-implement-design` + roundtrip writes). A canicode-owned packaging surface would (1) duplicate what `figma-implement-design` already does and (2) compete with it on quality where Figma has the home-field advantage (live design context, native plugin API, official Anthropic + Figma collaboration). canicode's leverage is upstream: making the Figma file information-complete so `figma-implement-design` produces accurate code with fewer gotchas. Roundtrip Experiment 10 already confirmed this hand-off works: once the augmentation pass closes the gotchas, the next analyze is clean and the design is ready for the downstream skill. Maintaining a parallel "canicode does code-gen too" surface contradicts that boundary and confuses users about which tool to invoke.
+
+**Impact**:
+- **External user surfaces removed**: `canicode-implement` skill (`.claude/skills/canicode-implement/`) and `canicode prompt` CLI command (`src/cli/commands/prompt.ts`). Removal tracked in #312.
+- **`design-to-code/PROMPT.md` relocated**: moves out of `.claude/skills/` (it is not a skill — it is a controlled prompt for measurement) into a calibration-internal location. References in `src/cli/commands/internal/calibrate-implement.ts`, `src/experiments/ablation/helpers.ts`, and `.claude/agents/calibration/converter.md` rewire to the new path. Calibration Converter and ablation experiments continue to use it unchanged.
+- **`canicode-roundtrip` SKILL.md scope statement**: closes at "design re-analyzes clean → ready for `figma-implement-design`", not at "code generated". ADR-009 and ADR-010 wording updated in lock-step (this PR).
+- **CLAUDE.md Core Goal** reframed from "AI implements design with low token cost" to "Figma + `figma-implement-design` produces accurate code because canicode closed the information gaps first".
+- **Calibration scope unchanged**: ablation experiments and pixel-similarity measurement still depend on a controlled prompt (the relocated PROMPT.md). The boundary applies only to *user-facing* code-generation packaging.
+
+**Why now (vs. earlier)**: This pivot was reached implicitly when `canicode-roundtrip` was added (ADR-010) — once the design itself improves, the user no longer needs canicode to package the inputs for an AI. ADR-009 and ADR-010 still carried legacy "code gen with gotcha context" wording from the pre-roundtrip framing. ADR-013 records the boundary explicitly so future feature ideas don't drift back across it ("should canicode also wrap the AI call?" → no, by ADR-013).
+
+**Verification**: This is a positioning decision, not an empirical one. The supporting observations are already documented:
+- Roundtrip viability — ADR-010 + ADR-011 + Experiments 07/08/09/10 (a clean post-roundtrip design is the contract `figma-implement-design` is built to consume).
+- `figma-implement-design` exists and is the official downstream — see ADR-009 references (Figma skills documentation, [From Claude Code to Figma — and Back Again](https://fig-events.figma.com/claude-to-figma/)).
+- Duplication cost — `canicode-implement` and `canicode prompt` see no live usage signal beyond calibration plumbing; removing them subtracts surface area without subtracting capability.
+
+**References**: ADR-009, ADR-010, ADR-011, #312 (removal + relocation work).

--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -6,7 +6,7 @@ Core decisions that shape every session. ADRs are listed by ADR number; chronolo
 
 **Decision**: Use curated design-tree format for AI/codegen inputs. Do not feed raw Figma JSON into AI/codegen. Ingestion pipelines (loader, FigmaFileLoader) accept raw JSON and transform it into design-tree before any codegen use.
 **Why**: design-tree 94% vs raw 79% pixel accuracy with 5x fewer tokens. Information curation > information abundance.
-**Impact**: All code generation pipelines use design-tree as input. Raw JSON is only for ingestion/transformation, never passed directly to AI.
+**Impact**: Downstream consumers of analysis output (calibration Converter, ablation experiments, and any external code-generation skill that picks up canicode's results — e.g. `figma-implement-design` after a `canicode-roundtrip` pass per ADR-013) consume design-tree, never raw Figma JSON. Raw JSON is only for ingestion/transformation inside canicode itself.
 
 ## ADR-002: Ablation + visual-compare for calibration, not LLM self-report
 
@@ -127,6 +127,6 @@ Core decisions that shape every session. ADRs are listed by ADR number; chronolo
 **Verification**: This is a positioning decision, not an empirical one. The supporting observations are already documented:
 - Roundtrip viability — ADR-010 + ADR-011 + Experiments 07/08/09/10 (a clean post-roundtrip design is the contract `figma-implement-design` is built to consume).
 - `figma-implement-design` exists and is the official downstream — see ADR-009 references (Figma skills documentation, [From Claude Code to Figma — and Back Again](https://fig-events.figma.com/claude-to-figma/)).
-- Duplication cost — `canicode-implement` and `canicode prompt` see no live usage signal beyond calibration plumbing; removing them subtracts surface area without subtracting capability.
+- Duplication cost — internal observation only: `canicode-implement` and `canicode prompt` are not exercised outside calibration plumbing in any flow we run or document, and we have no telemetry/issue evidence of external user adoption either way. Removal subtracts surface area without subtracting capability that we can show is in use; if external usage surfaces post-removal, the path forward is to re-introduce a thin wrapper around `figma-implement-design`, not to rebuild a parallel canicode-owned pipeline.
 
 **References**: ADR-009, ADR-010, ADR-011, #312 (removal + relocation work).

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -63,7 +63,7 @@ User-facing CLI commands mirror the MCP tool surface — call whichever channel 
 | `init` | Set up canicode with Figma API token |
 | `config` | Manage canicode configuration |
 | `list-rules` | List all analysis rules with scores and severity |
-| `prompt` | Output the standard design-to-code prompt for AI code generation. **Deprecated in docs (ADR-013); code remains until #312 lands** — runtime behavior unchanged for now. |
+| `prompt` | Output the standard design-to-code prompt. **Deprecated by ADR-013 — removal in #312.** |
 | `docs [topic]` | Show documentation (topics: setup, rules, config, visual-compare, design-tree) |
 
 ## Internal (Claude Code Only)

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -63,7 +63,7 @@ User-facing CLI commands mirror the MCP tool surface — call whichever channel 
 | `init` | Set up canicode with Figma API token |
 | `config` | Manage canicode configuration |
 | `list-rules` | List all analysis rules with scores and severity |
-| `prompt` | ⚠️ Removed by #312 (ADR-013) — code-generation is downstream of canicode |
+| `prompt` | Output the standard design-to-code prompt for AI code generation. **Deprecated in docs (ADR-013); code remains until #312 lands** — runtime behavior unchanged for now. |
 | `docs [topic]` | Show documentation (topics: setup, rules, config, visual-compare, design-tree) |
 
 ## Internal (Claude Code Only)

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -24,15 +24,19 @@
 - Data source: `gotcha-survey` MCP tool OR `npx canicode gotcha-survey --json` CLI fallback (canicode MCP server is optional)
 - Workflow: calls gotcha-survey → presents questions to user → collects answers → writes `.claude/skills/canicode-gotchas/SKILL.md` in the user's project
 - Output: skill file with design gotcha Q&A pairs (nodeId, ruleId, severity, question, answer)
-- **Code generation delivery**: Auto-discovery of a separate skill file cannot reach `figma-implement-design` (Figma skills only support explicit cross-references). The `canicode-roundtrip` orchestration skill (#277) connects analyze → gotcha survey → code generation in a single flow (ADR-009).
+- **Augmentation handoff**: Auto-discovery of a separate skill file cannot reach `figma-implement-design` (Figma skills only support explicit cross-references). The `canicode-roundtrip` orchestration skill (#277) connects analyze → gotcha survey → apply to Figma in a single flow; the user then invokes `figma-implement-design` for code generation (ADR-009, ADR-013).
 
 **3b. Claude Code Skill (`/canicode-roundtrip`)**
 - Location: `.claude/skills/canicode-roundtrip/SKILL.md` (copy to any project)
 - Data source: `analyze` + `gotcha-survey` MCP tools OR `npx canicode analyze/gotcha-survey --json` CLI fallback (canicode MCP server is optional). Figma MCP (`get_design_context`, `get_screenshot`, `use_figma`) is still REQUIRED — there is no CLI fallback for `use_figma`.
-- Workflow: analyze → gate on `isReadyForCodeGen` → gotcha survey (if needed) → **apply fixes to Figma via `use_figma`** → re-analyze → code generation
-- True roundtrip: gotcha answers are applied back to the Figma design (property modification, structural modification with confirmation, or annotations for unfixable issues) so the design itself improves
-- Requires Figma Full seat + file edit permission for `use_figma`; falls back to one-way flow (gotcha as code gen context) if no edit permission
+- Workflow: analyze → gate on `isReadyForCodeGen` → gotcha survey (if needed) → **apply fixes to Figma via `use_figma`** → re-analyze → ready for `figma-implement-design`
+- True roundtrip: gotcha answers are applied back to the Figma design (property modification, structural modification with confirmation, or annotations for unfixable issues) so the design itself improves. Code generation is the user-driven downstream step (ADR-013) — canicode hands off once the re-analyze passes.
+- Requires Figma Full seat + file edit permission for `use_figma`; falls back to one-way flow (gotcha answers stay as a separate skill file the user can reference) if no edit permission
 - See #281, ADR-010
+
+**Removed / relocated by #312 (ADR-013)**:
+- ~~`/canicode-implement` skill~~ — external code-gen packaging, removed; `figma-implement-design` is the downstream code-gen surface
+- ~~`.claude/skills/design-to-code/PROMPT.md`~~ — relocated as a calibration-internal artifact; not a user-facing skill
 
 **4. Web App (GitHub Pages)**
 - Source: `app/web/src/index.html`
@@ -59,7 +63,7 @@ User-facing CLI commands mirror the MCP tool surface — call whichever channel 
 | `init` | Set up canicode with Figma API token |
 | `config` | Manage canicode configuration |
 | `list-rules` | List all analysis rules with scores and severity |
-| `prompt` | Output the standard design-to-code prompt for AI code generation |
+| `prompt` | ⚠️ Removed by #312 (ADR-013) — code-generation is downstream of canicode |
 | `docs [topic]` | Show documentation (topics: setup, rules, config, visual-compare, design-tree) |
 
 ## Internal (Claude Code Only)
@@ -132,10 +136,26 @@ All 15 internal commands are registered in `src/cli/index.ts` (lines 82–95), h
 - Modes: `<fixture-path>` (single), `--all` (all active fixtures), `--resume <run-dir>`
 - `--all` mode: discovers active fixtures, runs sequentially, checks convergence via `fixture-done`, runs regression check, generates aggregate report
 
+**`/develop`**
+- Wrapper: runs `npx tsx scripts/develop.ts $ARGUMENTS` and reports the resulting `index.json` summary
+- Modes: `<issue-number>` (new run), `--resume <run-dir>` (continue), optional `--from <step>` (re-run from plan/implement/test/review/fix/verify/pr)
+- Source: `.claude/commands/develop.md` — orchestrates the full Plan → Implement → Test → Review → Fix → Verify → PR pipeline described under `scripts/develop.ts` above
+
 **`/review-run`**
 - Role: QA review of a completed `/develop` pipeline run — reads all output artifacts and produces a structured assessment
 - Input: run directory path (e.g. `logs/develop/253--2026-04-16-0903`)
 - Flow: index.json → plan.json → implement-log.json + git diff → test-result.json → review.json → fix-log.json → circuit.json → final verdict
+
+### Build & Doc Scripts
+
+Non-orchestrator helpers in `scripts/`. Build scripts are wired into `package.json` (`pnpm build:web`, `pnpm build:plugin`); the others run on demand.
+
+| Script | Role |
+|---|---|
+| `scripts/build-web.sh` | Build `app/web/` for GitHub Pages deployment |
+| `scripts/build-plugin.sh` | Build `app/figma-plugin/` (output `app/figma-plugin/dist/`, gitignored) |
+| `scripts/develop-heartbeat.sh` | PostToolUse hook for `/develop` Implementer sub-agents — appends a line to `implement-progress.jsonl` so the orchestrator can recover progress on timeout. Guarded by `$DEVELOP_RUN_DIR`; no-op outside `/develop` sessions. |
+| `scripts/sync-rule-docs.ts` | Auto-generate rule tables from `rule-config.ts` + rule registry into `docs/CUSTOMIZATION.md` (and the wiki `Rule-Reference.md` page if `/tmp/canicode-wiki/` is cloned). Run after editing rule config or registry. |
 
 ## File Output Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,11 @@ A CLI tool that analyzes Figma design structures to provide development-friendli
 
 ## Core Goal
 
-**Help teams implement Figma designs exactly as designed, with zero unnecessary AI token cost.**
+**Make the Figma file information-complete so `figma-implement-design` produces accurate code with fewer gotchas.**
 
-The design-tree format converts Figma data into a curated, CSS-ready representation that AI can implement directly. Early ablation experiments suggest design-tree produces higher pixel accuracy with significantly fewer tokens than raw Figma JSON. The key insight: **information curation > information abundance** — AI works better with focused, noise-free input.
+canicode's role is upstream of code generation: diagnose where design information is missing (`analyze`), elicit the missing answers from the user (`gotcha-survey`), and write those answers back into the Figma design (`canicode-roundtrip`). Once the design re-analyzes clean, the downstream code-generation step runs in Figma's official `figma-implement-design` skill — canicode does not own that step (see ADR-013 for the scope boundary).
+
+The design-tree format used internally by analysis is a curated, CSS-ready representation; ablation experiments use it as a controlled measurement input. The framing **information curation > information abundance** still drives rule design — fewer information gaps in the source design means cleaner downstream code.
 
 See [Experiment Wiki](https://github.com/let-sunny/canicode/wiki) for detailed data and methodology.
 
@@ -46,8 +48,11 @@ src/                          # Node.js runtime (tsup build)
 │   ├── rules/                # Rule definitions + config
 │   ├── contracts/            # Type definitions + Zod schemas
 │   ├── adapters/             # Figma API integrations
+│   ├── gotcha/               # Gotcha survey question generation, instance-context resolution
+│   ├── roundtrip/            # Apply gotcha answers to Figma (Plugin API helpers, annotation upsert)
 │   ├── report-html/          # HTML report generation
-│   └── monitoring/           # Telemetry
+│   ├── monitoring/           # Telemetry
+│   └── ui-helpers.ts / ui-constants.ts   # UI helpers shared with app/
 ├── cli/                      # Entrypoint: CLI
 ├── mcp/                      # Entrypoint: MCP server
 ├── agents/                   # Internal: Calibration pipeline (deterministic)
@@ -70,12 +75,23 @@ app/                          # Browser runtime
 │   ├── DESIGN-TREE.md        # Design tree format spec, annotations, conversion examples
 │   └── CALIBRATION.md        # Score calibration process, ablation experiments
 ├── skills/                   # Claude Code skills
-├── agents/                   # Calibration subagents (standalone via claude -p)
-└── commands/                 # Claude Code commands (calibrate, develop)
+│   ├── canicode/             #   CLI wrapper skill
+│   ├── canicode-gotchas/     #   Standalone gotcha survey
+│   ├── canicode-roundtrip/   #   Analyze → gotcha → apply to Figma orchestration
+│   ├── canicode-implement/   #   ⚠️ Removed by #312 (ADR-013) — external code-gen packaging, deprecated
+│   └── design-to-code/       #   ⚠️ Relocated by #312 (ADR-013) — calibration-internal prompt, not a skill
+├── agents/                   # Subagents invoked standalone via claude -p
+│   ├── calibration/          #   converter, gap-analyzer, critic, arbitrator, runner
+│   └── develop/              #   planner, implementer, reviewer, fixer
+└── commands/                 # Claude Code commands (calibrate, develop, review-run)
 
-scripts/                        # Orchestration scripts (run with tsx)
+scripts/                      # Orchestration + automation scripts
 ├── calibrate.ts              # Calibration pipeline orchestrator (ADR-008, single + --all mode)
-└── develop.ts                # Development pipeline orchestrator (#247)
+├── develop.ts                # Development pipeline orchestrator (#247)
+├── develop-heartbeat.sh      # PostToolUse hook — heartbeat lines for develop.ts timeout recovery
+├── sync-rule-docs.ts         # Auto-generate rule tables in docs/CUSTOMIZATION.md + Wiki Rule-Reference
+├── build-web.sh              # Build app/web/ for GitHub Pages
+└── build-plugin.sh           # Build app/figma-plugin/
 ```
 
 ## Architecture Decision Records


### PR DESCRIPTION
## Summary

- Records ADR-013: canicode is a **Figma augmentation** tool (analyze + gotcha + roundtrip). Code generation is downstream and runs in `figma-implement-design`.
- Reorders ADR-008 into numerical position (was placed after ADR-011 chronologically); header now states ADRs are listed by number, chronology in Wiki Decision Log.
- ADR-009/010 wording adjusted in lock-step so the orchestration scope ends at "design re-analyzes clean", not "code gen".
- CLAUDE.md Core Goal reframed; Project Structure tree updated to match reality (gotcha/, roundtrip/, four scripts/ helpers, develop subagent group, all five skills with deprecation markers for the two #312 targets).
- ARCHITECTURE.md gets a `/develop` Claude Code command section, a Build & Doc Scripts section, and a "Removed / relocated by #312" note under Skills.

Removal of the user-facing surfaces called out by ADR-013 (`canicode-implement` skill, `canicode prompt` CLI, `design-to-code/PROMPT.md` relocation) is tracked separately in #312.

## Review follow-ups

- `fcc231a` — addresses initial review: ADR-001 Impact reframed as downstream consumers, ARCHITECTURE `prompt` row marked deprecated-in-docs with code-still-live, ADR-013 Verification narrowed to "internal observation only" + post-removal recovery path.
- `2b80dee` — addresses second review: ADR-001 Impact split into three sentences for readability, ARCHITECTURE `prompt` table cell shortened.

## Test plan
- [x] Read ADR-013 end-to-end and confirm the scope boundary is stated clearly enough that future feature ideas don't drift back across it
- [x] Confirm ADR-009/010 still read coherently after the "code gen" wording adjustments
- [x] Confirm CLAUDE.md Project Structure tree matches actual repo contents
- [x] Confirm the deprecation markers in CLAUDE.md and ARCHITECTURE.md correctly point at #312
- [x] No code changes — type check / tests not required for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)