### PR TITLE
fix(roundtrip): pre-detect external library before allowDefinitionWrite picker (#357)

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -177,6 +177,51 @@ The helper walks the tiers in order; variable binding is an alternative writeFn 
 
 **Confirmation is a batch-level concern — and only needed when opting in.** A `use_figma` call runs one JavaScript batch and cannot pause mid-batch for user input. Under the ADR-012 default (`allowDefinitionWrite: false`), no propagation happens, so no confirmation is required — override-errors annotate and move on. The orchestrator sets `allowDefinitionWrite: true` only after enumerating the likely propagation set to the user up-front and collecting **one confirmation for the whole batch** that names the source component(s) and the affected instance set. When describing impact, note that the write reaches every **non-overridden** instance — any instance with a local override for the same property keeps its override. The helper below never prompts — it assumes that if the flag is on, confirmation already happened.
 
+**Pre-flight writability probe (#357).** Before showing the user the Definition write picker, call `CanICodeRoundtrip.probeDefinitionWritability(questions)` inside a small `use_figma` batch. The probe loads every distinct `sourceChildId` once and classifies it as writable or unwritable using the same detection as the runtime fallback (Experiment 10 `remote === true` and Experiment 11 unresolved-`null`). The result decides which version of the picker to show:
+
+```javascript
+// Inside a use_figma batch:
+const probe = await CanICodeRoundtrip.probeDefinitionWritability(questions);
+return { events: [], probe };
+```
+
+Branches on `probe`:
+
+- **`allUnwritable === true`** — every candidate source is in an external library (or unresolved). Opting in is structurally a no-op; every write would throw "Cannot write to internal and read-only node" and fall through to scene annotation anyway. Show the user a single-option picker:
+
+  ```
+  Definition write policy
+
+  This file's source components live in an external library and are
+  read-only from here ({unwritableSourceNames.join(", ")}). Tier 2
+  propagation cannot fire — every "opt-in" write would fall through
+  to a scene annotation regardless.
+
+  ❯ 1. Annotate only (only viable option for this file)
+    2. Cancel — duplicate the library locally first to enable propagation
+  ```
+
+  Skip the opt-in branch entirely and call the helpers with the default `allowDefinitionWrite: false`.
+
+- **`partiallyUnwritable === true`** — some sources are local, some remote. Surface the split:
+
+  ```
+  Definition write policy
+
+  {unwritableCount} of {totalCount} source components are remote
+  (read-only) and will fall through to annotation; the remaining
+  {totalCount - unwritableCount} are local and will propagate.
+  Remote sources: {unwritableSourceNames.join(", ")}.
+
+  Continue with allowDefinitionWrite: true?
+  ```
+
+  When confirmed, propagate to the local sources and let the helper's runtime fallback annotate the remote ones — the existing Experiment-10 retry path absorbs them without aborting the batch.
+
+- **`allUnwritable === false && partiallyUnwritable === false`** (the all-local / no-candidates case) — show the existing batch-level picker prose. No probe-driven adjustment needed.
+
+The probe is read-only and idempotent; running it before the picker adds one round-trip but saves the user a confusing "I opted in, why did I get annotations?" moment that #342 surfaced live on Simple Design System (Community).
+
 **Shared helpers (bundled)** — the deterministic helpers live in TypeScript at `src/core/roundtrip/*.ts` and are bundled to a single IIFE at `.claude/skills/canicode-roundtrip/helpers.js`. `use_figma` only accepts a self-contained JS string, so the source of truth is TypeScript (with vitest coverage) and the bundle is the delivery artifact.
 
 **Usage in a roundtrip session:**
@@ -190,6 +235,7 @@ The helper walks the tiers in order; variable binding is an alternative writeFn 
    - `applyWithInstanceFallback(question, writeFn, { categories, allowDefinitionWrite, telemetry })` — three-tier write policy with silent-ignore detection. `allowDefinitionWrite` defaults to `false` per ADR-012 — override-errors and silent-ignores annotate the scene naming the source component instead of writing the definition. Set `true` only after a batch-level confirmation. `telemetry` is an optional `(event, props) => void` callback fired when a definition write is skipped (wiring point for future Node-side opt-in usage data). The `writeFn` may return `false` to signal "write accepted but value unchanged" so the helper can route to the next tier.
    - `applyPropertyMod(question, answerValue, { categories, allowDefinitionWrite, telemetry })` — Strategy A entry point. Branches on `targetProperty` (single vs array) and answer shape (scalar, per-property object, `{ variable: "name" }` binding). Uses `setBoundVariableForPaint` for `fills` / `strokes` and `setBoundVariable` for scalar fields. Passes the full context through to `applyWithInstanceFallback`.
    - `resolveVariableByName(name)` — local-variable exact-name lookup; returns `null` for remote library variables not imported into this file.
+   - `probeDefinitionWritability(questions)` — async pre-flight (#357). Returns `{ totalCount, unwritableCount, unwritableSourceNames, allUnwritable, partiallyUnwritable }`. Use BEFORE the Definition write picker so the picker can drop the opt-in branch when every candidate is in an external library / unresolved (saves the user a wasted "I opted in, why did I get annotations?" decision). Read-only probe, dedupes by `sourceChildId`.
 
 Keep each `writeFn` small so a throw does not abort unrelated writes. Experiment 08 findings informed every branch in the bundled helpers, and the batch-level confirmation contract still applies *when opting in*: if the orchestrator passes `allowDefinitionWrite: true`, it must have already collected one confirmation covering every potential definition write in the batch. Under the default, no confirmation is needed — the helper annotates the scene instead of propagating.
 
@@ -410,4 +456,4 @@ Follow the **figma-implement-design** skill workflow to generate code from the F
 - **use_figma call fails for a node**: Report the error for that specific node, continue with other nodes. Failed property modifications become annotations so the context is not lost.
 - **Re-analyze shows new issues**: Only address issues from the original gotcha survey. New issues may appear due to structural changes — report them but do not re-enter the gotcha loop.
 - **Very large design (many gotchas)**: The gotcha survey already deduplicates sibling nodes and filters to blocking/risk severity only. If there are still many questions, ask the user if they want to focus on blocking issues only.
-- **External library components**: Applies only when the orchestrator has set `allowDefinitionWrite: true`. Experiment 10's observed case is `getMainComponentAsync()` resolving with `mainComponent.remote === true` — writes then throw *"Cannot write to internal and read-only node"*. The `mainComponent === null` case is documented in the Plugin API but was not reproduced live in Experiment 10; Experiment 11 (#309) unit-test-covers the helper's routing for that branch (override-error + no `sourceChildId` → annotate with `could not apply automatically:` markdown — see ADR-011 Verification), so the code path is regression-locked while live Figma reproduction remains a manual fixture-seeding follow-up. Under the default (`allowDefinitionWrite: false`), the definition write never fires and this throw cannot surface.
+- **External library components**: Applies only when the orchestrator has set `allowDefinitionWrite: true`. Experiment 10's observed case is `getMainComponentAsync()` resolving with `mainComponent.remote === true` — writes then throw *"Cannot write to internal and read-only node"*. The `mainComponent === null` case is documented in the Plugin API but was not reproduced live in Experiment 10; Experiment 11 (#309) unit-test-covers the helper's routing for that branch (override-error + no `sourceChildId` → annotate with `could not apply automatically:` markdown — see ADR-011 Verification), so the code path is regression-locked while live Figma reproduction remains a manual fixture-seeding follow-up. Under the default (`allowDefinitionWrite: false`), the definition write never fires and this throw cannot surface. **The pre-flight `probeDefinitionWritability` (#357) detects both branches up-front** so the Definition write picker can drop the opt-in option entirely when every candidate is unwritable, saving the user a wasted decision before the runtime fallback kicks in.

--- a/.claude/skills/canicode-roundtrip/helpers.js
+++ b/.claude/skills/canicode-roundtrip/helpers.js
@@ -251,9 +251,42 @@ ${markdown}`;
     );
   }
 
+  // src/core/roundtrip/probe-definition-writability.ts
+  async function probeDefinitionWritability(questions) {
+    const verdict = /* @__PURE__ */ new Map();
+    const unwritableNames = [];
+    const seenName = /* @__PURE__ */ new Set();
+    for (const q of questions) {
+      const id = q.sourceChildId;
+      if (!id) continue;
+      if (verdict.has(id)) continue;
+      const node = await figma.getNodeByIdAsync(id);
+      const isUnwritable = node === null || node.remote === true;
+      verdict.set(id, isUnwritable ? "unwritable" : "writable");
+      if (isUnwritable) {
+        const name = typeof node?.name === "string" && node.name || q.instanceContext?.sourceComponentName || id;
+        if (!seenName.has(name)) {
+          seenName.add(name);
+          unwritableNames.push(name);
+        }
+      }
+    }
+    const totalCount = verdict.size;
+    let unwritableCount = 0;
+    for (const v of verdict.values()) if (v === "unwritable") unwritableCount++;
+    return {
+      totalCount,
+      unwritableCount,
+      unwritableSourceNames: unwritableNames,
+      allUnwritable: totalCount > 0 && unwritableCount === totalCount,
+      partiallyUnwritable: unwritableCount > 0 && unwritableCount < totalCount
+    };
+  }
+
   exports.applyPropertyMod = applyPropertyMod;
   exports.applyWithInstanceFallback = applyWithInstanceFallback;
   exports.ensureCanicodeCategories = ensureCanicodeCategories;
+  exports.probeDefinitionWritability = probeDefinitionWritability;
   exports.resolveVariableByName = resolveVariableByName;
   exports.stripAnnotations = stripAnnotations;
   exports.upsertCanicodeAnnotation = upsertCanicodeAnnotation;

--- a/src/core/roundtrip/index.ts
+++ b/src/core/roundtrip/index.ts
@@ -8,3 +8,5 @@ export {
   applyPropertyMod,
   resolveVariableByName,
 } from "./apply-property-mod.js";
+export { probeDefinitionWritability } from "./probe-definition-writability.js";
+export type { DefinitionWritabilityProbe } from "./probe-definition-writability.js";

--- a/src/core/roundtrip/probe-definition-writability.test.ts
+++ b/src/core/roundtrip/probe-definition-writability.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach } from "vitest";
+import { probeDefinitionWritability } from "./probe-definition-writability.js";
+import {
+  createFigmaGlobal,
+  installFigmaGlobal,
+  uninstallFigmaGlobal,
+  type FigmaGlobalMock,
+} from "./test-utils.js";
+import type { FigmaNode, RoundtripQuestion } from "./types.js";
+
+function makeQuestion(
+  overrides: Partial<RoundtripQuestion>,
+): RoundtripQuestion {
+  return {
+    nodeId: "scene-1",
+    ruleId: "missing-size-constraint",
+    ...overrides,
+  };
+}
+
+function makeDef(overrides: Partial<FigmaNode>): FigmaNode {
+  return {
+    id: "def-1",
+    name: "DefNode",
+    type: "FRAME",
+    annotations: [],
+    ...overrides,
+  };
+}
+
+let mock: FigmaGlobalMock;
+
+afterEach(() => {
+  uninstallFigmaGlobal();
+});
+
+describe("probeDefinitionWritability (#357)", () => {
+  it("returns all-zero when no question carries a sourceChildId", async () => {
+    mock = createFigmaGlobal();
+    installFigmaGlobal(mock);
+    const result = await probeDefinitionWritability([
+      makeQuestion({ sourceChildId: undefined }),
+      makeQuestion({ sourceChildId: undefined }),
+    ]);
+    expect(result).toEqual({
+      totalCount: 0,
+      unwritableCount: 0,
+      unwritableSourceNames: [],
+      allUnwritable: false,
+      partiallyUnwritable: false,
+    });
+  });
+
+  it("classifies a local source as writable", async () => {
+    mock = createFigmaGlobal({
+      nodes: { "def-1": makeDef({ id: "def-1", remote: false }) },
+    });
+    installFigmaGlobal(mock);
+    const result = await probeDefinitionWritability([
+      makeQuestion({ sourceChildId: "def-1" }),
+    ]);
+    expect(result.totalCount).toBe(1);
+    expect(result.unwritableCount).toBe(0);
+    expect(result.allUnwritable).toBe(false);
+    expect(result.partiallyUnwritable).toBe(false);
+  });
+
+  it("classifies a remote source (Experiment 10) as unwritable", async () => {
+    mock = createFigmaGlobal({
+      nodes: { "def-1": makeDef({ id: "def-1", name: "RemoteCard", remote: true }) },
+    });
+    installFigmaGlobal(mock);
+    const result = await probeDefinitionWritability([
+      makeQuestion({ sourceChildId: "def-1" }),
+    ]);
+    expect(result.allUnwritable).toBe(true);
+    expect(result.unwritableSourceNames).toEqual(["RemoteCard"]);
+  });
+
+  it("classifies an unresolved source (Experiment 11 — null) as unwritable", async () => {
+    // Mock returns null for the lookup — same fallback path as
+    // applyWithInstanceFallback's "definition === null" branch.
+    mock = createFigmaGlobal();
+    installFigmaGlobal(mock);
+    const result = await probeDefinitionWritability([
+      makeQuestion({
+        sourceChildId: "def-missing",
+        instanceContext: {
+          parentInstanceNodeId: "p:1",
+          sourceNodeId: "src:1",
+          sourceComponentId: "C:1",
+          sourceComponentName: "MissingMaster",
+        },
+      }),
+    ]);
+    expect(result.allUnwritable).toBe(true);
+    // Falls back to instanceContext.sourceComponentName when the node lookup
+    // returned null.
+    expect(result.unwritableSourceNames).toEqual(["MissingMaster"]);
+  });
+
+  it("reports partially-unwritable when some sources are remote and some local", async () => {
+    mock = createFigmaGlobal({
+      nodes: {
+        "def-local": makeDef({ id: "def-local", name: "Local", remote: false }),
+        "def-remote": makeDef({ id: "def-remote", name: "Remote", remote: true }),
+      },
+    });
+    installFigmaGlobal(mock);
+    const result = await probeDefinitionWritability([
+      makeQuestion({ sourceChildId: "def-local", nodeId: "s:1" }),
+      makeQuestion({ sourceChildId: "def-remote", nodeId: "s:2" }),
+    ]);
+    expect(result.totalCount).toBe(2);
+    expect(result.unwritableCount).toBe(1);
+    expect(result.allUnwritable).toBe(false);
+    expect(result.partiallyUnwritable).toBe(true);
+    expect(result.unwritableSourceNames).toEqual(["Remote"]);
+  });
+
+  it("dedupes by sourceChildId so N replicas of one source count once", async () => {
+    mock = createFigmaGlobal({
+      nodes: { "def-shared": makeDef({ id: "def-shared", remote: true }) },
+    });
+    installFigmaGlobal(mock);
+    const result = await probeDefinitionWritability([
+      makeQuestion({ sourceChildId: "def-shared", nodeId: "s:1" }),
+      makeQuestion({ sourceChildId: "def-shared", nodeId: "s:2" }),
+      makeQuestion({ sourceChildId: "def-shared", nodeId: "s:3" }),
+    ]);
+    expect(result.totalCount).toBe(1);
+    expect(result.unwritableCount).toBe(1);
+    expect(mock.getNodeByIdAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes unwritable source names so the picker copy doesn't repeat", async () => {
+    mock = createFigmaGlobal({
+      nodes: {
+        "def-1": makeDef({ id: "def-1", name: "SharedRemote", remote: true }),
+        "def-2": makeDef({ id: "def-2", name: "SharedRemote", remote: true }),
+      },
+    });
+    installFigmaGlobal(mock);
+    const result = await probeDefinitionWritability([
+      makeQuestion({ sourceChildId: "def-1" }),
+      makeQuestion({ sourceChildId: "def-2" }),
+    ]);
+    expect(result.unwritableSourceNames).toEqual(["SharedRemote"]);
+  });
+
+  it("ignores questions without sourceChildId in the count", async () => {
+    mock = createFigmaGlobal({
+      nodes: { "def-1": makeDef({ id: "def-1", remote: true }) },
+    });
+    installFigmaGlobal(mock);
+    const result = await probeDefinitionWritability([
+      makeQuestion({ sourceChildId: undefined, nodeId: "s:1" }),
+      makeQuestion({ sourceChildId: "def-1", nodeId: "s:2" }),
+      makeQuestion({ sourceChildId: undefined, nodeId: "s:3" }),
+    ]);
+    expect(result.totalCount).toBe(1);
+    expect(result.allUnwritable).toBe(true);
+  });
+
+  it("preserves first-seen order in unwritableSourceNames", async () => {
+    mock = createFigmaGlobal({
+      nodes: {
+        "def-a": makeDef({ id: "def-a", name: "Beta", remote: true }),
+        "def-b": makeDef({ id: "def-b", name: "Alpha", remote: true }),
+      },
+    });
+    installFigmaGlobal(mock);
+    const result = await probeDefinitionWritability([
+      makeQuestion({ sourceChildId: "def-a" }),
+      makeQuestion({ sourceChildId: "def-b" }),
+    ]);
+    expect(result.unwritableSourceNames).toEqual(["Beta", "Alpha"]);
+  });
+});

--- a/src/core/roundtrip/probe-definition-writability.ts
+++ b/src/core/roundtrip/probe-definition-writability.ts
@@ -1,0 +1,86 @@
+import type { FigmaGlobal, RoundtripQuestion } from "./types.js";
+
+declare const figma: FigmaGlobal;
+
+// #357: Pre-flight probe surfaced in Step 4 BEFORE the Definition write
+// picker. When all candidate source components live in an external library
+// (`mainComponent.remote === true`, Experiment 10) or are unresolved
+// (`mainComponent === null`, Experiment 11 — the unshared library reference
+// case unit-test-locked in ADR-011 Verification), opting into definition
+// writes is structurally a no-op — every write would throw
+// "Cannot write to internal and read-only node" and the helper would
+// fall through to scene annotation regardless. Surfacing this UP-FRONT
+// turns the picker into "annotation is the only viable choice on this
+// file" instead of "you opted in, why did I get annotations?" wasted-
+// decision moment.
+//
+// The probe deliberately mirrors the same writability detection as the
+// runtime fallback in `apply-with-instance-fallback.ts` so the picker
+// branch and the actual apply behaviour cannot diverge — if the runtime
+// would annotate, the probe would predict it.
+
+export interface DefinitionWritabilityProbe {
+  // Distinct candidate source child ids inspected (deduped — many questions
+  // may target the same source child, e.g. when #356 collapsed N replicas).
+  totalCount: number;
+  // Subset that resolved to a remote (read-only) source component
+  // (`remote === true`) OR resolved to null (Experiment 11 unshared library
+  // reference). Both branches end at the annotation fallback at runtime.
+  unwritableCount: number;
+  // Display names (or sourceChildId fallback) of the unwritable source
+  // components, deduped, in first-seen order — for the picker copy.
+  unwritableSourceNames: string[];
+  // True when EVERY candidate is unwritable. Picker should drop the opt-in
+  // branch and offer only "annotate / cancel".
+  allUnwritable: boolean;
+  // True when SOME but not all candidates are unwritable. Picker can show
+  // the split count notice.
+  partiallyUnwritable: boolean;
+}
+
+type ProbeInput = Pick<
+  RoundtripQuestion,
+  "sourceChildId" | "instanceContext" | "ruleId"
+>;
+
+export async function probeDefinitionWritability(
+  questions: readonly ProbeInput[],
+): Promise<DefinitionWritabilityProbe> {
+  // Map<sourceChildId, "writable" | "unwritable">. Using a Map (not Set) so
+  // we visit each source child id at most once even if N replicas share it.
+  const verdict = new Map<string, "writable" | "unwritable">();
+  const unwritableNames: string[] = [];
+  const seenName = new Set<string>();
+
+  for (const q of questions) {
+    const id = q.sourceChildId;
+    if (!id) continue;
+    if (verdict.has(id)) continue;
+    const node = await figma.getNodeByIdAsync(id);
+    const isUnwritable = node === null || node.remote === true;
+    verdict.set(id, isUnwritable ? "unwritable" : "writable");
+    if (isUnwritable) {
+      const name =
+        (typeof node?.name === "string" && node.name) ||
+        q.instanceContext?.sourceComponentName ||
+        id;
+      if (!seenName.has(name)) {
+        seenName.add(name);
+        unwritableNames.push(name);
+      }
+    }
+  }
+
+  const totalCount = verdict.size;
+  let unwritableCount = 0;
+  for (const v of verdict.values()) if (v === "unwritable") unwritableCount++;
+
+  return {
+    totalCount,
+    unwritableCount,
+    unwritableSourceNames: unwritableNames,
+    allUnwritable: totalCount > 0 && unwritableCount === totalCount,
+    partiallyUnwritable:
+      unwritableCount > 0 && unwritableCount < totalCount,
+  };
+}


### PR DESCRIPTION
Closes #357.

## Summary
- Adds `CanICodeRoundtrip.probeDefinitionWritability(questions)` — a read-only async pre-flight that mirrors the runtime fallback's writability detection (`remote === true` from Experiment 10, unresolved `null` from Experiment 11) so the SKILL.md Step 4 picker can prune the opt-in branch when every candidate source is in an external library or unresolved.
- Returns `{ totalCount, unwritableCount, unwritableSourceNames, allUnwritable, partiallyUnwritable }`. Dedupes by `sourceChildId` (one `getNodeByIdAsync` per source even when N replicas share it) and dedupes display names so picker copy doesn't repeat.
- SKILL.md Step 4 gains a "Pre-flight writability probe (#357)" sub-section with three branched prose blocks (all-unwritable / partially-unwritable / all-writable) so the agent's picker prediction and the helper's actual apply behaviour cannot diverge.

## Why
On real fixtures like Simple Design System (Community), every gotcha source is a library component. Today the user opts into Definition writes, sees only annotations, and asks "why did I get annotations?". The probe lets the picker drop the opt-in branch entirely in that case, so the user never makes a wasted decision.

## Files
- `src/core/roundtrip/probe-definition-writability.ts` (+ `.test.ts`, 9 cases)
- `src/core/roundtrip/index.ts` — re-export
- `.claude/skills/canicode-roundtrip/helpers.js` — regenerated bundle
- `.claude/skills/canicode-roundtrip/SKILL.md` — new sub-section + helper-reference + Edge-Case pointer

## Test plan
- [x] `pnpm test:run` — 869 passed
- [x] `pnpm lint` — clean
- [x] Bundle exposes `CanICodeRoundtrip.probeDefinitionWritability`
- [ ] Live smoke on Simple Design System (Community) — deferred to manual run, no live Figma in PR


Made with [Cursor](https://cursor.com)