### PR TITLE
fix(survey): missing-size-constraint targetProperty returns both bounds (#374)

### DIFF
--- a/src/core/engine/scoring.test.ts
+++ b/src/core/engine/scoring.test.ts
@@ -556,7 +556,8 @@ describe("buildResultJson", () => {
     expect(issues[2]).toMatchObject({
       ruleId: "missing-size-constraint",
       applyStrategy: "property-mod",
-      targetProperty: "minWidth",
+      // #374: every missing-size-constraint subType targets both bounds.
+      targetProperty: ["minWidth", "maxWidth"],
       isInstanceChild: false,
     });
   });

--- a/src/core/gotcha/apply-context.test.ts
+++ b/src/core/gotcha/apply-context.test.ts
@@ -88,20 +88,23 @@ describe("computeApplyContext", () => {
       ).toEqual(["layoutSizingHorizontal", "layoutSizingVertical"]);
     });
 
-    it("missing-size-constraint wrap → minWidth", () => {
+    // #374: every missing-size-constraint subType returns BOTH bounds so the
+    // `{ minWidth, maxWidth }` answer shape lands fully (apply iterates each
+    // property in the array; missing keys in a partial answer are skipped).
+    it("missing-size-constraint wrap → minWidth + maxWidth (#374)", () => {
       expect(
         computeApplyContext(
           makeViolation("missing-size-constraint", { subType: "wrap" }),
         ).targetProperty,
-      ).toBe("minWidth");
+      ).toEqual(["minWidth", "maxWidth"]);
     });
 
-    it("missing-size-constraint max-width → maxWidth", () => {
+    it("missing-size-constraint max-width → minWidth + maxWidth (#374)", () => {
       expect(
         computeApplyContext(
           makeViolation("missing-size-constraint", { subType: "max-width" }),
         ).targetProperty,
-      ).toBe("maxWidth");
+      ).toEqual(["minWidth", "maxWidth"]);
     });
 
     it("missing-size-constraint grid → minWidth + maxWidth", () => {

--- a/src/core/gotcha/apply-context.ts
+++ b/src/core/gotcha/apply-context.ts
@@ -87,9 +87,15 @@ function resolveTargetProperty(
       // both-axes — write both axes
       return ["layoutSizingHorizontal", "layoutSizingVertical"];
     case "missing-size-constraint":
-      if (subType === "wrap") return "minWidth";
-      if (subType === "max-width") return "maxWidth";
-      // grid — both bounds
+      // #374: always return BOTH bounds so `applyPropertyMod`'s array branch
+      // iterates the full `{ minWidth, maxWidth }` answer shape. Pre-fix the
+      // `wrap` subType returned `"minWidth"` and `max-width` returned
+      // `"maxWidth"` as single strings — the user typically answered with
+      // both keys (the gotcha hint asks for both) and the apply step
+      // silently dropped half the intent because it only iterated the one
+      // property in `targetProperty`. Partial answers still work: the per-
+      // property lookup in `applyPropertyMod` returns `undefined` for the
+      // missing key and the helper skips it.
       return ["minWidth", "maxWidth"];
     case "irregular-spacing":
       if (subType === "gap") return "itemSpacing";

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -523,7 +523,12 @@ describe("generateGotchaSurvey", () => {
       );
 
       expect(survey.questions[0]!.applyStrategy).toBe("property-mod");
-      expect(survey.questions[0]!.targetProperty).toBe("minWidth");
+      // #374: missing-size-constraint always returns both bounds so the
+      // `{ minWidth, maxWidth }` answer shape lands fully.
+      expect(survey.questions[0]!.targetProperty).toEqual([
+        "minWidth",
+        "maxWidth",
+      ]);
     });
 
     it("structural-mod rule carries strategy without targetProperty for deep-nesting", () => {


### PR DESCRIPTION
## Summary

For `missing-size-constraint`, `resolveTargetProperty` returned a single string (e.g. `"minWidth"`) determined from the violation's `subType`. But the gotcha question for this rule presents **both** bounds to the user at once and the answer comes back shaped like `{ minWidth: …, maxWidth: … }`.

`applyPropertyMod` has two branches:

- string `targetProperty` → write `node[targetProperty] = answer` (for primitive answers)
- string\[\] `targetProperty` → iterate the array and write each `answer[key]` (for object answers)

With `targetProperty: "minWidth"`, the array branch never fires, so `applyPropertyMod` wrote the entire `{ minWidth, maxWidth }` object onto `node.minWidth` and the maxWidth half of the user's answer was silently dropped on the floor. The user's intent was halved without warning.

## Fix

`resolveTargetProperty` now always returns `["minWidth", "maxWidth"]` for `missing-size-constraint`, regardless of `subType`. The string-branch is no longer reachable for this rule and `applyPropertyMod` correctly fans the answer object across both bounds.

## Changes

- `src/core/gotcha/apply-context.ts`: collapse the per-`subType` switch into a single `["minWidth", "maxWidth"]` return.
- `src/core/gotcha/apply-context.test.ts`: update expectations across `wrap` / `max-width` / `grid` sub-types.
- `src/core/gotcha/survey-generator.test.ts`: update the question-shape assertion.
- `src/core/engine/scoring.test.ts`: update the issue-enrichment assertion.

## Test plan

- [ ] \`pnpm test:run\` (apply-context + survey-generator + scoring suites green)
- [ ] In a real session: answer a \`missing-size-constraint\` question with both \`minWidth\` and \`maxWidth\` — both values must land on the Figma node.

Closes #374

Made with [Cursor](https://cursor.com)