### PR TITLE
fix(survey): skip sibling dedupe for instance children so source-dedupe can fan out (#373)

### DIFF
--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -1038,6 +1038,183 @@ describe("generateGotchaSurvey", () => {
       expect(q.nodeName).toBe("Title");
     });
 
+    // #373 regression: pre-fix the parent-path sibling dedupe ran BEFORE
+    // source-component dedupe and dropped instance-child siblings (e.g.
+    // `Title` + `Subtitle` on the same `Card` instance — different
+    // sourceNodeIds but the same parent path) without preserving them on
+    // `replicaNodeIds`. The dropped scenes received neither a write nor an
+    // annotation. The fix routes instance-child issues straight to the
+    // source-component dedupe; siblings with different sourceNodeIds now
+    // remain separate questions and siblings sharing the same sourceNodeId
+    // (the cross-instance dedupe target) collapse with replicaNodeIds.
+    it("does NOT collapse instance-child siblings with different sourceNodeIds (#373)", () => {
+      const document: AnalysisNode = {
+        id: "0:1",
+        name: "Document",
+        type: "DOCUMENT",
+        visible: true,
+        children: [
+          {
+            id: "100:1",
+            name: "Card",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+        ],
+      };
+      const components = {
+        "C:1": { key: "k1", name: "Card", description: "" },
+      };
+      const issues = [
+        // Two siblings on the SAME parent instance (same parent path "Root >
+        // Card") but different definition node ids → must stay separate per
+        // #373.
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:13799",
+          nodePath: "Root > Card > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:99999",
+          nodePath: "Root > Card > Subtitle",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, { document, components }),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions).toHaveLength(2);
+      expect(survey.questions[0]!.replicas).toBeUndefined();
+      expect(survey.questions[1]!.replicas).toBeUndefined();
+    });
+
+    it("collapses instance-child issues across instances even when on different scene parents (#373)", () => {
+      // Pre-fix the sibling dedupe could have dropped same-source siblings
+      // before source-dedupe saw them. Now source-dedupe owns it: same
+      // sourceComponentId + sourceNodeId + ruleId → one question with the
+      // others on `replicaNodeIds`.
+      const document: AnalysisNode = {
+        id: "0:1",
+        name: "Document",
+        type: "DOCUMENT",
+        visible: true,
+        children: [
+          {
+            id: "100:1",
+            name: "Card A",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+          {
+            id: "100:2",
+            name: "Card B",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+          {
+            id: "100:3",
+            name: "Card C",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+        ],
+      };
+      const components = {
+        "C:1": { key: "k1", name: "Platform=Desktop", description: "" },
+      };
+      // Three instances of the same source component each render two source
+      // children that fail the same rule (Title at 2143:13799 and Subtitle
+      // at 2143:99999). Pre-#373 sibling dedupe dropped one of each pair;
+      // now source-dedupe collapses the three Title issues and the three
+      // Subtitle issues into two questions each carrying replicaNodeIds.
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:13799",
+          nodePath: "Root > Card A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:99999",
+          nodePath: "Root > Card A > Subtitle",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:2;2143:13799",
+          nodePath: "Root > Card B > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:2;2143:99999",
+          nodePath: "Root > Card B > Subtitle",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:3;2143:13799",
+          nodePath: "Root > Card C > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:3;2143:99999",
+          nodePath: "Root > Card C > Subtitle",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, { document, components }),
+        makeScoreReport("D"),
+      );
+
+      expect(survey.questions).toHaveLength(2);
+      const titleQ = survey.questions.find(
+        (q) => q.nodeId === "I100:1;2143:13799",
+      )!;
+      const subtitleQ = survey.questions.find(
+        (q) => q.nodeId === "I100:1;2143:99999",
+      )!;
+      expect(titleQ.replicas).toBe(3);
+      expect(titleQ.replicaNodeIds).toEqual([
+        "I100:2;2143:13799",
+        "I100:3;2143:13799",
+      ]);
+      expect(subtitleQ.replicas).toBe(3);
+      expect(subtitleQ.replicaNodeIds).toEqual([
+        "I100:2;2143:99999",
+        "I100:3;2143:99999",
+      ]);
+    });
+
     it("output with replicas + replicaNodeIds passes GotchaSurveySchema validation", () => {
       const issues = [
         makeIssue({

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -9,7 +9,10 @@ import type {
 import type { AnalysisFile, AnalysisNode } from "../contracts/figma-node.js";
 import type { RuleId } from "../contracts/rule.js";
 import { GOTCHA_QUESTIONS } from "../rules/gotcha-questions.js";
-import { parseInstanceChildNodeId } from "../adapters/instance-id-parser.js";
+import {
+  isInstanceChildNodeId,
+  parseInstanceChildNodeId,
+} from "../adapters/instance-id-parser.js";
 import { computeApplyContext } from "./apply-context.js";
 
 const NODE_PATH_SEPARATOR = " > ";
@@ -64,12 +67,26 @@ export function generateGotchaSurvey(
 /**
  * Deduplicate issues where the same ruleId fires on multiple children of the
  * same parent. Keeps the first occurrence (preserving traversal order).
+ *
+ * #373: skip instance-child issues here. They are routed to the
+ * source-component dedupe in Step 5, which preserves dropped scene ids on
+ * `replicaNodeIds` so the apply step can fan the answer out to every replica.
+ * The pre-#373 behaviour collapsed sibling instance children (e.g. `Title` +
+ * `Subtitle` on the same `Card` instance — different definition nodes, same
+ * `Card` parent path, same ruleId) into a single question and lost the
+ * dropped scenes entirely (no `replicaNodeIds`, no annotation, no write).
+ * Source-component dedupe naturally keeps different `sourceNodeId`s separate,
+ * so the previously-dropped siblings now surface as their own questions.
  */
 function deduplicateSiblingIssues(issues: AnalysisIssue[]): AnalysisIssue[] {
   const seen = new Set<string>();
   const result: AnalysisIssue[] = [];
 
   for (const issue of issues) {
+    if (isInstanceChildNodeId(issue.violation.nodeId)) {
+      result.push(issue);
+      continue;
+    }
     const parentPath = getParentPath(issue.violation.nodePath);
     const key = `${parentPath}||${issue.violation.ruleId}`;
 


### PR DESCRIPTION
## Summary

#356 introduced two deduplication passes inside `generateGotchaSurvey`:

1. `deduplicateSiblingIssues` — collapses sibling issues that share the same parent path + ruleId.
2. `deduplicateBySourceComponent` — collapses cross-instance issues that share the same `sourceComponentId` + `sourceNodeId` + `ruleId`, attaching the sibling scene IDs to `replicaNodeIds` so that the apply step can fan the user's single answer out to every replica.

Pass 1 ran first and didn't know about instance children. When two instance-child siblings shared a parent path (e.g. the same `Card` instance had a `Title` and a `Subtitle` violation), pass 1 dropped one of them before pass 2 ever saw it — which both lost the dropped scene's annotation/write target AND prevented `replicaNodeIds` from ever being populated for that source-component pair (because pass 2 only had one replica to work with).

Symptom from the bug report: 17 violations collapsed down to 10 questions, but every resulting question had `replicaNodeIds: []`. Step 4 then wrote to the single picked instance and the other instances were never touched.

## Fix

`deduplicateSiblingIssues` now early-returns each instance-child issue (detected via `isInstanceChildNodeId`) into the result list without comparing it against siblings. Definition-node and free scene-node issues still go through the original sibling collapse — that path is unaffected.

Pass 2 (`deduplicateBySourceComponent`) is now the single owner of cross-instance dedupe and correctly attaches `replicaNodeIds`.

## Changes

- `src/core/gotcha/survey-generator.ts`: skip instance-child issues in the sibling dedupe loop.
- `src/core/gotcha/survey-generator.test.ts`: two new regression tests —
  - instance-child siblings with **different** sourceNodeIds stay as separate questions
  - instance-child issues across **multiple instances** sharing the same sourceNodeId + ruleId collapse into one question with the other scene IDs on \`replicaNodeIds\`

## Test plan

- [ ] \`pnpm test:run\` (survey-generator suite green, especially the two new \`(#373)\` tests)
- [ ] In a real session: a page with N instances of the same component each having the same violation should produce ONE survey question whose answer fans out to all N instances.

Closes #373

Made with [Cursor](https://cursor.com)