### PR TITLE
fix(cli): correct docs topics list in --help

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -98,7 +98,7 @@ registerCodeMetrics(cli);
 // Documentation command
 // ============================================
 cli
-  .command("docs [topic]", "Show documentation (topics: setup, rules, config, visual-compare, design-tree)")
+  .command("docs [topic]", "Show documentation (topics: setup, config, scoring, visual-compare, design-tree)")
   .action((topic?: string) => {
     handleDocs(topic);
   });


### PR DESCRIPTION
## Summary

- Help text for `canicode docs [topic]` listed `setup, rules, config, visual-compare, design-tree`, but the actual `DOCS_TOPICS` handler accepts `setup, install, config, scoring, visual-compare, design-tree`
- A user typing `canicode docs rules` would get "Unknown topic"
- Aligns the help string to the canonical topic names (omitting `install` since it's an alias of `setup`)

## Discovery

Surfaced during the #333 pre-launch smoke run on a fresh-dir tarball install — first-impression friction for any user trying the help text's suggested topics.

## Test plan

- [x] `pnpm lint` green
- [x] `pnpm test:run` green (851)
- [x] `pnpm build` green
- [x] Fresh-dir tarball install: `npx canicode --help` now shows the corrected topics list
- [x] Each listed topic resolves: `canicode docs setup`, `config`, `scoring`, `visual-compare`, `design-tree` all return their guides

🤖 Generated with [Claude Code](https://claude.com/claude-code)