### PR TITLE
fix(mcp): default analyze tool to silent — opt in to opening the HTML report (#365)

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -45,6 +45,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     preset: z.enum(["relaxed", "dev-friendly", "ai-ready", "strict"]).optional().describe("Analysis preset"),
     targetNodeId: z.string().optional().describe("Scope analysis to a specific node ID"),
     configPath: z.string().optional().describe("Path to config JSON file for rule overrides"),
+    openReport: z.boolean().optional().describe("Open the generated HTML report in the user's browser. Defaults to false — opt in only when a visible report is the explicit user request (#365). The HTML file is always written to disk regardless."),
   },
   {
     readOnlyHint: false,
@@ -52,7 +53,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     openWorldHint: true,
     title: "Analyze Figma Design",
   },
-  async ({ input, token, preset, targetNodeId, configPath }) => {
+  async ({ input, token, preset, targetNodeId, configPath, openReport }) => {
     trackEvent(EVENTS.MCP_TOOL_CALLED, { tool: "analyze" });
     try {
       // Fetch via REST API or load from fixture
@@ -92,9 +93,15 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
         });
       });
 
-      // Open report in browser
-      const openCmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-      exec(`${openCmd} "${reportPath}"`);
+      // #365: only open the report in the user's browser when explicitly
+      // requested. The MCP `analyze` tool is machine-callable from skill
+      // workflows (e.g. `/canicode-roundtrip` Step 1 + Step 5), where
+      // popping a browser tab mid-conversation breaks flow. The HTML file
+      // is still written to disk so follow-up sessions can open it manually.
+      if (openReport === true) {
+        const openCmd = process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+        exec(`${openCmd} "${reportPath}"`);
+      }
 
       trackEvent(EVENTS.ANALYSIS_COMPLETED, {
         nodeCount: result.nodeCount,


### PR DESCRIPTION
## Summary

The MCP `analyze` tool unconditionally shelled out to `open` / `xdg-open` / `start` after every successful run. That's fine when a human directly asks "show me the report", but `analyze` is also called programmatically by the `/canicode-roundtrip` skill (Steps 1 and 5). In that flow, the popped browser tab interrupts the conversation right when Step 2 is starting and the user has to dismiss it manually before they can keep going.

## Fix

Add an `openReport: boolean` parameter to the `analyze` tool's input schema, default `false`. The HTML file is still always written to disk regardless — only the auto-open is gated on the flag. Skill workflows pass nothing (silent), human callers can ask "open the report" and the model will pass `openReport: true`.

## Changes

- `src/mcp/server.ts`: add `openReport` to the zod schema with a clear opt-in description; gate the `exec("open …")` call on `openReport === true`.

## Test plan

- [ ] \`pnpm test:run\` (no test should regress; behaviour is observable in a live MCP session)
- [ ] Live MCP call without \`openReport\` → no browser tab opens, JSON response still carries \`reportPath\`.
- [ ] Live MCP call with \`openReport: true\` → browser tab opens to the report.

Closes #365

Made with [Cursor](https://cursor.com)