### PR TITLE
docs(install): long-form npx flags + drop -e FIGMA_TOKEN + pick-one matrix (#364, #366, #367)

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@
 - Annotations: NOT available (REST API annotations field is private beta)
 
 **2. MCP Server (`canicode-mcp`)**
-- Install: `claude mcp add canicode -- npx -y -p canicode canicode-mcp`
+- Install: `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp` (long-form flags; short-form `-y -p` collides with `claude mcp add`'s parser, #366)
 - Tools: `analyze`, `gotcha-survey`, `list-rules`, `visual-compare`, `version`, `docs`
 - Data source: Figma REST API via `input` param (Figma URL or fixture path). Requires FIGMA_TOKEN for live URLs.
 

--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -9,7 +9,7 @@ Run a gotcha survey on a Figma design to identify implementation pitfalls, colle
 
 ## Prerequisites
 
-- **canicode MCP server** (preferred): `claude mcp add canicode -e FIGMA_TOKEN=figd_xxx -- npx -y -p canicode canicode-mcp`
+- **canicode MCP server** (preferred): `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp` — long-form flags only; the short-form `-y -p` collides with `claude mcp add`'s parser (#366). The MCP server reads `FIGMA_TOKEN` from `~/.canicode/config.json` or the host environment, so do **not** pass `-e FIGMA_TOKEN=…` here (#364).
 - **Without canicode MCP** (fallback): the `canicode gotcha-survey --json` CLI produces the same response shape — no MCP installation required.
 - **FIGMA_TOKEN** configured for live Figma URLs
 

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -11,7 +11,7 @@ Orchestrate the full design-to-code roundtrip: analyze a Figma design for readin
 ## Prerequisites
 
 - **Figma MCP server** installed (provides `get_design_context`, `get_screenshot`, `use_figma`, and other Figma tools) — REQUIRED, there is no CLI fallback for `use_figma`
-- **canicode MCP server** (preferred): `claude mcp add canicode -e FIGMA_TOKEN=figd_xxx -- npx -y -p canicode canicode-mcp`
+- **canicode MCP server** (preferred): `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp` — long-form flags only; the short-form `-y -p` collides with `claude mcp add`'s parser (#366). The MCP server reads `FIGMA_TOKEN` from `~/.canicode/config.json` or the host environment, so do **not** pass `-e FIGMA_TOKEN=…` here (#364).
 - **Without canicode MCP** (fallback): Steps 1 (analyze) and 3 (gotcha-survey) shell out to `npx canicode <command> --json` — same JSON shape as the MCP tools. Step 4 (apply to Figma) still requires Figma MCP `use_figma`.
 - **FIGMA_TOKEN** configured for live Figma URLs
 - **Figma Full seat + file edit permission** (required for `use_figma` to modify the design)

--- a/.mcpb
+++ b/.mcpb
@@ -15,7 +15,7 @@
       "package": "canicode",
       "command": "npx -y -p canicode canicode-mcp"
     },
-    "claude_code": "claude mcp add canicode -- npx -y -p canicode canicode-mcp",
+    "claude_code": "claude mcp add canicode -- npx --yes --package=canicode canicode-mcp",
     "cursor": {
       "mcpServers": {
         "canicode": {

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ npx canicode init --token figd_xxxxxxxxxxxxx
 npx canicode analyze "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234"
 
 # MCP Server — works with Claude Code, Cursor, Claude Desktop
-claude mcp add canicode -- npx -y -p canicode canicode-mcp
+claude mcp add canicode -- npx --yes --package=canicode canicode-mcp
 ```
 
 <details>
@@ -107,18 +107,64 @@ Each issue is classified: **Blocking** > **Risk** > **Missing Info** > **Suggest
 
 ---
 
-## Installation
+## Installation — pick one
+
+Each row below is a **complete** install. Don't run more than one — they cover overlapping use cases. (#367)
+
+| If you use… | Install |
+|-------------|---------|
+| **Claude Code** (recommended for the roundtrip workflow) | `npx canicode init --token figd_xxxxxxxxxxxxx` — saves the token AND drops `/canicode`, `/canicode-gotchas`, `/canicode-roundtrip` skills into `./.claude/skills/`. The skills already know how to call canicode via `npx canicode …`, no MCP install needed. |
+| **Cursor / Claude Desktop / other MCP host** | `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp` — registers the MCP server. |
+| **Just the CLI** (CI, scripts) | Nothing. `npx canicode analyze "<figma-url>"` works directly. Run `canicode init --token …` once if you want the token persisted to `~/.canicode/config.json`. |
+
+> **Get your token:** Figma → Settings → Security → Personal access tokens → Generate new token
+
+> **Roundtrip prerequisite:** the `/canicode-roundtrip` skill calls the Figma MCP server to read and write the design. Install it once with `claude mcp add -s project -t http figma https://mcp.figma.com/mcp` and restart Claude Code so the new MCP tools load.
 
 <details>
-<summary><strong>CLI</strong></summary>
+<summary><strong>Claude Code Skills</strong> — install details</summary>
+
+```bash
+npx canicode init --token figd_xxxxxxxxxxxxx
+```
+
+Drops three skills into `./.claude/skills/`:
+
+- **canicode** — lightweight CLI wrapper (use `/canicode <figma-url>`)
+- **canicode-gotchas** — standalone gotcha survey (use `/canicode-gotchas <figma-url>`)
+- **canicode-roundtrip** — full analyze → gotcha → apply roundtrip (use `/canicode-roundtrip <figma-url>`)
+
+The skills shell out to `npx canicode …` for analyze / gotcha-survey when the canicode MCP server is not installed — both paths produce the same JSON shape. The Figma MCP server is still required for the apply step (Step 4 in `/canicode-roundtrip`); see the prereq note above.
+
+Flags: `--global` installs into `~/.claude/skills/` instead. `--no-skills` skips skill install (token only). `--force` overwrites existing skill files without prompting. Run `canicode docs setup` for the full setup guide.
+
+</details>
+
+<details>
+<summary><strong>MCP Server</strong> — install details</summary>
+
+```bash
+claude mcp add canicode -- npx --yes --package=canicode canicode-mcp
+```
+
+Then ask: *"Analyze this Figma design: https://www.figma.com/design/..."*
+
+canicode's rule engine analyzes the design data — the AI assistant just orchestrates the calls. The MCP server reads `FIGMA_TOKEN` from `~/.canicode/config.json` (set via `canicode init --token …`) or from the host's environment, so passing `-e FIGMA_TOKEN=…` to `claude mcp add` is **not** required and the current parser rejects it anyway (#364).
+
+If you genuinely need a per-server token without using `canicode init`, export it on the calling shell instead: `export FIGMA_TOKEN=figd_xxxxxxxxxxxxx`.
+
+For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md).
+
+</details>
+
+<details>
+<summary><strong>CLI</strong> — install details</summary>
 
 ```bash
 npx canicode analyze "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234"
 ```
 
-Setup: `npx canicode init --token figd_xxxxxxxxxxxxx` — saves the token AND installs the Claude Code skills (see below).
-
-> **Get your token:** Figma → Settings → Security → Personal access tokens → Generate new token
+Setup: `npx canicode init --token figd_xxxxxxxxxxxxx` saves the token (and installs the Claude Code skills as a bonus — pass `--no-skills` to skip).
 
 **Figma API Rate Limits** — Rate limits depend on **where the file lives**, not just your plan.
 
@@ -128,47 +174,6 @@ Setup: `npx canicode init --token figd_xxxxxxxxxxxxx` — saves the token AND in
 | Dev, Full | 6 req/month | 10–20 req/min |
 
 Hitting 429 errors? Make sure the file is in a paid workspace. Or save a fixture once and analyze locally. [Full details](https://developers.figma.com/docs/rest-api/rate-limits/)
-
-</details>
-
-<details>
-<summary><strong>MCP Server</strong> (Claude Code / Cursor / Claude Desktop)</summary>
-
-```bash
-claude mcp add canicode -- npx -y -p canicode canicode-mcp
-claude mcp add -s project -t http figma https://mcp.figma.com/mcp
-```
-
-Then ask: *"Analyze this Figma design: https://www.figma.com/design/..."*
-
-canicode's rule engine analyzes the design data — the AI assistant just orchestrates the calls.
-
-With a Figma API token:
-```bash
-claude mcp add canicode -e FIGMA_TOKEN=figd_xxxxxxxxxxxxx -- npx -y -p canicode canicode-mcp
-```
-
-For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md).
-
-</details>
-
-
-<details>
-<summary><strong>Claude Code Skills</strong> (lightweight, no MCP install)</summary>
-
-```bash
-npx canicode init --token figd_xxxxxxxxxxxxx
-```
-
-Saves your Figma token AND installs three skills into `./.claude/skills/`:
-
-- **canicode** — lightweight CLI wrapper (use `/canicode <figma-url>`)
-- **canicode-gotchas** — standalone gotcha survey (use `/canicode-gotchas <figma-url>`)
-- **canicode-roundtrip** — full analyze → gotcha → apply roundtrip (use `/canicode-roundtrip <figma-url>`)
-
-> **Next:** install the Figma MCP server (`claude mcp add -s project -t http figma https://mcp.figma.com/mcp`) and restart Claude Code so both the skills and the MCP tools load. See the **MCP Server** section above for context.
-
-Flags: `--global` installs into `~/.claude/skills/` instead. `--no-skills` skips skill install (token only). `--force` overwrites existing skill files without prompting. Run `canicode docs setup` for the full setup guide.
 
 </details>
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -143,7 +143,7 @@ cli.help((sections) => {
       title: "\nInstallation",
       body: [
         `  CLI:     npm install -g canicode`,
-        `  MCP:     claude mcp add canicode -- npx -y -p canicode canicode-mcp`,
+        `  MCP:     claude mcp add canicode -- npx --yes --package=canicode canicode-mcp`,
         `  Skills:  github.com/let-sunny/canicode`,
       ].join("\n"),
     },

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -307,10 +307,10 @@ Get your token: Figma → Settings → Security → Personal access tokens → G
 
 ## MCP Server (Claude Code / Cursor / Claude Desktop)
 \`\`\`bash
-claude mcp add canicode -e FIGMA_TOKEN=figd_xxxxxxxxxxxxx -- npx -y -p canicode canicode-mcp
+claude mcp add canicode -- npx --yes --package=canicode canicode-mcp
 \`\`\`
 
-Requires FIGMA_TOKEN for live Figma URL analysis.
+Requires FIGMA_TOKEN for live Figma URL analysis. The MCP server reads it from \`~/.canicode/config.json\` (set via \`canicode init --token …\`) or from the host's environment, so do **not** pass \`-e FIGMA_TOKEN=…\` to \`claude mcp add\` — \`@anthropic-ai/claude-code\`'s current parser rejects short-form flags placed before \`--\`. (#364, #366)
 
 ## CLI only (no MCP server)
 


### PR DESCRIPTION
## Summary

Three install-docs bugs, all hitting users on their very first session:

- **#366** — every install one-liner used `claude mcp add canicode -- npx -y -p canicode canicode-mcp`. `claude mcp add`'s argv parser refuses to forward short-form flags placed before `--`, so fresh users hit a "flag not recognized" error on first install.
- **#364** — the same lines also passed `-e FIGMA_TOKEN=figd_xxx` to `claude mcp add`. The MCP server already reads the token from `~/.canicode/config.json` (set via `canicode init --token …`) or the host environment, so the flag is redundant — and per #366 the parser rejects it anyway.
- **#367** — the README presented "CLI", "MCP Server", and "Claude Code Skills" as a stack of independent install steps, suggesting users ran all three. They cover overlapping use cases — running more than one just produces a confusing mix of channels.

## Changes

- **README.md** — Installation section becomes a "pick one" matrix (Claude Code / MCP host / CLI) with a clear "do not run more than one" warning, followed by collapsible install-detail blocks.
- **src/cli/index.ts** — `canicode --help` install hint switches to `npx --yes --package=canicode canicode-mcp`.
- **src/mcp/server.ts** — the inline `setup` docs topic served by the `docs` MCP tool gets the same long-form command and an explicit "do not pass `-e FIGMA_TOKEN`" callout.
- **.claude/docs/ARCHITECTURE.md** — install line updated to long-form flags with a parser-collision note.
- **.claude/skills/canicode-roundtrip/SKILL.md**, **.claude/skills/canicode-gotchas/SKILL.md** — same install-line fix; fresh users copy these too.
- **.mcpb** — the user-visible `claude_code` install command field switches to long-form. The `command` / `args` fields that the MCP host invokes directly (parsed as JSON arrays, not shell strings) are left alone — `npx` itself accepts the short flags.

## Test plan

- [ ] On a fresh machine, copy the new \`claude mcp add canicode -- npx --yes --package=canicode canicode-mcp\` line and confirm it succeeds (no "unknown flag" error).
- [ ] Run \`canicode --help\` and confirm the printed MCP install hint matches the README.
- [ ] In an MCP session, call the \`docs\` tool with \`topic: setup\` and confirm the rendered markdown matches.
- [ ] \`pnpm test:run\` still passes.

Closes #364
Closes #366
Closes #367

Made with [Cursor](https://cursor.com)