### PR TITLE
feat: bundle Claude Code skills in npm package and install via `canicode init`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ node_modules/
 
 # Build output
 dist/
-skills/
+/skills/
 
 # IDE
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 
 # Build output
 dist/
+skills/
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Each issue is classified: **Blocking** > **Risk** > **Missing Info** > **Suggest
 npx canicode analyze "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234"
 ```
 
-Setup: `canicode init --token figd_xxxxxxxxxxxxx`
+Setup: `canicode init --token figd_xxxxxxxxxxxxx` — saves the token AND installs the Claude Code skills (see below).
 
 > **Get your token:** Figma → Settings → Security → Personal access tokens → Generate new token
 
@@ -139,13 +139,19 @@ For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZA
 
 
 <details>
-<summary><strong>Claude Code Skill</strong> (lightweight, no MCP install)</summary>
+<summary><strong>Claude Code Skills</strong> (lightweight, no MCP install)</summary>
 
 ```bash
-cp -r .claude/skills/canicode /your-project/.claude/skills/
+canicode init --token figd_xxxxxxxxxxxxx
 ```
 
-Requires FIGMA_TOKEN. Then use `/canicode` with a Figma URL.
+Saves your Figma token AND installs three skills into `./.claude/skills/`:
+
+- **canicode** — lightweight CLI wrapper (use `/canicode <figma-url>`)
+- **canicode-gotchas** — standalone gotcha survey (use `/canicode-gotchas <figma-url>`)
+- **canicode-roundtrip** — full analyze → gotcha → apply roundtrip (use `/canicode-roundtrip <figma-url>`)
+
+Flags: `--global` installs into `~/.claude/skills/` instead. `--no-skills` skips skill install (token only). `--force` overwrites existing skill files without prompting. Run `canicode docs setup` for the full setup guide.
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -17,19 +17,21 @@
     }
   },
   "scripts": {
-    "build": "tsup --config tsup.config.ts",
+    "build": "tsup --config tsup.config.ts && pnpm build:roundtrip && pnpm bundle:skills",
     "build:web": "bash scripts/build-web.sh",
     "build:roundtrip": "tsup --config tsup.roundtrip.config.ts",
+    "bundle:skills": "bash scripts/bundle-skills.sh",
     "dev": "tsup --watch",
     "test": "vitest",
     "test:run": "vitest run",
     "lint": "tsc --noEmit",
     "build:plugin": "bash scripts/build-plugin.sh",
     "sync-docs": "tsx scripts/sync-rule-docs.ts",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist skills"
   },
   "files": [
     "dist",
+    "skills",
     "README.md",
     "docs/CUSTOMIZATION.md"
   ],

--- a/scripts/bundle-skills.sh
+++ b/scripts/bundle-skills.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Stage Claude Code skill files into a top-level `skills/` directory for the npm tarball.
+# The three skills (canicode, canicode-gotchas, canicode-roundtrip) are authored under
+# `.claude/skills/` — we copy them to `skills/<name>/` because `.claude/` is the harness
+# directory (also contains agents/, commands/, docs/, worktrees/) and shipping it to npm
+# would leak internals. `skills/` is listed in package.json `files`.
+#
+# NOTE: `canicode-roundtrip/helpers.js` is produced by `pnpm build:roundtrip` (tsup IIFE
+# bundle). Run that before this script if invoking standalone. `pnpm build` already chains
+# both in the right order.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/.claude/skills"
+DEST="$ROOT/skills"
+
+SKILLS=(canicode canicode-gotchas canicode-roundtrip)
+
+echo "=== Bundling Claude Code skills for npm ==="
+
+rm -rf "$DEST"
+mkdir -p "$DEST"
+
+for name in "${SKILLS[@]}"; do
+  if [ ! -d "$SRC/$name" ]; then
+    echo "ERROR: source skill dir missing: $SRC/$name"
+    exit 1
+  fi
+  cp -R "$SRC/$name" "$DEST/$name"
+  echo "  copied $name"
+done
+
+# Verify required files landed
+REQUIRED=(
+  "$DEST/canicode/SKILL.md"
+  "$DEST/canicode-gotchas/SKILL.md"
+  "$DEST/canicode-roundtrip/SKILL.md"
+  "$DEST/canicode-roundtrip/helpers.js"
+)
+
+for f in "${REQUIRED[@]}"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: expected bundled file missing: $f"
+    echo "  (if canicode-roundtrip/helpers.js is missing, run 'pnpm build:roundtrip' first)"
+    exit 1
+  fi
+done
+
+echo "=== Skills bundled into $DEST ==="

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -4,16 +4,24 @@ import { z } from "zod";
 import {
   initAiready, getConfigPath, getReportsDir,
 } from "../../core/engine/config-store.js";
+import { installSkills } from "../skill-installer.js";
 
 const InitOptionsSchema = z.object({
   token: z.string().optional(),
+  global: z.boolean().optional(),
+  // cac maps `--no-skills` to `skills: false` (mirrors `--no-telemetry`).
+  skills: z.boolean().optional(),
+  force: z.boolean().optional(),
 });
 
 export function registerInit(cli: CAC): void {
   cli
     .command("init", "Set up canicode with Figma API token")
-    .option("--token <token>", "Save Figma API token to ~/.canicode/")
-    .action((rawOptions: Record<string, unknown>) => {
+    .option("--token <token>", "Save Figma API token and install Claude Code skills to .claude/skills/")
+    .option("--global", "Install skills to ~/.claude/skills/ instead of ./.claude/skills/")
+    .option("--no-skills", "Skip skill installation (token only)")
+    .option("--force", "Overwrite existing skill files without prompting (also for non-TTY/CI)")
+    .action(async (rawOptions: Record<string, unknown>) => {
       try {
         const parseResult = InitOptionsSchema.safeParse(rawOptions);
         if (!parseResult.success) {
@@ -28,6 +36,28 @@ export function registerInit(cli: CAC): void {
 
           console.log(`  Config saved: ${getConfigPath()}`);
           console.log(`  Reports will be saved to: ${getReportsDir()}/`);
+
+          if (options.skills !== false) {
+            try {
+              const summary = await installSkills({
+                target: options.global ? "global" : "project",
+                force: options.force ?? false,
+              });
+              console.log(`\n  Skills installed to: ${summary.targetDir}/`);
+              console.log(`    installed:   ${summary.installed.length}`);
+              console.log(`    overwritten: ${summary.overwritten.length}`);
+              console.log(`    skipped:     ${summary.skipped.length}`);
+              if (summary.skipped.length > 0) {
+                console.log(`  (Re-run with --force to overwrite skipped files.)`);
+              }
+            } catch (skillError) {
+              console.error(
+                `\n  Skill install failed: ${skillError instanceof Error ? skillError.message : String(skillError)}`,
+              );
+              process.exitCode = 1;
+            }
+          }
+
           console.log(`\n  Next: canicode analyze "https://www.figma.com/design/..."`);
           return;
         }
@@ -36,6 +66,12 @@ export function registerInit(cli: CAC): void {
         console.log(`CANICODE SETUP\n`);
         console.log(`  canicode init --token YOUR_FIGMA_TOKEN`);
         console.log(`  Get token: figma.com > Settings > Personal access tokens\n`);
+        console.log(`Skills:`);
+        console.log(`  --token also installs three Claude Code skills into ./.claude/skills/`);
+        console.log(`  (canicode, canicode-gotchas, canicode-roundtrip).`);
+        console.log(`  --global       Install to ~/.claude/skills/ instead`);
+        console.log(`  --no-skills    Skip skill install (token only)`);
+        console.log(`  --force        Overwrite existing skill files without prompting\n`);
         console.log(`After setup:`);
         console.log(`  canicode analyze "https://www.figma.com/design/..."`);
       } catch (error) {

--- a/src/cli/docs.ts
+++ b/src/cli/docs.ts
@@ -34,7 +34,7 @@ CANICODE SETUP GUIDE
 
   Setup:
     canicode init --token figd_xxxxxxxxxxxxx
-    (saved to ~/.canicode/config.json, reports go to ~/.canicode/reports/)
+    (saves token + installs skills — see section 2 for --no-skills)
 
   Use:
     canicode analyze "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234"
@@ -49,14 +49,27 @@ CANICODE SETUP GUIDE
     ~/.canicode/reports/report-YYYY-MM-DD-HH-mm-<filekey>.html
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- 2. CLAUDE CODE SKILL (requires FIGMA_TOKEN)
+ 2. CLAUDE CODE SKILLS (requires FIGMA_TOKEN)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
   Setup:
-    cp -r .claude/skills/canicode /your-project/.claude/skills/
+    canicode init --token figd_xxxxxxxxxxxxx
+    (installs three skills into ./.claude/skills/ alongside the token)
+
+  Installed skills:
+    canicode             Lightweight CLI wrapper
+    canicode-gotchas     Standalone gotcha survey
+    canicode-roundtrip   Full analyze -> gotcha -> apply roundtrip
+
+  Flags:
+    --global      Install to ~/.claude/skills/ instead of ./.claude/skills/
+    --no-skills   Skip skill install (token only — legacy behavior)
+    --force       Overwrite existing skill files without prompting
 
   Use (in Claude Code):
     /canicode https://www.figma.com/design/ABC123/MyDesign?node-id=1-234
+    /canicode-gotchas <url>      Run a gotcha survey
+    /canicode-roundtrip <url>    Analyze, fix gotchas in Figma, re-analyze
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  TOKEN PRIORITY

--- a/src/cli/skill-installer.test.ts
+++ b/src/cli/skill-installer.test.ts
@@ -1,0 +1,138 @@
+import {
+  mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync,
+} from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { vi } from "vitest";
+
+import { installSkills } from "./skill-installer.js";
+
+let tempRoot: string;
+let sourceDir: string;
+let cwd: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), "canicode-skill-installer-"));
+  sourceDir = join(tempRoot, "skills");
+  cwd = join(tempRoot, "project");
+  originalHome = process.env["HOME"];
+
+  mkdirSync(cwd, { recursive: true });
+
+  // Build a fixture skills tree mirroring the real shape: three skills,
+  // canicode-roundtrip has both SKILL.md and helpers.js.
+  for (const name of ["canicode", "canicode-gotchas", "canicode-roundtrip"]) {
+    const dir = join(sourceDir, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), `# ${name}\nfresh\n`, "utf-8");
+  }
+  writeFileSync(
+    join(sourceDir, "canicode-roundtrip", "helpers.js"),
+    "// helpers fresh\n",
+    "utf-8",
+  );
+});
+
+afterEach(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+  if (originalHome === undefined) {
+    delete process.env["HOME"];
+  } else {
+    process.env["HOME"] = originalHome;
+  }
+  vi.restoreAllMocks();
+});
+
+describe("installSkills", () => {
+  it("performs a fresh install — copies all skill files into ./.claude/skills/", async () => {
+    const summary = await installSkills({
+      target: "project",
+      force: false,
+      cwd,
+      sourceDir,
+    });
+
+    expect(summary.targetDir).toBe(join(cwd, ".claude", "skills"));
+    expect(summary.installed.sort()).toEqual([
+      join("canicode", "SKILL.md"),
+      join("canicode-gotchas", "SKILL.md"),
+      join("canicode-roundtrip", "SKILL.md"),
+      join("canicode-roundtrip", "helpers.js"),
+    ].sort());
+    expect(summary.overwritten).toEqual([]);
+    expect(summary.skipped).toEqual([]);
+
+    expect(existsSync(join(summary.targetDir, "canicode-roundtrip", "SKILL.md"))).toBe(true);
+    expect(existsSync(join(summary.targetDir, "canicode-roundtrip", "helpers.js"))).toBe(true);
+    expect(readFileSync(join(summary.targetDir, "canicode", "SKILL.md"), "utf-8"))
+      .toBe("# canicode\nfresh\n");
+  });
+
+  it("overwrites existing files when force=true and reports them in `overwritten`", async () => {
+    // Pre-create one file with stale content
+    const stalePath = join(cwd, ".claude", "skills", "canicode", "SKILL.md");
+    mkdirSync(join(cwd, ".claude", "skills", "canicode"), { recursive: true });
+    writeFileSync(stalePath, "# stale\n", "utf-8");
+
+    const summary = await installSkills({
+      target: "project",
+      force: true,
+      cwd,
+      sourceDir,
+    });
+
+    expect(summary.overwritten).toContain(join("canicode", "SKILL.md"));
+    expect(readFileSync(stalePath, "utf-8")).toBe("# canicode\nfresh\n");
+  });
+
+  it("skips existing files when force=false and stdin is non-TTY (CI safe default)", async () => {
+    const stalePath = join(cwd, ".claude", "skills", "canicode", "SKILL.md");
+    mkdirSync(join(cwd, ".claude", "skills", "canicode"), { recursive: true });
+    writeFileSync(stalePath, "# stale\n", "utf-8");
+
+    // vitest runs without a TTY (process.stdin.isTTY/process.stdout.isTTY are
+    // undefined), so promptOverwrite hits its non-TTY branch and returns false.
+    expect(process.stdin.isTTY).toBeFalsy();
+
+    const summary = await installSkills({
+      target: "project",
+      force: false,
+      cwd,
+      sourceDir,
+    });
+
+    expect(summary.skipped).toContain(join("canicode", "SKILL.md"));
+    expect(summary.overwritten).not.toContain(join("canicode", "SKILL.md"));
+    expect(readFileSync(stalePath, "utf-8")).toBe("# stale\n");
+  });
+
+  it("target=global writes under os.homedir()/.claude/skills/", async () => {
+    const fakeHome = join(tempRoot, "home");
+    mkdirSync(fakeHome, { recursive: true });
+    // os.homedir() respects $HOME on Unix; on darwin (CI + dev), this is enough.
+    process.env["HOME"] = fakeHome;
+
+    const summary = await installSkills({
+      target: "global",
+      force: false,
+      cwd,
+      sourceDir,
+    });
+
+    expect(summary.targetDir).toBe(join(fakeHome, ".claude", "skills"));
+    expect(existsSync(join(fakeHome, ".claude", "skills", "canicode", "SKILL.md"))).toBe(true);
+  });
+
+  it("throws a clear error when sourceDir is missing", async () => {
+    await expect(
+      installSkills({
+        target: "project",
+        force: false,
+        cwd,
+        sourceDir: join(tempRoot, "does-not-exist"),
+      }),
+    ).rejects.toThrow(/Bundled skills directory not found/);
+  });
+});

