### PR TITLE
chore(release): v0.10.0 + wire CLI_INIT telemetry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Score your Figma designs with AI-calibrated rules. CLI + MCP server.",
   "type": "module",

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -5,6 +5,7 @@ import {
   initAiready, getConfigPath, getReportsDir,
 } from "../../core/engine/config-store.js";
 import { installSkills } from "../skill-installer.js";
+import { trackEvent, EVENTS } from "../../core/monitoring/index.js";
 
 const InitOptionsSchema = z.object({
   token: z.string().optional(),
@@ -38,6 +39,7 @@ export function registerInit(cli: CAC): void {
           console.log(`  Reports will be saved to: ${getReportsDir()}/`);
 
           let skillStepOk = true;
+          let skillSummary: { installed: number; overwritten: number; skipped: number } | undefined;
           if (options.skills !== false) {
             try {
               const summary = await installSkills({
@@ -51,6 +53,11 @@ export function registerInit(cli: CAC): void {
               if (summary.skipped.length > 0) {
                 console.log(`  (Re-run with --force to overwrite skipped files.)`);
               }
+              skillSummary = {
+                installed: summary.installed.length,
+                overwritten: summary.overwritten.length,
+                skipped: summary.skipped.length,
+              };
             } catch (skillError) {
               console.error(
                 `\n  Skill install failed: ${skillError instanceof Error ? skillError.message : String(skillError)}`,
@@ -59,6 +66,14 @@ export function registerInit(cli: CAC): void {
               skillStepOk = false;
             }
           }
+
+          trackEvent(EVENTS.CLI_INIT, {
+            skillsRequested: options.skills !== false,
+            skillStepOk,
+            target: options.global ? "global" : "project",
+            force: options.force ?? false,
+            ...(skillSummary ?? {}),
+          });
 
           if (skillStepOk) {
             console.log(`\n  Next: canicode analyze "https://www.figma.com/design/..."`);


### PR DESCRIPTION
## Summary

Cuts the next public release (0.9.1 → 0.10.0) and fixes one telemetry omission surfaced during the #333 pre-launch audit.

## Commits

1. **feat(telemetry): wire CLI_INIT event in init command** — `EVENTS.CLI_INIT` was registered in #305 but no caller emitted it, so init usage shipped invisible to dashboards. Properties capture init-flow shape (skills opt-in, target, --force, summary counts, success flag) without any PII.
2. **chore(release): v0.10.0** — version bump only.

## Notable changes since v0.9.1

- **ADR-012** (#304 / #307): annotate-by-default for definition writes; `allowDefinitionWrite` opt-in
- **ADR-013** (#313 / #314): scope boundary — code generation handed to `figma-implement-design`; `canicode prompt` CLI removed
- **ADR-014** (#319 / #321): Claude Code skills bundled in npm and installed via `canicode init`
- canicode-roundtrip orchestration skill (#280, #283, #289, #292)
- README repositioned roundtrip-first (#331)
- ONBOARDING-TEST.md walkthrough script (#329)
- Pre-launch fixes from #333: docs help text (#334), CLI/MCP topic alignment (#335), CLI_INIT telemetry wiring (this PR)

## Pre-launch audit (#333)

All sections green or accepted (see #333 checklist):
- A·B·C·D·H·I·J ✅ automated
- E·F·G ✅ user-confirmed manual
- Known follow-ups filed: **#332** (post-release execution validation), **#336** (helpers.js → PostHog telemetry bridge)

## Test plan

- [x] `pnpm lint` green
- [x] `pnpm test:run` green (851)
- [x] `pnpm build` green
- [x] `npm pack --dry-run` shows expected 17 files including all bundled skills
- [x] Fresh-dir tarball install: `canicode init --token figd_x` prints `installed: 4`
- [x] Both surfaces consistent: `canicode docs scoring`/`rules` and MCP `docs(topic="scoring")`/`docs(topic="rules")` all return content
- [x] `dist/cli/index.js` contains the new `trackEvent(EVENTS.CLI_INIT, ...)` call site

## After merge

Push the `v0.10.0` tag: `git tag v0.10.0 && git push origin v0.10.0` → GitHub Actions publishes to npm → unblocks **#332** (post-release execution validation in fresh dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)