### PR TITLE
feat: fix(cli): `canicode init` UX polish — gate `Next:` on success + batch overwrite prompt

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -37,6 +37,7 @@ export function registerInit(cli: CAC): void {
           console.log(`  Config saved: ${getConfigPath()}`);
           console.log(`  Reports will be saved to: ${getReportsDir()}/`);
 
+          let skillStepOk = true;
           if (options.skills !== false) {
             try {
               const summary = await installSkills({
@@ -55,10 +56,13 @@ export function registerInit(cli: CAC): void {
                 `\n  Skill install failed: ${skillError instanceof Error ? skillError.message : String(skillError)}`,
               );
               process.exitCode = 1;
+              skillStepOk = false;
             }
           }
 
-          console.log(`\n  Next: canicode analyze "https://www.figma.com/design/..."`);
+          if (skillStepOk) {
+            console.log(`\n  Next: canicode analyze "https://www.figma.com/design/..."`);
+          }
           return;
         }
 

--- a/src/cli/skill-installer.test.ts
+++ b/src/cli/skill-installer.test.ts
@@ -8,6 +8,34 @@ import { vi } from "vitest";
 
 import { installSkills } from "./skill-installer.js";
 
+vi.mock("node:readline/promises", () => ({
+  createInterface: vi.fn(),
+}));
+
+async function getCreateInterfaceMock(): Promise<ReturnType<typeof vi.fn>> {
+  const mod = await import("node:readline/promises");
+  return mod.createInterface as unknown as ReturnType<typeof vi.fn>;
+}
+
+function forceTty(): void {
+  Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+}
+
+function preCreateAllStaleSkills(cwd: string): string[] {
+  const staleFiles = [
+    join(cwd, ".claude", "skills", "canicode", "SKILL.md"),
+    join(cwd, ".claude", "skills", "canicode-gotchas", "SKILL.md"),
+    join(cwd, ".claude", "skills", "canicode-roundtrip", "SKILL.md"),
+    join(cwd, ".claude", "skills", "canicode-roundtrip", "helpers.js"),
+  ];
+  for (const p of staleFiles) {
+    mkdirSync(join(p, ".."), { recursive: true });
+    writeFileSync(p, "# stale\n", "utf-8");
+  }
+  return staleFiles;
+}
+
 let tempRoot: string;
 let sourceDir: string;
 let cwd: string;
@@ -42,6 +70,9 @@ afterEach(async () => {
   } else {
     process.env["HOME"] = originalHome;
   }
+  // Restore TTY state to vitest's default (undefined) after tests that forced it.
+  Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+  Object.defineProperty(process.stdout, "isTTY", { value: undefined, configurable: true });
   vi.restoreAllMocks();
 });
 
@@ -134,5 +165,82 @@ describe("installSkills", () => {
         sourceDir: join(tempRoot, "does-not-exist"),
       }),
     ).rejects.toThrow(/Bundled skills directory not found/);
+  });
+
+  it("prompts per candidate when user answers 'y' to each", async () => {
+    const staleFiles = preCreateAllStaleSkills(cwd);
+    forceTty();
+
+    const question = vi.fn()
+      .mockResolvedValueOnce("y")
+      .mockResolvedValueOnce("y")
+      .mockResolvedValueOnce("y")
+      .mockResolvedValueOnce("y");
+    const close = vi.fn();
+    const createInterface = await getCreateInterfaceMock();
+    createInterface.mockReturnValue({ question, close });
+
+    const summary = await installSkills({
+      target: "project",
+      force: false,
+      cwd,
+      sourceDir,
+    });
+
+    expect(createInterface).toHaveBeenCalledTimes(1);
+    expect(question).toHaveBeenCalledTimes(staleFiles.length);
+    expect(summary.overwritten.length).toBe(staleFiles.length);
+    expect(summary.skipped).toEqual([]);
+    for (const p of staleFiles) {
+      expect(readFileSync(p, "utf-8")).not.toBe("# stale\n");
+    }
+  });
+
+  it("'a' short-circuits remaining decisions to overwrite", async () => {
+    const staleFiles = preCreateAllStaleSkills(cwd);
+    forceTty();
+
+    const question = vi.fn().mockResolvedValueOnce("a");
+    const close = vi.fn();
+    const createInterface = await getCreateInterfaceMock();
+    createInterface.mockReturnValue({ question, close });
+
+    const summary = await installSkills({
+      target: "project",
+      force: false,
+      cwd,
+      sourceDir,
+    });
+
+    expect(question).toHaveBeenCalledTimes(1);
+    expect(summary.overwritten.length).toBe(staleFiles.length);
+    expect(summary.skipped).toEqual([]);
+    for (const p of staleFiles) {
+      expect(readFileSync(p, "utf-8")).not.toBe("# stale\n");
+    }
+  });
+
+  it("'s' short-circuits remaining decisions to skip", async () => {
+    const staleFiles = preCreateAllStaleSkills(cwd);
+    forceTty();
+
+    const question = vi.fn().mockResolvedValueOnce("s");
+    const close = vi.fn();
+    const createInterface = await getCreateInterfaceMock();
+    createInterface.mockReturnValue({ question, close });
+
+    const summary = await installSkills({
+      target: "project",
+      force: false,
+      cwd,
+      sourceDir,
+    });
+
+    expect(question).toHaveBeenCalledTimes(1);
+    expect(summary.skipped.length).toBe(staleFiles.length);
+    expect(summary.overwritten).toEqual([]);
+    for (const p of staleFiles) {
+      expect(readFileSync(p, "utf-8")).toBe("# stale\n");
+    }
   });
 });

