### PR TITLE
chore(release): v0.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Score your Figma designs with AI-calibrated rules. CLI + MCP server.",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release bundling the v0.10.1 regression test follow-up.

| Issue | PR | Change |
|---|---|---|
| #349 | #350 | `canicode init` output replaces the single `Next: canicode analyze` hint with a prereq-aware checklist (Install Figma MCP if missing → Restart Claude Code → Run /canicode-roundtrip). Detects existing `.mcp.json` Figma entry and skips the install step when already present. |

## Test plan

- [x] PR #350 merged on main
- [ ] Tag v0.10.2 → CI auto-publish
- [ ] Fresh-dir regression: `npx canicode@0.10.2 init --token ...` prints the new 3-step (or 2-step if MCP detected) checklist
- [ ] Continue #342 walkthrough on v0.10.2 — the new init output should make Step 0 (#339) precheck redundant in the common path