### PR TITLE
fix(docs): align CLI and MCP topic sets (add scoring to MCP, rules to CLI)

### DIFF
--- a/src/cli/docs.ts
+++ b/src/cli/docs.ts
@@ -15,6 +15,7 @@ CANICODE DOCUMENTATION (v${pkg.version})
   canicode docs setup      Full setup guide (CLI, MCP, Skills)
   canicode docs config     Config override guide + example
   canicode docs scoring    Scoring model explanation
+  canicode docs rules      Pointer to rule list (canicode list-rules)
 
 Full documentation: github.com/let-sunny/canicode#readme
 `.trimStart());
@@ -200,6 +201,21 @@ USE CASES
 `.trimStart());
 }
 
+/** Print pointer to the rule list. */
+export function printDocsRules(): void {
+  console.log(`
+RULES
+
+  Run 'canicode list-rules' for the full table of rule IDs, scores, and severity.
+
+  Customize per-rule via config:
+    canicode docs config
+
+  Full reference:
+    https://github.com/let-sunny/canicode/blob/main/docs/CUSTOMIZATION.md
+`.trimStart());
+}
+
 /** Print the scoring model summary with pointer to full docs. */
 export function printDocsScoring(): void {
   console.log(`
@@ -222,6 +238,7 @@ const DOCS_TOPICS: Record<string, () => void> = {
   install: printDocsSetup, // alias
   config: printDocsConfig,
   scoring: printDocsScoring,
+  rules: printDocsRules,
   "visual-compare": printDocsVisualCompare,
   "design-tree": printDocsDesignTree,
 };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -98,7 +98,7 @@ registerCodeMetrics(cli);
 // Documentation command
 // ============================================
 cli
-  .command("docs [topic]", "Show documentation (topics: setup, config, scoring, visual-compare, design-tree)")
+  .command("docs [topic]", "Show documentation (topics: setup, config, scoring, rules, visual-compare, design-tree)")
   .action((topic?: string) => {
     handleDocs(topic);
   });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -272,6 +272,7 @@ server.tool(
 
 Available topics:
 - setup: Installation and token configuration
+- scoring: Scoring model formula (density+diversity, severity weights, grades)
 - rules: All rule IDs with default scores and severity
 - config: Config overrides (scores, severity, node exclusions, thresholds)
 - visual-compare: Pixel-level comparison between Figma and AI-generated code
@@ -280,7 +281,7 @@ Available topics:
 
 Use this when the user asks about how to use canicode, configuration, rules, visual comparison, or any feature.`,
   {
-    topic: z.enum(["all", "setup", "rules", "config", "visual-compare", "design-tree"]).optional()
+    topic: z.enum(["all", "setup", "scoring", "rules", "config", "visual-compare", "design-tree"]).optional()
       .describe("Topic to retrieve. Default: all"),
   },
   {
@@ -367,6 +368,37 @@ Viewport and device pixel ratio are auto-inferred from the Figma PNG dimensions 
 ## Requirements
 - npx playwright install chromium
 - Figma API token with read access`,
+
+      "scoring": `# Scoring Model
+
+Score = density (70%) + diversity (30%), averaged across 6 categories.
+
+## Severity weights
+
+| Severity | Weight |
+|----------|--------|
+| blocking | 3.0x |
+| risk | 2.0x |
+| missing-info | 1.0x |
+| suggestion | 0.5x |
+
+## Grades
+
+| Grade | Min score |
+|-------|-----------|
+| S | 95 |
+| A+ | 90 |
+| A | 85 |
+| B+ | 80 |
+| B | 75 |
+| C+ | 70 |
+| C | 65 |
+| D | 50 |
+| F | <50 |
+
+Floor: 5% minimum.
+
+Full documentation: https://github.com/let-sunny/canicode/wiki/Scoring-Model`,
 
       "design-tree": `# Design Tree
 


### PR DESCRIPTION
## Summary

Before: CLI exposed `scoring` (formula) but not `rules`; MCP exposed `rules` (table) but not `scoring`. Same conceptual surface, different vocabulary — users moving between Claude Desktop and the terminal hit "Unknown topic" depending on which they tried first.

Both surfaces now expose both topics with matching content:

- **CLI gains `rules`** — short pointer to `canicode list-rules` (the canonical rule-table command) plus a link to `docs/CUSTOMIZATION.md`
- **MCP gains `scoring`** — the same scoring-model summary the CLI prints (formula, severity weights, grade thresholds), formatted as markdown for MCP clients

After this PR, the topic vocabulary is identical across both surfaces:

| Topic | CLI | MCP |
|---|---|---|
| setup | ✅ | ✅ |
| install (alias of setup) | ✅ | — (MCP doesn't carry aliases) |
| config | ✅ | ✅ |
| **scoring** | ✅ | ✅ (new) |
| **rules** | ✅ (new) | ✅ |
| visual-compare | ✅ | ✅ |
| design-tree | ✅ | ✅ |
| all (full dump) | — | ✅ (MCP-specific) |

## Discovery

Surfaced during the #333 pre-launch smoke pass on the next-release tarball.

## Test plan

- [x] `pnpm lint` green
- [x] `pnpm test:run` green (851)
- [x] `pnpm build` green
- [x] `canicode docs --help` shows the new topic list
- [x] `canicode docs scoring` returns the scoring model
- [x] `canicode docs rules` returns the rules pointer
- [x] MCP `docs(topic="scoring")` returns the scoring-model markdown via JSON-RPC

🤖 Generated with [Claude Code](https://claude.com/claude-code)