### PR TITLE
chore(release): v0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Score your Figma designs with AI-calibrated rules. CLI + MCP server.",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release bundling the four onboarding-test follow-ups surfaced in #332.

| Issue | PR | Change |
|---|---|---|
| #338 | #343 | README install line uses `npx canicode init` (fresh shells no longer hit exit 127) |
| #339 | #345 | Roundtrip skill adds Step 0 — verifies Figma MCP `use_figma` is callable before spending analyze + survey time |
| #340 | #346 | `canicode-gotchas/SKILL.md` switches to ADR-style append (workflow region preserved + per-design sections) — recorded as ADR-015 |
| #341 | #344 | Step 5 reports issues delta (`X resolved / Y annotated / Z remaining`), gate flipped from grade to `V == 0` |

## Test plan

- [x] All four PRs merged on `main` (97986ab → 78bbd83)
- [x] ADR-016 → ADR-015 renumbered (#347)
- [x] Wiki Decision Log + Experiment-09 onboarding entry pushed
- [ ] Tag `v0.10.1` after merge → CI auto-publishes to npm
- [ ] #342 regression test on a fresh `npx canicode@0.10.1 init` walkthrough