### PR TITLE
docs: renumber ADR-016 → ADR-015 (no ADR-015 was reserved)

### DIFF
--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -152,7 +152,7 @@ Core decisions that shape every session. ADRs are listed by ADR number; chronolo
 
 **References**: ADR-009 (skill auto-discovery clarification), ADR-013 (scope boundary), #318 (implementation — CLI, build, README, bundled skill files), [README install section](https://github.com/let-sunny/canicode#installation), [Wiki Setup](https://github.com/let-sunny/canicode/wiki/Setup).
 
-## ADR-016: Gotchas SKILL.md lifecycle — workflow at top, accumulating per-design sections
+## ADR-015: Gotchas SKILL.md lifecycle — workflow at top, accumulating per-design sections
 
 **Decision**: `.claude/skills/canicode-gotchas/SKILL.md` is a single file with two regions separated by the `# Collected Gotchas` heading. Everything above that heading (YAML frontmatter + workflow prose, installed by `canicode init`) is the skill loader contract — written once and never modified by `/canicode-gotchas` or `/canicode-roundtrip` runs. Per-design gotcha answers live in numbered sections below the heading, identified by a `Design key` bullet (`<fileKey>#<nodeId>` for Figma URLs; absolute fixture path otherwise). Re-running on the same design replaces that section in place (preserving its `#NNN` number); a different design appends a new section. No auto-prune — history grows until a user manually edits it.
 


### PR DESCRIPTION
## Summary

#346 landed the gotcha-skill lifecycle decision as ADR-016, but no ADR-015 was ever reserved — the previous head was ADR-014. Renumbers the new entry to ADR-015 to keep the sequence dense.

## Why this happened

The follow-up reminder I left on #340 said "Place it as ADR-016" — off by one. The implementer correctly followed the suggestion. No other file (source, wiki, git history) references ADR-015, so the renumber is a single-line change with no downstream cleanup.

## Test plan

- [x] grep ADR-015 (no matches)
- [x] grep ADR-016 (only the one heading we're renaming)
- [x] no SKILL.md / wiki / issue body references the number