### PR TITLE
chore(release): v0.10.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Rule scores aren't guesswork. The calibration pipeline converts real Figma desig
    - ✅ **scene write succeeded** — the property was written directly to the scene node or instance override.
    - 📝 **annotated the scene node** — the skill left a structured annotation instead of writing the property. This is the [ADR-012](.claude/docs/ADR.md) default for instance-child layout writes, because propagating a property to the component definition (and therefore every instance of it) is almost never what the user wants. **A summary full of 📝 markers is correct behavior, not failure.**
    - 🌐 **definition write propagated** — the property was written to the component definition and every instance inherited it. Only happens when the user opted in up front with `allowDefinitionWrite`.
-4. **Re-analyze** — verify the grade improved. Repeat step 2 if new gotchas surface.
+4. **Re-analyze** — verify the gotchas were addressed (grade movement is a side-effect). Repeat step 2 if new gotchas surface.
 5. **Hand off** to `figma-implement-design` — canicode's scope ends here ([ADR-013](.claude/docs/ADR.md)). Figma's official code-generation skill takes the now-clean design and produces code.
 
 ---

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "canicode",
   "version": "0.10.3",
   "mcpName": "io.github.let-sunny/canicode",
-  "description": "Score your Figma designs with AI-calibrated rules. CLI + MCP server.",
+  "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Score your Figma designs with AI-calibrated rules. CLI + MCP server.",
   "type": "module",


### PR DESCRIPTION
## Summary

Patch release bundling four follow-ups from the v0.10.2 onboarding regression test (#332 / #342 walkthrough on 2026-04-19) plus copy alignment with the post-roundtrip identity.

| Issue | PR | Change |
|---|---|---|
| #354 | #358 | Gate `missing-interaction-state` on positive evidence — when both `componentPropertyDefinitions` and `componentDefinitions` are empty for an INSTANCE, treat the verdict as unknown and skip rather than asserting a missing variant (false-positive class on nested external-library instances). |
| #352, #353, #355 | #359 | Annotation labelMarkdown drops the `**[canicode] <ruleId>**` prefix in favour of an italic `— *<ruleId>*` footer; `canicode:auto-fix` category renamed to `canicode:flag` (legacy id exposed read-only so Step 5 cleanup still sweeps old files); Step 5 / Stop / post-handoff wrap-up messages lead with the issues-delta block, grade as a footnote. |
| #356 | #360 | Survey dedupe: collapse N instance-child questions sharing `(sourceComponentId, sourceNodeId, ruleId)` into one with `replicas` / `replicaNodeIds`; apply step iterates the merged set. Question text rebuilds `{nodeName}` with the source component name. |
| #357 | #361 | Pre-flight `probeDefinitionWritability` runs in a small `use_figma` batch BEFORE the Definition write picker. Mirrors the runtime fallback (Experiment 10 `remote === true`, Experiment 11 `null`). When every candidate is unwritable, drop the opt-in branch entirely. |
| n/a | this | `package.json` description and README Step 4 wording aligned with the roundtrip identity (drops score-centric framing). GitHub repo description updated separately. |

#336 closed without action — its pickup conditions (ADR-012 default re-evaluation, annotate-by-default complaints) are structurally invalidated by #357's picker, which asks the user every batch instead of relying on a silent default.

#333 deferred — manual live-Figma smoke checklist, not autonomous.

## Test plan

- [x] All four feature PRs merged on main (`pnpm test:run` 884/884 + `pnpm lint` clean post-merge)
- [ ] Tag v0.10.3 → CI auto-publish to npm
- [ ] Fresh-dir regression (#342 follow-up): re-walk `/canicode-roundtrip` on Simple Design System (Community) under v0.10.3 — annotations should land with `canicode:flag` category + footer-only ruleId; survey should collapse the 7 FILL replicas into 1 question; picker should drop the opt-in option since every source is remote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)