### PR TITLE
fix(rule): missing-interaction-state false positive when master not in componentDefinitions (#354)

### DIFF
--- a/src/core/rules/interaction/index.test.ts
+++ b/src/core/rules/interaction/index.test.ts
@@ -12,9 +12,11 @@ describe("missing-interaction-state", () => {
     expect(def.category).toBe("interaction");
   });
 
-  it("flags INSTANCE button without hover variant", () => {
+  it("flags INSTANCE button without hover variant (master fetched, no variants)", () => {
+    const masterNode = makeNode({ id: "c:1", name: "Button Master", type: "COMPONENT" });
     const node = makeNode({ id: "1:1", name: "Primary Button", type: "INSTANCE", componentId: "c:1" });
-    const ctx = makeContext({ path: ["Page", "Button"] });
+    const file = makeFile({ componentDefinitions: { "c:1": masterNode } });
+    const ctx = makeContext({ file, path: ["Page", "Button"] });
     const result = missingInteractionState.check(node, ctx);
 
     expect(result).not.toBeNull();
@@ -83,6 +85,7 @@ describe("missing-interaction-state", () => {
   });
 
   it("still flags hover even when ON_HOVER prototype exists (prototype ≠ variant)", () => {
+    const masterNode = makeNode({ id: "c:1", name: "Link Master", type: "COMPONENT" });
     const node = makeNode({
       id: "1:1",
       name: "Link Item",
@@ -92,15 +95,18 @@ describe("missing-interaction-state", () => {
         { trigger: { type: "ON_HOVER" }, actions: [{ navigation: "CHANGE_TO", destinationId: "d:1" }] },
       ],
     });
-    const ctx = makeContext();
+    const file = makeFile({ componentDefinitions: { "c:1": masterNode } });
+    const ctx = makeContext({ file });
     const result = missingInteractionState.check(node, ctx);
     expect(result).not.toBeNull();
     expect(result!.subType).toBe("hover");
   });
 
   it("flags input without focus variant", () => {
+    const masterNode = makeNode({ id: "c:1", name: "Input Master", type: "COMPONENT" });
     const node = makeNode({ id: "1:1", name: "Search Input", type: "INSTANCE", componentId: "c:1" });
-    const ctx = makeContext({ path: ["Page", "Input"] });
+    const file = makeFile({ componentDefinitions: { "c:1": masterNode } });
+    const ctx = makeContext({ file, path: ["Page", "Input"] });
     const result = missingInteractionState.check(node, ctx);
 
     expect(result).not.toBeNull();
@@ -108,8 +114,10 @@ describe("missing-interaction-state", () => {
   });
 
   it("flags tab without hover variant", () => {
+    const masterNode = makeNode({ id: "c:1", name: "Tab Master", type: "COMPONENT" });
     const node = makeNode({ id: "1:1", name: "Navigation Tab", type: "INSTANCE", componentId: "c:1" });
-    const ctx = makeContext({ path: ["Page", "Tab"] });
+    const file = makeFile({ componentDefinitions: { "c:1": masterNode } });
+    const ctx = makeContext({ file, path: ["Page", "Tab"] });
     const result = missingInteractionState.check(node, ctx);
 
     expect(result).not.toBeNull();
@@ -117,7 +125,9 @@ describe("missing-interaction-state", () => {
   });
 
   it("deduplicates per componentId + subType", () => {
-    const ctx = makeContext({ path: ["Page", "Section"] });
+    const masterNode = makeNode({ id: "c:1", name: "Link Master", type: "COMPONENT" });
+    const file = makeFile({ componentDefinitions: { "c:1": masterNode } });
+    const ctx = makeContext({ file, path: ["Page", "Section"] });
     // Use link — only expects hover (single state), so dedup is clean
     const node1 = makeNode({ id: "1:1", name: "Link", type: "INSTANCE", componentId: "c:1" });
     const node2 = makeNode({ id: "1:2", name: "Link", type: "INSTANCE", componentId: "c:1" });
@@ -128,6 +138,65 @@ describe("missing-interaction-state", () => {
     expect(result1).not.toBeNull();
     expect(result1!.subType).toBe("hover");
     expect(result2).toBeNull(); // deduped: same componentId + hover
+  });
+
+  // ============================================
+  // #354: false-positive on nested instance whose master was not fetched
+  // ============================================
+
+  it("returns null when nested instance has no propDefs and master is not in componentDefinitions", () => {
+    // Repro for #354: deeply-nested INSTANCE child whose master the loader
+    // never fetched. Both data paths the rule consults are empty, so the
+    // verdict is unknown — must NOT fire.
+    const node = makeNode({
+      id: "1:1",
+      name: "Email Button",
+      type: "INSTANCE",
+      componentId: "c:nested-354",
+    });
+    const file = makeFile({ componentDefinitions: {} });
+    const ctx = makeContext({ file, path: ["Page", "Form", "Button"] });
+    expect(missingInteractionState.check(node, ctx)).toBeNull();
+  });
+
+  it("still flags missing variant when master IS resolved without it", () => {
+    // Regression guard: the new probe gate must NOT swallow a real miss when
+    // we have positive evidence (master fetched, demonstrably no State variant).
+    const masterNode = makeNode({
+      id: "c:resolved-354",
+      name: "Button Master",
+      type: "COMPONENT",
+      componentPropertyDefinitions: {
+        "Size": { type: "VARIANT", variantOptions: ["Sm", "Lg"] },
+      },
+    });
+    const node = makeNode({
+      id: "1:1",
+      name: "Submit Button",
+      type: "INSTANCE",
+      componentId: "c:resolved-354",
+    });
+    const file = makeFile({ componentDefinitions: { "c:resolved-354": masterNode } });
+    const ctx = makeContext({ file, path: ["Page", "Button"] });
+    const result = missingInteractionState.check(node, ctx);
+    expect(result).not.toBeNull();
+    expect(result!.subType).toBe("hover");
+  });
+
+  it("flags when instance carries empty componentPropertyDefinitions", () => {
+    // Empty object (vs undefined) is positive evidence the API answered for
+    // this instance and the master truly has no variant axes — must fire.
+    const node = makeNode({
+      id: "1:1",
+      name: "Confirm Button",
+      type: "INSTANCE",
+      componentId: "c:empty-354",
+      componentPropertyDefinitions: {},
+    });
+    const ctx = makeContext({ path: ["Page", "Button"] });
+    const result = missingInteractionState.check(node, ctx);
+    expect(result).not.toBeNull();
+    expect(result!.subType).toBe("hover");
   });
 });
 

--- a/src/core/rules/interaction/index.ts
+++ b/src/core/rules/interaction/index.ts
@@ -70,6 +70,32 @@ function hasStateInComponentMaster(
   return hasStateInVariantProps(master, statePattern);
 }
 
+/**
+ * Decide whether we have enough source data to assert a state variant is missing.
+ *
+ * The Figma REST API does not consistently mirror `componentPropertyDefinitions`
+ * onto deeply-nested INSTANCE children, and `context.file.componentDefinitions`
+ * only contains masters the loader actually fetched (external-library masters
+ * stay null even after extra passes). When BOTH paths are empty for an INSTANCE
+ * we cannot tell whether the master defines the variant or not — treat that as
+ * "unknown" (return false here) rather than asserting a missing variant.
+ *
+ * COMPONENT nodes are special: a COMPONENT IS the master, so the absence of
+ * `componentPropertyDefinitions` on a COMPONENT is itself meaningful evidence
+ * (standalone master with no variant axis at all). Always treat COMPONENTs as
+ * determinable so the rule still catches the "designer never added variants"
+ * case the rule is supposed to flag.
+ */
+function canDetermineVariants(node: AnalysisNode, context: RuleContext): boolean {
+  if (node.type === "COMPONENT") return true;
+  if (node.componentPropertyDefinitions !== undefined) return true;
+  if (node.componentId !== undefined) {
+    const defs = context.file.componentDefinitions;
+    if (defs && defs[node.componentId] !== undefined) return true;
+  }
+  return false;
+}
+
 // ============================================
 // missing-interaction-state
 // ============================================
@@ -92,6 +118,14 @@ const missingInteractionStateCheck: RuleCheckFn = (node, context) => {
 
   const expectedStates = EXPECTED_STATES[interactiveType];
   if (!expectedStates) return null;
+
+  // Probe gate: only assert a missing variant when we can actually observe the
+  // master's variant axes. For nested INSTANCE children whose master was not
+  // fetched into `componentDefinitions` and whose own `componentPropertyDefinitions`
+  // is undefined, treat the verdict as unknown and skip — this avoids the
+  // false-positive class described in #354. The data-availability check is
+  // per-node (not per-state), so it lives outside the for-loop below.
+  if (!canDetermineVariants(node, context)) return null;
 
   const seen = getSeen(context);
   const nodePath = context.path.join(" > ");


### PR DESCRIPTION
Closes #354.

## Summary

`missing-interaction-state` was firing false positives on every nested INSTANCE child whose master the loader could not fetch into `context.file.componentDefinitions`. Both data paths the rule consults (`node.componentPropertyDefinitions` and the master fallback) returned empty, but the rule still asserted "missing variant". On Simple Design System (Community) — the calibration / fixture / onboarding-test reference file — every nested input/button under the Hero Form got a noisy annotation the designer could not dismiss.

This PR adopts option **(3) probe-based dedupe** from the issue: gate the violation on positive data evidence, treat empty-data as **unknown** (not **missing**).

## Change

- New helper `canDetermineVariants(node, context)` in `src/core/rules/interaction/index.ts`. Returns true when ANY of these holds:
  - `node.type === 'COMPONENT'` — a COMPONENT IS the master, so absence of `componentPropertyDefinitions` is itself meaningful (preserves the "designer never added variants" catch).
  - `node.componentPropertyDefinitions !== undefined` — even an empty object `{}` is positive evidence the API answered for this instance.
  - The instance's master is present in `context.file.componentDefinitions`.
- `missingInteractionStateCheck` calls the helper after the `expectedStates` guard but **before** the per-state for-loop, and returns `null` early when the verdict is unknown. The hoist is intentional — data-availability is per-node, not per-state, so checking inside the loop would re-evaluate the same boolean and interact subtly with the existing `seen` dedup Set.
- `missingPrototypeCheck` is **untouched** in this PR. Its data shape differs (FRAME nodes can fire without any componentId) and the issue is scoped to `missing-interaction-state`. If a parallel false-positive class surfaces on `missing-prototype`, a follow-up issue can apply the analogous fix.

## Trade-off

A real missing variant on a master canicode could not fetch now goes silently un-flagged. This is exactly the trade-off issue #354 acknowledges. The alternative (option 1, raise loader `maxPasses`) only narrows the gap — external-library components return `null` from the Figma REST API regardless of pass count (see `src/core/adapters/component-resolver.ts` "Skip failed batches"), so the rule must handle empty-data gracefully either way. False positives erode trust more than the rare silent miss.

## Tests

- 5 existing tests that flagged INSTANCEs with no data path were updated to attach a master fixture (so they continue to assert "no variant" with positive evidence — the realistic top-level INSTANCE case the loader does fetch).
- 3 new tests cover the new behavior:
  - `returns null when nested instance has no propDefs and master is not in componentDefinitions` — the #354 repro shape.
  - `still flags missing variant when master IS resolved without it` — regression guard.
  - `flags when instance carries empty componentPropertyDefinitions` — empty-object positive evidence path.

## Test plan

- [x] `pnpm test:run` — full suite green (863 tests)
- [x] `pnpm lint` — clean
- [ ] Re-run on Simple Design System (Community), node `3245-8209` after merge — `missing-interaction-state` should no longer fire on the Hero Form's Input Field instances.

## Acceptance from #354

- [x] Repro on Simple Design System (Community): no more false positives on nested input/button (covered by synthetic test #1)
- [x] No regression on existing fixtures where the rule legitimately fires (test #2 + 5 updated tests)
- [x] Test stash for nested instance whose master has the variant — covered


Made with [Cursor](https://cursor.com)