### PR TITLE
fix(rule): suppress inconsistent-naming-convention when suggested rename is a no-op (#372)

### DIFF
--- a/src/core/rules/naming/inconsistent-naming-convention.test.ts
+++ b/src/core/rules/naming/inconsistent-naming-convention.test.ts
@@ -113,6 +113,26 @@ describe("inconsistent-naming-convention", () => {
     expect(result!.suggestedName).toBe("my-url-parser");
   });
 
+  // #372 regression: single-character names like "X" detect as
+  // SCREAMING_SNAKE_CASE but the case-conversion to PascalCase produces "X"
+  // — the same string. Pre-fix the rule fired and the apply step wrote
+  // `target.name = "X"` over `X`, then reported it as a "✅ resolved
+  // (auto-fix renames)" entry in the wrap-up despite changing nothing.
+  // Suppress no-op renames at the rule level so the misleading wrap-up
+  // line never gets emitted.
+  it("does not flag when the suggested rename equals the current name (#372)", () => {
+    // Three siblings — two PascalCase establish the dominant convention.
+    // "X" detects as SCREAMING_SNAKE_CASE but converts to "X" under PascalCase.
+    const sibA = makeNode({ id: "2:1", name: "ProductCard" });
+    const sibB = makeNode({ id: "2:2", name: "ReviewCard" });
+    const node = makeNode({ id: "1:1", name: "X" });
+    const siblings = [node, sibA, sibB];
+
+    expect(
+      inconsistentNamingConvention.check(node, makeContext({ siblings })),
+    ).toBeNull();
+  });
+
   it("still flags multi-word PascalCase in Title Case context", () => {
     const sibA = makeNode({ id: "2:1", name: "Card Grid" }); // Title Case
     const sibB = makeNode({ id: "2:2", name: "Review Card" }); // Title Case

--- a/src/core/rules/naming/index.ts
+++ b/src/core/rules/naming/index.ts
@@ -177,6 +177,12 @@ const inconsistentNamingConventionCheck: RuleCheckFn = (node, context) => {
     if (isCompatible(nodeConvention, dominantConvention, node.name)) return null;
 
     const suggested = convertName(node.name, dominantConvention);
+    // #372: suppress when the case-conversion produces the same string as
+    // the current name. Single-character names ("X"), all-numeric names, and
+    // any input whose every word maps to itself across cases all fall into
+    // this bucket — flagging them produces a no-op rename, an empty diff
+    // visible as a misleading "✅ resolved" wrap-up entry.
+    if (suggested === node.name) return null;
     return {
       ruleId: inconsistentNamingConventionDef.id,
       nodeId: node.id,


### PR DESCRIPTION
## Summary

`inconsistent-naming-convention` flagged any node whose name didn't match the dominant convention and proposed `convertName(node.name, dominantConvention)` as the fix. For names that are already canonical under the target convention — e.g. a single-letter `X` "converted" to PascalCase yields `X` — the rule still fired, the user "fixed" it by accepting the suggestion, and the resulting Figma write was a no-op rename.

That created a fake green check: the issue was reported as resolved, but nothing changed on the design and the next analysis pass produced the exact same violation. Multi-round roundtrip flows would loop forever on these.

## Fix

After computing `suggested = convertName(node.name, dominantConvention)`, return `null` immediately if `suggested === node.name`. The rule no longer surfaces no-op renames at all — there's nothing to fix and nothing to falsely resolve.

## Changes

- `src/core/rules/naming/index.ts`: short-circuit `inconsistentNamingConventionCheck` when the suggested rename equals the current name.
- `src/core/rules/naming/inconsistent-naming-convention.test.ts`: new test asserting `null` for a single-character name that round-trips through PascalCase conversion unchanged.

## Test plan

- [ ] \`pnpm test:run\` (naming suite green, especially the new no-op test)
- [ ] In a real design with single-letter or already-canonical names: those nodes must NOT show up in the issue list.

Closes #372

Made with [Cursor](https://cursor.com)