### PR TITLE
feat: feat(roundtrip): precheck Figma MCP availability before Step 4

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -18,6 +18,18 @@ Orchestrate the full design-to-code roundtrip: analyze a Figma design for readin
 
 ## Workflow
 
+### Step 0: Verify Figma MCP tools are loaded
+
+Before Step 1, verify that `use_figma` is callable in **this** session — not merely listed in `.mcp.json`. Newly registered MCP servers (e.g. via `claude mcp add -s project -t http figma https://mcp.figma.com/mcp`) require a Claude Code restart to load their tools; reading `.mcp.json` is not a substitute for checking the live tool list you have access to right now.
+
+If `use_figma` is unavailable in the current session, **Do NOT proceed to Step 1**. Steps 1 (analyze) and 3 (gotcha-survey) spend real Figma API calls and 5–15 minutes of human survey time before Step 4 would otherwise discover `use_figma` is missing. Halt immediately and tell the user:
+
+1. Confirm `.mcp.json` registers the Figma MCP entry (e.g. `figma` under `mcpServers`).
+2. Restart Claude Code so the newly registered tools load.
+3. Re-invoke `/canicode-roundtrip <url>`.
+
+See the Edge Case **No Figma MCP server** below for the one-way fallback when Figma MCP genuinely cannot be installed — the precheck above is for the common "installed but not restarted" case, not a replacement for that fallback.
+
 ### Step 1: Analyze the design
 
 If the `analyze` MCP tool is available, call it with the user's Figma URL:


### PR DESCRIPTION
## Summary

Add a Step 0 precheck to the canicode-roundtrip SKILL.md that verifies Figma MCP tools (specifically `use_figma`) are loaded in the current Claude Code session before Step 1. If the tools are missing — e.g. because the user registered Figma MCP via `claude mcp add ...` but didn't restart — halt immediately with a clear message instructing them to restart Claude Code and re-invoke `/canicode-roundtrip`. The existing fallback path (Edge Cases: "No Figma MCP server") stays intact for users who genuinely cannot install Figma MCP. This is a documentation-only change to one SKILL.md file — no TypeScript, no new code, no bundle rebuild.

## Tasks

- Insert Step 0 precheck before Step 1 in canicode-roundtrip SKILL.md

## Self-review

Docs-only change correctly scoped to SKILL.md. The new Step 0 precheck is phrased to catch the exact failure mode from #332 (registered in .mcp.json but not callable in current session), names use_figma as the canonical probe, halts before any Figma API calls or survey time is spent, and cross-references the existing No-Figma-MCP Edge Case so the one-way fallback remains discoverable. Numbering as Step 0 preserves stability of downstream Step 1-6 references (grep confirmed no collision).
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 2

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #339

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))