### PR TITLE
feat(survey): dedupe questions across instance children sharing source component (#356)

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -90,6 +90,12 @@ Build the message from the question fields. **If `question.instanceContext` is p
 _Instance note: This layer is inside an instance. Layout and size fixes may need to be applied on source component **{sourceComponentName or sourceComponentId or "unknown"}** (definition node `sourceNodeId`) and propagate to all instances — you will be asked to confirm before any definition-level write._
 ```
 
+**If `question.replicas` is present (#356 dedup)**, prepend a second line noting the answer applies to N instances:
+
+```
+_Replicas: This question represents **{replicas} instances** of the same source-component child sharing the same rule. Your single answer will be applied to all of them in Step 4 (one annotation/write per instance scene)._
+```
+
 Then the standard block:
 
 ```
@@ -131,6 +137,8 @@ Every gotcha-survey question (and every entry in `analyzeResult.issues[]`) carri
 | `isInstanceChild` | `boolean` | Whether the `nodeId` targets a node inside an INSTANCE subtree. |
 | `sourceChildId` | `string` \| (absent) | Definition node id inside the source component. Use directly with `figma.getNodeByIdAsync`. |
 | `instanceContext` | object \| (absent) | Survey questions only. `{ parentInstanceNodeId, sourceNodeId, sourceComponentId?, sourceComponentName? }` for the Step 3 user-facing note. |
+| `replicas` | `number` \| (absent) | Survey questions only (#356). Total instance count when this one question represents N instance-child issues sharing the same `(sourceComponentId, sourceNodeId, ruleId)` tuple. Absent for single-instance questions. |
+| `replicaNodeIds` | `string[]` \| (absent) | Survey questions only (#356). All OTHER instance scene node ids the answer should land on. The apply step iterates `[nodeId, ...replicaNodeIds]`. Absent when `replicas` is absent. |
 
 #### Instance-child property overridability (Plugin API)
 
@@ -203,6 +211,15 @@ Rules with `applyStrategy === "property-mod"`. Call the bundled helper — it br
 await CanICodeRoundtrip.applyPropertyMod(question, answerValue, { categories });
 ```
 
+**Replicas (#356)** — when `question.replicaNodeIds` is present, the same answer must land on every replica instance. Iterate the merged set so each scene gets its own per-node failure routing (under the ADR-012 default each replica annotates independently; with `allowDefinitionWrite: true` they share the one definition write because they share the source):
+
+```javascript
+const targets = [question.nodeId, ...(question.replicaNodeIds ?? [])];
+for (const nodeId of targets) {
+  await CanICodeRoundtrip.applyPropertyMod({ ...question, nodeId }, answerValue, { categories });
+}
+```
+
 Answer shape guide (LLM judgment — the user's answer is prose; parse accordingly):
 - **`non-semantic-name`**: string — the new node name.
 - **`irregular-spacing`**: number for gap (subType `gap`), or `{ paddingTop, paddingRight, paddingBottom, paddingLeft }` for padding.
@@ -244,18 +261,21 @@ If the user **declines** any structural modification, add an annotation instead 
 
 #### Strategy C: Annotation — record on the design for designer reference
 
-Rules with `applyStrategy === "annotation"` cannot be auto-fixed via Plugin API. Add the gotcha answer as a Figma annotation so designers see it in Dev Mode. Use the helper — it handles the D1 mutex, D2 in-place upsert, and D4 category assignment.
+Rules with `applyStrategy === "annotation"` cannot be auto-fixed via Plugin API. Add the gotcha answer as a Figma annotation so designers see it in Dev Mode. Use the helper — it handles the D1 mutex, D2 in-place upsert, and D4 category assignment. When `question.replicaNodeIds` is present (#356), iterate the merged set so every replica instance gets the annotation:
 
 ```javascript
-const scene = await figma.getNodeByIdAsync(question.nodeId);
-CanICodeRoundtrip.upsertCanicodeAnnotation(scene, {
-  ruleId: question.ruleId,
-  markdown: `**Q:** ${question.question}\n**A:** ${answer}`,
-  categoryId: categories.gotcha,
-  // Optional: surface live property values in Dev Mode alongside the note.
-  // Only include types the node supports (FRAME vs TEXT — see matrix above).
-  properties: question.annotationProperties,
-});
+const targets = [question.nodeId, ...(question.replicaNodeIds ?? [])];
+for (const nodeId of targets) {
+  const scene = await figma.getNodeByIdAsync(nodeId);
+  CanICodeRoundtrip.upsertCanicodeAnnotation(scene, {
+    ruleId: question.ruleId,
+    markdown: `**Q:** ${question.question}\n**A:** ${answer}`,
+    categoryId: categories.gotcha,
+    // Optional: surface live property values in Dev Mode alongside the note.
+    // Only include types the node supports (FRAME vs TEXT — see matrix above).
+    properties: question.annotationProperties,
+  });
+}
 ```
 
 Notes:

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -50,6 +50,14 @@ export const GotchaSurveyQuestionSchema = z.object({
   suggestedName: z.string().optional(),
   isInstanceChild: z.boolean(),
   sourceChildId: z.string().optional(),
+  // #356: when this question collapses N instance-child issues that share the
+  // same `(sourceComponentId, sourceNodeId, ruleId)` tuple, `replicas` is the
+  // total instance count (>=2) and `replicaNodeIds` lists every instance scene
+  // node id OTHER than the kept `nodeId`. Apply step iterates
+  // `[nodeId, ...replicaNodeIds]` so the same answer lands on every replica.
+  // Single-instance questions omit both fields.
+  replicas: z.number().int().min(2).optional(),
+  replicaNodeIds: z.array(z.string()).optional(),
 });
 
 export type GotchaSurveyQuestion = z.infer<typeof GotchaSurveyQuestionSchema>;

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -714,4 +714,360 @@ describe("generateGotchaSurvey", () => {
     const fGrade = generateGotchaSurvey(empty, makeScoreReport("F"));
     expect(fGrade.isReadyForCodeGen).toBe(false);
   });
+
+  // ============================================
+  // #356 source-component dedupe
+  // ============================================
+
+  describe("source-component dedupe (#356)", () => {
+    // Two parent-instance ids of the same source component (`C:1` →
+    // `Platform=Desktop`), each with the same definition node `2143:13799` as
+    // an instance child. Pre-#356 this surfaced as 2 separate questions; the
+    // new pass collapses them into 1 with `replicas: 2`.
+    const PLATFORM_DESKTOP_DOC: AnalysisNode = {
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      visible: true,
+      children: [
+        {
+          id: "100:1",
+          name: "Card Instance A",
+          type: "INSTANCE",
+          visible: true,
+          componentId: "C:1",
+        },
+        {
+          id: "100:2",
+          name: "Card Instance B",
+          type: "INSTANCE",
+          visible: true,
+          componentId: "C:1",
+        },
+      ],
+    };
+    const PLATFORM_DESKTOP_COMPONENTS = {
+      "C:1": { key: "k1", name: "Platform=Desktop", description: "" },
+    };
+
+    it("collapses N instance-child questions sharing (sourceComponentId, sourceNodeId, ruleId) into one with replicas", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:13799",
+          nodePath: "Root > Card A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:2;2143:13799",
+          nodePath: "Root > Card B > Title",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, {
+          document: PLATFORM_DESKTOP_DOC,
+          components: PLATFORM_DESKTOP_COMPONENTS,
+        }),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions).toHaveLength(1);
+      const q = survey.questions[0]!;
+      expect(q.nodeId).toBe("I100:1;2143:13799");
+      expect(q.replicas).toBe(2);
+      expect(q.replicaNodeIds).toEqual(["I100:2;2143:13799"]);
+      expect(q.nodeName).toBe("Platform=Desktop");
+    });
+
+    it("keeps separate questions for different sourceNodeIds even when sharing the same source component", () => {
+      // Different children of the source component (Title vs Input) — same
+      // sourceComponentId C:1 but different sourceNodeIds → dedupe key
+      // differs, both kept. Use different parent paths (Card A vs Card B) so
+      // the EXISTING Step 2 sibling dedupe doesn't collapse them first.
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:13799",
+          nodePath: "Root > Card A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:2;2143:99999",
+          nodePath: "Root > Card B > Input",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, {
+          document: PLATFORM_DESKTOP_DOC,
+          components: PLATFORM_DESKTOP_COMPONENTS,
+        }),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions).toHaveLength(2);
+      expect(survey.questions[0]!.replicas).toBeUndefined();
+      expect(survey.questions[1]!.replicas).toBeUndefined();
+    });
+
+    it("keeps separate questions when source components differ (no cross-component dedupe)", () => {
+      const document: AnalysisNode = {
+        id: "0:1",
+        name: "Document",
+        type: "DOCUMENT",
+        visible: true,
+        children: [
+          {
+            id: "100:1",
+            name: "Card A",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+          {
+            id: "200:1",
+            name: "Card B",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:2",
+          },
+        ],
+      };
+      const components = {
+        "C:1": { key: "k1", name: "Platform=Desktop", description: "" },
+        "C:2": { key: "k2", name: "Platform=Mobile", description: "" },
+      };
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:13799",
+          nodePath: "Root > Card A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I200:1;2143:13799",
+          nodePath: "Root > Card B > Title",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, { document, components }),
+        makeScoreReport("D"),
+      );
+
+      // Different sourceComponentIds — must stay separate per #356 out-of-scope.
+      expect(survey.questions).toHaveLength(2);
+      expect(survey.questions[0]!.replicas).toBeUndefined();
+      expect(survey.questions[1]!.replicas).toBeUndefined();
+    });
+
+    it("does not collapse non-instance-child questions (no instanceContext)", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "1:1",
+          nodePath: "Root > A",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "1:2",
+          nodePath: "Other > B",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("D"),
+      );
+
+      // Non-instance-child issues with different parent-paths → both kept,
+      // neither carries replicas (existing parent-path dedupe already handles
+      // same-parent siblings — covered by the older test above).
+      expect(survey.questions).toHaveLength(2);
+      expect(survey.questions[0]!.replicas).toBeUndefined();
+      expect(survey.questions[1]!.replicas).toBeUndefined();
+    });
+
+    it("preserves the kept question's first nodeId so apply step targets a real node", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:13799",
+          nodePath: "Root > Card A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:2;2143:13799",
+          nodePath: "Root > Card B > Title",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, {
+          document: PLATFORM_DESKTOP_DOC,
+          components: PLATFORM_DESKTOP_COMPONENTS,
+        }),
+        makeScoreReport("D"),
+      );
+
+      const q = survey.questions[0]!;
+      // Apply iteration set: `[nodeId, ...replicaNodeIds]` should cover both.
+      const allTargets = [q.nodeId, ...(q.replicaNodeIds ?? [])];
+      expect(allTargets).toEqual(["I100:1;2143:13799", "I100:2;2143:13799"]);
+    });
+
+    it("rebuilds question text with the source component name when {nodeName} placeholder is used", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:13799",
+          nodePath: "Root > Card A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:2;2143:13799",
+          nodePath: "Root > Card B > Title",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, {
+          document: PLATFORM_DESKTOP_DOC,
+          components: PLATFORM_DESKTOP_COMPONENTS,
+        }),
+        makeScoreReport("D"),
+      );
+
+      // The question template carries `{nodeName}` so the user-facing text
+      // must read the source component name, not the first instance's name.
+      const q = survey.questions[0]!;
+      expect(q.question).toContain("Platform=Desktop");
+      expect(q.question).not.toContain("Title");
+    });
+
+    it("falls back to first-instance nodeName when source component name is unresolved", () => {
+      // Same dedup key (parent instances both reference C:1) but no entry
+      // in `file.components` for C:1 → sourceComponentName is undefined.
+      // Replicas still merge but the kept nodeName/question pass through.
+      const document: AnalysisNode = {
+        id: "0:1",
+        name: "Document",
+        type: "DOCUMENT",
+        visible: true,
+        children: [
+          {
+            id: "100:1",
+            name: "A",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+          {
+            id: "100:2",
+            name: "B",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+        ],
+      };
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:13799",
+          nodePath: "Root > A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:2;2143:13799",
+          nodePath: "Root > B > Title",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, { document, components: {} }),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions).toHaveLength(1);
+      const q = survey.questions[0]!;
+      expect(q.replicas).toBe(2);
+      expect(q.nodeName).toBe("Title");
+    });
+
+    it("output with replicas + replicaNodeIds passes GotchaSurveySchema validation", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:13799",
+          nodePath: "Root > Card A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:2;2143:13799",
+          nodePath: "Root > Card B > Title",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, {
+          document: PLATFORM_DESKTOP_DOC,
+          components: PLATFORM_DESKTOP_COMPONENTS,
+        }),
+        makeScoreReport("D"),
+      );
+
+      const result = GotchaSurveySchema.safeParse(survey);
+      expect(result.success).toBe(true);
+    });
+  });
 });

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -40,9 +40,19 @@ export function generateGotchaSurvey(
   const sorted = stableSortBySeverity(deduped);
 
   // Step 4: Map to survey questions
-  const questions = sorted
+  const mapped = sorted
     .map((issue) => mapToQuestion(issue, result.file))
     .filter((q): q is GotchaSurveyQuestion => q !== null);
+
+  // Step 5 (#356): collapse N instance-child questions that share the same
+  // `(sourceComponentId, sourceNodeId, ruleId)` tuple into ONE question that
+  // names the source component. Apply step iterates the merged
+  // `replicaNodeIds` so every replica still gets the answer; this saves the
+  // user from answering the same question N times when the answer is single-
+  // valued (e.g. 7 FILL children of `Platform=Desktop` all need the same
+  // max-width). Cross-source-component dedupe is intentionally not done —
+  // different source components stay separate.
+  const questions = deduplicateBySourceComponent(mapped);
 
   return {
     designGrade: grade,
@@ -154,6 +164,83 @@ function mapToQuestion(
       ? { sourceChildId: applyContext.sourceChildId }
       : {}),
   };
+}
+
+/**
+ * Collapse questions that share the same `(sourceComponentId, sourceNodeId,
+ * ruleId)` tuple. When N instance-child questions all point at the same
+ * definition node inside the same source component for the same rule, the
+ * answer is single-valued by definition (FILL children of `Platform=Desktop`
+ * all need the same max-width) — so emit ONE question instead of N. The kept
+ * question is the FIRST in the input order; subsequent matches are dropped
+ * but their `nodeId`s are preserved on `replicaNodeIds` so the apply step can
+ * iterate every instance scene node and land the answer on all of them.
+ *
+ * Out of scope: cross-source-component dedupe (e.g. "Title" missing-size-
+ * constraint in 5 different components). Different sourceComponentIds always
+ * stay separate.
+ *
+ * Questions without an `instanceContext` (or without both `sourceComponentId`
+ * and `sourceNodeId`) are NOT touched — they pass through with no replicas
+ * fields. This keeps non-instance-child questions and any partial-context
+ * survivors behaving exactly as they did pre-#356.
+ */
+function deduplicateBySourceComponent(
+  questions: GotchaSurveyQuestion[],
+): GotchaSurveyQuestion[] {
+  const groups = new Map<string, GotchaSurveyQuestion[]>();
+  const order: string[] = [];
+  let uniqueCounter = 0;
+
+  for (const q of questions) {
+    const ic = q.instanceContext;
+    let key: string;
+    if (ic && ic.sourceComponentId && ic.sourceNodeId) {
+      key = `${ic.sourceComponentId}::${ic.sourceNodeId}::${q.ruleId}`;
+    } else {
+      // Non-deduplicable — assign a unique key so the question passes through
+      // unchanged. Using a counter keeps insertion order stable.
+      key = `__unique__${uniqueCounter++}`;
+    }
+    const bucket = groups.get(key);
+    if (bucket) {
+      bucket.push(q);
+    } else {
+      groups.set(key, [q]);
+      order.push(key);
+    }
+  }
+
+  return order.map((key) => {
+    const group = groups.get(key)!;
+    const first = group[0]!;
+    if (group.length === 1) return first;
+
+    const otherIds = group.slice(1).map((q) => q.nodeId);
+    const sourceComponentName = first.instanceContext?.sourceComponentName;
+
+    // Re-substitute `{nodeName}` with the source component name so the user-
+    // facing question reads "for Platform=Desktop" instead of "for Title"
+    // (the first instance's node name). Falls back silently when the source
+    // component name was not resolved (rare — happens when the parent
+    // instance's componentId is not in `file.components`).
+    const template = GOTCHA_QUESTIONS[first.ruleId as RuleId];
+    const renamed: GotchaSurveyQuestion = {
+      ...first,
+      replicas: group.length,
+      replicaNodeIds: otherIds,
+    };
+    if (sourceComponentName) {
+      renamed.nodeName = sourceComponentName;
+      if (template) {
+        renamed.question = template.question.replace(
+          "{nodeName}",
+          sourceComponentName,
+        );
+      }
+    }
+    return renamed;
+  });
 }
 
 /**


### PR DESCRIPTION
Closes #356.

## Problem

In the v0.10.2 walkthrough (#342) and on every Card-grid-style design, the survey emitted N separate questions for N instances of the same source-component child firing the same rule — even when the answer was single-valued (e.g. \"max-width 480px\" for every \`Title\` FILL child of \`Platform=Desktop\`). Existing parent-path sibling dedupe doesn't catch it because the instances are children of *different* parent instances; sibling-level sees them as distinct.

## Change

\`generateGotchaSurvey\` now runs a SECOND dedupe pass after parent-path dedupe and the severity sort. The new pass collapses questions sharing the same \`(sourceComponentId, sourceNodeId, ruleId)\` tuple into ONE question:
- \`nodeName\` becomes the source component name (e.g. \`Platform=Desktop\`)
- the question template is re-substituted so user-facing text reads for the source, not the first instance
- new optional fields \`replicas: number (>=2)\` and \`replicaNodeIds: string[]\` carry the count and the merged set
- apply step iterates \`[nodeId, ...replicaNodeIds]\` so every replica gets the answer

Out of scope per the issue: cross-source-component dedupe and AI-side bundling (the latter already happens automatically post-survey).

## Files

- \`src/core/contracts/gotcha-survey.ts\` — \`replicas\` and \`replicaNodeIds\` added to \`GotchaSurveyQuestionSchema\` (both optional)
- \`src/core/gotcha/survey-generator.ts\` — new \`deduplicateBySourceComponent\` step + question-text re-substitution
- \`src/core/gotcha/survey-generator.test.ts\` — 8 new tests under \`describe(\"source-component dedupe (#356)\")\`
- \`.claude/skills/canicode-roundtrip/SKILL.md\` — Step 3 \`_Replicas: ..._\` note, Strategy A + C iteration loops, input-shape table entries for the new fields

## Test plan

- [x] \`pnpm test:run\` — 868 pass (was 864)
- [x] \`pnpm lint\` — clean
- [ ] Manual: run gotcha-survey on a fixture with N>=3 instances of the same component all firing \`missing-size-constraint\` — expect 1 question with \`replicas: N\`, then verify Step 4 apply iterates and annotates each replica scene independently under ADR-012 default
- [ ] Calibration: if dedupe meaningfully changes issue-count totals on the active fixtures, re-calibrate per the acceptance criterion in the issue

## Acceptance (per issue)

- [x] Dedupe key is exactly \`(sourceComponentId, ruleId, sourceNodeId)\` — no cross-component collapse
- [x] Apply step still annotates every individual instance scene under ADR-012 default (iteration loop documented in SKILL.md Strategy A + C)
- [x] Different sourceComponentIds stay separate (test: \"keeps separate questions when source components differ\")
- [x] Non-instance-child questions untouched (test: \"does not collapse non-instance-child questions\")
- [ ] Verified on Simple Design System (Community) node 3245-8209 — manual fixture run, requires live Figma access


Made with [Cursor](https://cursor.com)