--- a/src/cli/skill-installer.ts
+++ b/src/cli/skill-installer.ts
@@ -61,6 +61,15 @@ export async function installSkills(rawOptions: InstallSkillsOptions): Promise<I
     targetDir,
   };
 
+  type Action = "install" | "force-overwrite" | "needs-decision";
+  interface Op {
+    src: string;
+    dest: string;
+    label: string;
+    action: Action;
+  }
+  const ops: Op[] = [];
+
   for (const skillName of SKILL_NAMES) {
     const srcSkillDir = join(sourceDir, skillName);
     if (!existsSync(srcSkillDir)) {
@@ -77,25 +86,37 @@ export async function installSkills(rawOptions: InstallSkillsOptions): Promise<I
       mkdirSync(dirname(dest), { recursive: true });
 
       const label = join(skillName, relPath);
-
+      let action: Action;
       if (!existsSync(dest)) {
-        copyFileSync(src, dest);
-        summary.installed.push(label);
-        continue;
-      }
-
-      if (options.force) {
-        copyFileSync(src, dest);
-        summary.overwritten.push(label);
-        continue;
-      }
-
-      const overwrite = await promptOverwrite(dest);
-      if (overwrite) {
-        copyFileSync(src, dest);
-        summary.overwritten.push(label);
+        action = "install";
+      } else if (options.force) {
+        action = "force-overwrite";
       } else {
-        summary.skipped.push(label);
+        action = "needs-decision";
+      }
+      ops.push({ src, dest, label, action });
+    }
+  }
+
+  const candidates = ops.filter(op => op.action === "needs-decision");
+  const decisions = candidates.length > 0
+    ? await promptOverwriteBatch(candidates.map(op => ({ label: op.label, dest: op.dest })))
+    : new Map<string, "overwrite" | "skip">();
+
+  for (const op of ops) {
+    if (op.action === "install") {
+      copyFileSync(op.src, op.dest);
+      summary.installed.push(op.label);
+    } else if (op.action === "force-overwrite") {
+      copyFileSync(op.src, op.dest);
+      summary.overwritten.push(op.label);
+    } else {
+      const decision = decisions.get(op.label) ?? "skip";
+      if (decision === "overwrite") {
+        copyFileSync(op.src, op.dest);
+        summary.overwritten.push(op.label);
+      } else {
+        summary.skipped.push(op.label);
       }
     }
   }
@@ -120,18 +141,50 @@ function listFilesRecursive(dir: string): string[] {
   return out;
 }
 
-async function promptOverwrite(destPath: string): Promise<boolean> {
+async function promptOverwriteBatch(
+  candidates: Array<{ label: string; dest: string }>,
+): Promise<Map<string, "overwrite" | "skip">> {
+  const decisions = new Map<string, "overwrite" | "skip">();
+
   // Non-interactive (CI, piped stdin): default to skip — safer than silently
   // clobbering a user-edited skill file. Users who want unattended overwrite
   // pass --force.
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return false;
+    for (const { label } of candidates) {
+      decisions.set(label, "skip");
+    }
+    return decisions;
   }
+
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   try {
-    const answer = await rl.question(`File exists: ${destPath}. Overwrite? [y/N] `);
-    return answer.trim().toLowerCase().startsWith("y");
+    let mode: "ask" | "all" | "none" = "ask";
+    for (const { label, dest } of candidates) {
+      if (mode === "all") {
+        decisions.set(label, "overwrite");
+        continue;
+      }
+      if (mode === "none") {
+        decisions.set(label, "skip");
+        continue;
+      }
+      const answer = (await rl.question(
+        `File exists: ${dest}. Overwrite? [y/N/a=all/s=skip-all] `,
+      )).trim().toLowerCase();
+      if (answer === "a") {
+        decisions.set(label, "overwrite");
+        mode = "all";
+      } else if (answer === "s") {
+        decisions.set(label, "skip");
+        mode = "none";
+      } else if (answer.startsWith("y")) {
+        decisions.set(label, "overwrite");
+      } else {
+        decisions.set(label, "skip");
+      }
+    }
   } finally {
     rl.close();
   }
+  return decisions;
 }


### PR DESCRIPTION
## Summary

Two UX polish fixes to `canicode init` from PR #323 review. (1) `src/cli/commands/init.ts` unconditionally prints the `Next: canicode analyze ...` line even after a skill install failure that sets `process.exitCode = 1`, masking failure in scrollback. Gate the `Next:` print on success (or on `--no-skills`). (2) `src/cli/skill-installer.ts#promptOverwrite` opens a fresh readline per existing file, so upgrading users with N pre-existing skill files get N independent prompts with no `apply to all` affordance. Refactor to accumulate overwrite candidates, open a single readline session, and offer `[y/N/a=all/s=skip-all]` with short-circuit semantics. Both fixes ship in one PR — same module, same test file, no architectural change.

## Tasks

- Gate `Next:` print behind successful skill install
- Batch overwrite prompt with `[y/N/a=all/s=skip-all]`
- Add unit tests for batch prompt branches

## Self-review

Both fixes match AC and plan. Task 1 correctly uses a `skillStepOk` flag so `--no-skills` still prints `Next:` while install failure suppresses it. Task 2's two-phase classify/prompt/apply refactor cleanly batches overwrite decisions, preserves `--force` and non-TTY CI-safe skip, and adds `[y/N/a=all/s=skip-all]` with proper short-circuits. Tests cover the three new branches and all 8 tests pass under `pnpm test:run`; `pnpm lint` is clean.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 2

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #326

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))