--- a/src/cli/skill-installer.ts
+++ b/src/cli/skill-installer.ts
@@ -1,0 +1,136 @@
+import {
+  existsSync, mkdirSync, readdirSync, statSync, copyFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, relative } from "node:path";
+import { createInterface } from "node:readline/promises";
+import { fileURLToPath } from "node:url";
+import { z } from "zod";
+
+const InstallSkillsOptionsSchema = z.object({
+  target: z.enum(["project", "global"]),
+  force: z.boolean(),
+  cwd: z.string().optional(),
+  sourceDir: z.string().optional(),
+});
+
+export type InstallSkillsOptions = z.input<typeof InstallSkillsOptionsSchema>;
+
+export interface InstallSummary {
+  installed: string[];
+  overwritten: string[];
+  skipped: string[];
+  targetDir: string;
+}
+
+const SKILL_NAMES = ["canicode", "canicode-gotchas", "canicode-roundtrip"] as const;
+
+// Resolve the bundled `skills/` dir at runtime. The CLI entrypoint is
+// `<pkg>/dist/cli/index.js` (see package.json bin) and this module is
+// `<pkg>/dist/cli/skill-installer.js` after build, so `../../skills/` from
+// import.meta.url lands on `<pkg>/skills/`. If tsup ever changes layout,
+// update this URL.
+function defaultSourceDir(): string {
+  return fileURLToPath(new URL("../../skills/", import.meta.url));
+}
+
+export async function installSkills(rawOptions: InstallSkillsOptions): Promise<InstallSummary> {
+  const options = InstallSkillsOptionsSchema.parse(rawOptions);
+  const sourceDir = options.sourceDir ?? defaultSourceDir();
+
+  if (!existsSync(sourceDir)) {
+    throw new Error(
+      `Bundled skills directory not found: ${sourceDir}\n` +
+      `If you are developing canicode, run 'pnpm build' first.\n` +
+      `If you installed canicode from npm, please file a bug report — the tarball is missing skills/.`,
+    );
+  }
+
+  const cwd = options.cwd ?? process.cwd();
+  const targetDir = options.target === "global"
+    ? join(homedir(), ".claude", "skills")
+    : join(cwd, ".claude", "skills");
+
+  mkdirSync(targetDir, { recursive: true });
+
+  const summary: InstallSummary = {
+    installed: [],
+    overwritten: [],
+    skipped: [],
+    targetDir,
+  };
+
+  for (const skillName of SKILL_NAMES) {
+    const srcSkillDir = join(sourceDir, skillName);
+    if (!existsSync(srcSkillDir)) {
+      throw new Error(`Bundled skill directory missing: ${srcSkillDir}`);
+    }
+
+    const destSkillDir = join(targetDir, skillName);
+    mkdirSync(destSkillDir, { recursive: true });
+
+    const files = listFilesRecursive(srcSkillDir);
+    for (const relPath of files) {
+      const src = join(srcSkillDir, relPath);
+      const dest = join(destSkillDir, relPath);
+      mkdirSync(dirname(dest), { recursive: true });
+
+      const label = join(skillName, relPath);
+
+      if (!existsSync(dest)) {
+        copyFileSync(src, dest);
+        summary.installed.push(label);
+        continue;
+      }
+
+      if (options.force) {
+        copyFileSync(src, dest);
+        summary.overwritten.push(label);
+        continue;
+      }
+
+      const overwrite = await promptOverwrite(dest);
+      if (overwrite) {
+        copyFileSync(src, dest);
+        summary.overwritten.push(label);
+      } else {
+        summary.skipped.push(label);
+      }
+    }
+  }
+
+  return summary;
+}
+
+function listFilesRecursive(dir: string): string[] {
+  const out: string[] = [];
+  const walk = (current: string): void => {
+    for (const entry of readdirSync(current)) {
+      const full = join(current, entry);
+      const stat = statSync(full);
+      if (stat.isDirectory()) {
+        walk(full);
+      } else if (stat.isFile()) {
+        out.push(relative(dir, full));
+      }
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+async function promptOverwrite(destPath: string): Promise<boolean> {
+  // Non-interactive (CI, piped stdin): default to skip — safer than silently
+  // clobbering a user-edited skill file. Users who want unattended overwrite
+  // pass --force.
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return false;
+  }
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = await rl.question(`File exists: ${destPath}. Overwrite? [y/N] `);
+    return answer.trim().toLowerCase().startsWith("y");
+  } finally {
+    rl.close();
+  }
+}

--- a/src/cli/skill-installer.ts
+++ b/src/cli/skill-installer.ts
@@ -25,11 +25,12 @@ export interface InstallSummary {
 
 const SKILL_NAMES = ["canicode", "canicode-gotchas", "canicode-roundtrip"] as const;
 
-// Resolve the bundled `skills/` dir at runtime. The CLI entrypoint is
-// `<pkg>/dist/cli/index.js` (see package.json bin) and this module is
-// `<pkg>/dist/cli/skill-installer.js` after build, so `../../skills/` from
-// import.meta.url lands on `<pkg>/skills/`. If tsup ever changes layout,
-// update this URL.
+// Resolve the bundled `skills/` dir at runtime. tsup bundles this module
+// into the CLI entrypoint `<pkg>/dist/cli/index.js` (splitting: false), so
+// `import.meta.url` at runtime resolves to that entrypoint — depth 2 under
+// the package root. `../../skills/` therefore lands on `<pkg>/skills/`.
+// If tsup's output layout ever changes (new entrypoint depth, splitting
+// enabled, etc.), update this URL.
 function defaultSourceDir(): string {
   return fileURLToPath(new URL("../../skills/", import.meta.url));
 }


### PR DESCRIPTION
## Summary

Bundle the three Claude Code skill files (canicode, canicode-gotchas, canicode-roundtrip incl. helpers.js) inside the published canicode npm package and install them via `canicode init`. The current package.json `files` array only ships `dist/`, so `.claude/skills/*` is invisible to end users who install from npm — making `canicode-roundtrip` unreachable. This issue adds (a) a build step that stages the skills into a top-level `skills/` directory that npm includes in the tarball, (b) a skill installer module that copies those bundled files into the user's `./.claude/skills/` (or `~/.claude/skills/` with `--global`), (c) new `canicode init` flags (`--global`, `--no-skills`, `--force`) with a confirmation prompt on overwrite, and (d) docs updates in README.md and `canicode docs setup` that replace the manual `cp -r .claude/skills/canicode ...` instruction with the single `canicode init --token` command. ADR-014 already records the policy decision — this is the implementation. Out-of-tree docs (Wiki Setup / Decision Log) are explicitly tracked in sibling issue #319, not here.

## Tasks

- Add build-time skill bundling into top-level `skills/` directory and include in npm files
- Add `installSkills` module that resolves bundled skills path and copies into a target `.claude/skills/` dir with force/prompt semantics
- Wire `canicode init` to install skills by default and add `--global` / `--no-skills` / `--force` flags
- Update `canicode docs setup` output to reflect the new install flow
- Update README.md install section to remove manual `cp -r` and describe new flow

## Self-review

Implementation is thorough and mostly faithful to the plan — bundling + installer + docs all land correctly, tests cover the important branches, and conventions (ESM, .js imports, zod at boundary, kebab-case) are respected. However, the new `.gitignore` pattern `skills/` (no leading slash) silently ignores any NEW files added under `.claude/skills/` — matching not just the intended build-artifact root `skills/` but also the authoritative source `.claude/skills/`. This is a latent footgun that bites as soon as a skill gains a new file. One additional accuracy issue: a load-bearing comment in `skill-installer.ts` about tsup's output layout is wrong (the math still works, but the explanation would mislead a future maintainer debugging a layout change).
- Verdict: request-changes
- Errors: 1, Warnings: 1, Total: 4

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #318

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))