### PR TITLE
feat(roundtrip): re-analyze recognises canicode annotations as acknowledgments (#371)

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -244,6 +244,8 @@ The probe is read-only and idempotent; running it before the picker adds one rou
    - `applyPropertyMod(question, answerValue, { categories, allowDefinitionWrite, telemetry })` — Strategy A entry point. Branches on `targetProperty` (single vs array) and answer shape (scalar, per-property object, `{ variable: "name" }` binding). Uses `setBoundVariableForPaint` for `fills` / `strokes` and `setBoundVariable` for scalar fields. Passes the full context through to `applyWithInstanceFallback`.
    - `resolveVariableByName(name)` — local-variable exact-name lookup; returns `null` for remote library variables not imported into this file.
    - `probeDefinitionWritability(questions)` — async pre-flight (#357). Returns `{ totalCount, unwritableCount, unwritableSourceNames, allUnwritable, partiallyUnwritable }`. Use BEFORE the Definition write picker so the picker can drop the opt-in branch when every candidate is in an external library / unresolved (saves the user a wasted "I opted in, why did I get annotations?" decision). Read-only probe, dedupes by `sourceChildId`.
+   - `extractAcknowledgmentsFromNode(node, canicodeCategoryIds?)` — synchronous pure helper (#371). Reads one node's annotations and returns `{ nodeId, ruleId }[]` for entries gated by canicode `categoryId` plus a recognisable `— *<ruleId>*` footer (or legacy `**[canicode] <ruleId>**` prefix). When `canicodeCategoryIds` is omitted, footer-text matching alone is sufficient (test mode).
+   - `readCanicodeAcknowledgments(rootNodeId, categories?)` — async tree walker (#371). Loads `rootNodeId` via `figma.getNodeByIdAsync`, recurses through `children`, and accumulates one acknowledgment per recognised entry. Used at the top of Step 5a to harvest the side channel that lets the analysis pipeline distinguish "still broken" from "the designer has a plan" — pass the result straight to `analyze({ acknowledgments })`. Errors on individual nodes are swallowed so locked / external nodes don't abort the sweep.
 
 Keep each `writeFn` small so a throw does not abort unrelated writes. Experiment 08 findings informed every branch in the bundled helpers, and the batch-level confirmation contract still applies *when opting in*: if the orchestrator passes `allowDefinitionWrite: true`, it must have already collected one confirmation covering every potential definition write in the batch. Under the default, no confirmation is needed — the helper annotates the scene instead of propagating.
 
@@ -389,13 +391,44 @@ Applied {N} changes to the Figma design:
 
 ### Step 5: Re-analyze and report what the roundtrip addressed
 
-Run `analyze` again on the same Figma URL:
+#### Step 5a: Harvest canicode-authored annotations as acknowledgments (#371)
+
+Before re-running `analyze`, collect every `(nodeId, ruleId)` pair that Step 4 wrote as a Figma annotation. The REST API does not expose annotations, so this side channel is the only way the analysis pipeline learns that a roundtrip-touched issue is "the designer has a plan" rather than "still broken". Without it the grade and issue count look identical to the pre-roundtrip state — `32 → 32` — even when every gotcha has been captured per ADR-012.
+
+Run a short `use_figma` batch that walks the same subtree the original `analyze` covered (`targetNodeId` if you used one, else `figma.root.id`), reads canicode-categorised annotations, and serialises the result:
+
+```javascript
+// Inside a use_figma batch:
+const categories = await CanICodeRoundtrip.ensureCanicodeCategories();
+const acknowledgments = await CanICodeRoundtrip.readCanicodeAcknowledgments(
+  targetNodeId ?? figma.root.id,
+  categories
+);
+return { events: [], acknowledgments };
+```
+
+`readCanicodeAcknowledgments` walks `node.children` recursively, gates on the `canicode:gotcha` / `canicode:flag` / `canicode:fallback` (and legacy `canicode:auto-fix`) category ids, and extracts the ruleId from the annotation footer (`— *<ruleId>*`) or the legacy `**[canicode] <ruleId>**` prefix. The categoryId guard keeps user-authored notes that happen to end in italic kebab-case from being mistaken for canicode acknowledgments.
+
+#### Step 5b: Re-analyze with acknowledgments
+
+Pass the harvested array straight into `analyze` so the engine flags matching issues as `acknowledged: true` and the density score gives them half weight:
 
 ```
-analyze({ input: "<figma-url>" })
+analyze({ input: "<figma-url>", acknowledgments })
 ```
 
-Under ADR-012's annotate-by-default policy, most instance-child gotchas route to 📝 annotations and do **not** move the numeric grade — so the headline for this step is the **issues-delta** (what the roundtrip captured), not a grade comparison. Grade is kept as a footnote so the Row 8 regression guardrail still applies.
+**Without canicode MCP** — the CLI accepts the same input via `--acknowledgments <path>` (JSON file containing the array). Write the array to a temp file from the `use_figma` return, then:
+
+```bash
+npx canicode analyze "<figma-url>" --json --acknowledgments /tmp/canicode-acks.json
+```
+
+The response now carries:
+- `acknowledgedCount` (top level) — how many issues matched an acknowledgment.
+- `issues[i].acknowledged: true` (per matched issue) — survives into the report and downstream skills.
+- `summary` text — when `acknowledgedCount > 0`, the Total line reads `Total: N (A acknowledged via canicode annotations / N-A unaddressed)`.
+
+Under ADR-012's annotate-by-default policy, most instance-child gotchas route to 📝 annotations and do **not** move the numeric grade — but the half-weight density now produces a small visible movement when annotations are recognised. The headline for this step remains the **issues-delta** (what the roundtrip captured); grade movement is a secondary signal.
 
 **Tally inputs** — derive the counts from the data you already have:
 - `X` (✅ resolved): count of ✅ + 🔧 + 🔗 markers from the Step 4 report block you just emitted (scene/instance-child writes, auto-fix renames, and variable bindings all successfully landed the value).
@@ -403,11 +436,13 @@ Under ADR-012's annotate-by-default policy, most instance-child gotchas route to
 - `Z` (🌐 definition writes): count of 🌐 markers from Step 4 — only non-zero when the orchestrator opted in with `allowDefinitionWrite: true` (helper context option, not a CLI flag).
 - `W` (⏭️ skipped): count of ⏭️ markers from Step 4 plus any Step 3 questions the user answered with `skip` or `n/a`.
 - `V` (remaining): `issues.length` from the re-analyze response — unresolved gotchas plus non-actionable rules still flagged by the design.
+- `V_ack` (acknowledged remaining): `acknowledgedCount` from the same response — issues that the design still surfaces but that carry a canicode annotation per Step 5a.
+- `V_open` (unaddressed remaining): `V - V_ack` — issues with no canicode annotation; the user's actual follow-up backlog.
 - `N` (addressed) = `X + Y + Z + W`.
 
-If Step 4 produced no report block (e.g. user skipped every question, or no gotcha survey ran), all four counts are zero — that is a legitimate outcome; report the breakdown with zeros rather than treating it as an error.
+If Step 4 produced no report block (e.g. user skipped every question, or no gotcha survey ran), all four counts are zero, `V_ack = 0`, and `V_open = V` — report the breakdown with zeros rather than treating it as an error. (Skipping Step 5a and passing no `acknowledgments` argument is also valid in this case — the response simply has `acknowledgedCount: 0`.)
 
-**All gotcha issues resolved** (`V == 0`, i.e. re-analyze surfaces no remaining issues — note this is independent of grade since ADR-012 annotations do not move the score):
+**All gotcha issues resolved** (`V == 0`, i.e. re-analyze surfaces no remaining issues — note this is mostly independent of grade since ADR-012 annotations only move the score by the half-weight reduction enabled in Step 5b):
 - Tell the user (fill in the counts from the tally above):
 
   ```
@@ -440,7 +475,7 @@ for (const id of nodeIds) {
 - Proceed to **Step 6**.
 
 **Some issues remain** (`V > 0`):
-- Show the same breakdown and ask whether to proceed:
+- Show the same breakdown and ask whether to proceed. When `V_ack > 0`, expand the remaining line into the acknowledged/unaddressed split surfaced by the re-analyze (#371) so the user can see how much of `V` is "captured for code-gen" vs "still on the user's plate":
 
   ```
   Roundtrip complete — N issues addressed:
@@ -449,10 +484,14 @@ for (const id of nodeIds) {
     🌐  Z definition writes propagated (only when allowDefinitionWrite: true)
     ⏭️  W skipped (user declined or "skip")
     —
-    V issues remaining (unresolved gotchas + non-actionable rules)
+    V issues remaining
+       ↳ V_ack acknowledged via canicode annotations (carried into code-gen)
+       ↳ V_open unaddressed (no annotation — your follow-up backlog)
 
   Grade: {oldGrade} → {newGrade}. Proceed to code generation with remaining context?
   ```
+
+  When `V_ack == 0` (re-analyze returned `acknowledgedCount: 0`), keep the single `V issues remaining (unresolved gotchas + non-actionable rules)` line.
 - If yes → proceed to **Step 6** with remaining gotcha context.
 - If no → stop and emit the **Stop wrap-up** below; do **not** restate the grade as the lead.
 
@@ -466,11 +505,15 @@ Stopped — N issues addressed, V remaining for manual follow-up:
   📝  Y annotated on Figma (carried into code-gen via canicode-gotchas)
   🌐  Z definition writes propagated
   ⏭️  W skipped
+   —
+  V remaining
+     ↳ V_ack acknowledged via canicode annotations
+     ↳ V_open unaddressed
 
 Grade: {oldGrade} → {newGrade}.
 ```
 
-Anti-pattern (do **not** lead with a grade-only sentence like "Grade: C → C+. Most size-constraint gotchas are now annotations…"). Lead with the delta block; mention grade once, on its own footnote line, plain prose only.
+When `V_ack == 0`, drop the `↳` lines and leave a single `V remaining` row. Anti-pattern (do **not** lead with a grade-only sentence like "Grade: C → C+. Most size-constraint gotchas are now annotations…"). Lead with the delta block; mention grade once, on its own footnote line, plain prose only.
 
 ### Step 6: Implement with Figma MCP
 
@@ -497,10 +540,14 @@ Roundtrip complete — N issues addressed, code generated:
   ⏭️  W skipped
   —
   V issues remaining
+     ↳ V_ack acknowledged via canicode annotations
+     ↳ V_open unaddressed
 
 Grade: {oldGrade} → {newGrade}.
 Code: <files generated / next-step pointer from figma-implement-design>
 ```
+
+(Drop the `↳` lines when `V_ack == 0`.)
 
 ## Edge Cases
 

--- a/.claude/skills/canicode-roundtrip/helpers.js
+++ b/.claude/skills/canicode-roundtrip/helpers.js
@@ -318,10 +318,68 @@ ${footer}`;
     return null;
   }
 
+  // src/core/roundtrip/read-acknowledgments.ts
+  var FOOTER_RE = /—\s+\*([A-Za-z0-9-]+)\*\s*$/;
+  var LEGACY_PREFIX_RE = /^\*\*\[canicode\]\s+([A-Za-z0-9-]+)\*\*/;
+  function extractAcknowledgmentsFromNode(node, canicodeCategoryIds) {
+    if (!node || !("annotations" in node)) return [];
+    const annotations = node.annotations ?? [];
+    if (annotations.length === 0) return [];
+    const out = [];
+    for (const a of annotations) {
+      const text = (typeof a.labelMarkdown === "string" && a.labelMarkdown.length > 0 ? a.labelMarkdown : "") || (typeof a.label === "string" && a.label.length > 0 ? a.label : "");
+      if (!text) continue;
+      if (canicodeCategoryIds) {
+        if (!a.categoryId || !canicodeCategoryIds.has(a.categoryId)) continue;
+      }
+      const ruleId = extractRuleId(text);
+      if (!ruleId) continue;
+      out.push({ nodeId: node.id, ruleId });
+    }
+    return out;
+  }
+  function extractRuleId(text) {
+    const footer = FOOTER_RE.exec(text);
+    if (footer) return footer[1] ?? null;
+    const legacy = LEGACY_PREFIX_RE.exec(text);
+    if (legacy) return legacy[1] ?? null;
+    return null;
+  }
+  async function readCanicodeAcknowledgments(rootNodeId, categories) {
+    const root = await figma.getNodeByIdAsync(rootNodeId);
+    if (!root) return [];
+    const canicodeCategoryIds = categories ? new Set(
+      [
+        categories.gotcha,
+        categories.flag,
+        categories.fallback,
+        categories.legacyAutoFix
+      ].filter((id) => typeof id === "string" && id.length > 0)
+    ) : void 0;
+    const out = [];
+    walk(root, canicodeCategoryIds, out);
+    return out;
+  }
+  function walk(node, canicodeCategoryIds, out) {
+    try {
+      const local = extractAcknowledgmentsFromNode(node, canicodeCategoryIds);
+      for (const a of local) out.push(a);
+    } catch {
+    }
+    const children = node.children;
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        if (child && typeof child === "object") walk(child, canicodeCategoryIds, out);
+      }
+    }
+  }
+
   exports.applyPropertyMod = applyPropertyMod;
   exports.applyWithInstanceFallback = applyWithInstanceFallback;
   exports.ensureCanicodeCategories = ensureCanicodeCategories;
+  exports.extractAcknowledgmentsFromNode = extractAcknowledgmentsFromNode;
   exports.probeDefinitionWritability = probeDefinitionWritability;
+  exports.readCanicodeAcknowledgments = readCanicodeAcknowledgments;
   exports.resolveVariableByName = resolveVariableByName;
   exports.stripAnnotations = stripAnnotations;
   exports.upsertCanicodeAnnotation = upsertCanicodeAnnotation;

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
 import type { CAC } from "cac";
 import { z } from "zod";
@@ -7,6 +7,10 @@ import { z } from "zod";
 import type { RuleConfig, RuleId } from "../../core/contracts/rule.js";
 import { analyzeFile } from "../../core/engine/rule-engine.js";
 import { loadFile, isJsonFile, isFixtureDir } from "../../core/engine/loader.js";
+import {
+  AcknowledgmentListSchema,
+  type Acknowledgment,
+} from "../../core/contracts/acknowledgment.js";
 import {
   getFigmaToken, getReportsDir, ensureReportsDir,
 } from "../../core/engine/config-store.js";
@@ -26,6 +30,7 @@ const AnalyzeOptionsSchema = z.object({
   config: z.string().optional(),
   noOpen: z.boolean().optional(),
   json: z.boolean().optional(),
+  acknowledgments: z.string().optional(),
 });
 
 
@@ -40,6 +45,7 @@ export function registerAnalyze(cli: CAC): void {
     .option("--config <path>", "Path to config JSON file (override rule scores/settings)")
     .option("--no-open", "Don't open report in browser after analysis")
     .option("--json", "Output JSON results to stdout (same format as MCP)")
+    .option("--acknowledgments <path>", "(#371) Path to a JSON file containing [{ nodeId, ruleId }] pairs harvested from canicode-authored Figma annotations. Matching issues are flagged acknowledged and contribute half weight to density.")
     .example("  canicode analyze https://www.figma.com/design/ABC123/MyDesign")
     .example("  canicode analyze https://www.figma.com/design/ABC123/MyDesign --api --token YOUR_TOKEN")
     .example("  canicode analyze ./fixtures/my-design --output report.html")
@@ -127,12 +133,27 @@ export function registerAnalyze(cli: CAC): void {
           log(`Config loaded: ${options.config}`);
         }
 
+        let acknowledgments: Acknowledgment[] | undefined;
+        if (options.acknowledgments) {
+          const ackPath = resolve(options.acknowledgments);
+          const raw = await readFile(ackPath, "utf-8");
+          const parsed = AcknowledgmentListSchema.safeParse(JSON.parse(raw));
+          if (!parsed.success) {
+            throw new Error(
+              `Invalid --acknowledgments file at ${ackPath}: ${parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; ")}`
+            );
+          }
+          acknowledgments = parsed.data;
+          log(`Acknowledgments loaded: ${acknowledgments.length} entries from ${ackPath}`);
+        }
+
         // Build analysis options
         const analyzeOptions = {
           configs: configs as Record<RuleId, RuleConfig>,
           ...(effectiveNodeId && { targetNodeId: effectiveNodeId }),
           ...(excludeNodeNames && { excludeNodeNames }),
           ...(excludeNodeTypes && { excludeNodeTypes }),
+          ...(acknowledgments && { acknowledgments }),
         };
 
         // Run analysis

--- a/src/core/contracts/acknowledgment.ts
+++ b/src/core/contracts/acknowledgment.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+/**
+ * Acknowledgment marker — surfaced from a Figma Dev Mode annotation that
+ * canicode itself wrote during a roundtrip. When the analysis pipeline
+ * receives a list of acknowledgments, matching `(nodeId, ruleId)` issues are
+ * flagged `acknowledged: true` and contribute half their normal weight to
+ * the density score (#371).
+ *
+ * This contract is consumed by:
+ * - The MCP `analyze` tool (`acknowledgments?: Acknowledgment[]` input)
+ * - The CLI `analyze --acknowledgments <path>` flag
+ * - `RuleEngineOptions.acknowledgments`
+ *
+ * It is produced by the Plugin-API helper
+ * `extractAcknowledgmentsFromNode` / `readCanicodeAcknowledgments`
+ * (see `src/core/roundtrip/read-acknowledgments.ts`).
+ */
+export const AcknowledgmentSchema = z.object({
+  nodeId: z.string(),
+  ruleId: z.string(),
+});
+
+export type Acknowledgment = z.infer<typeof AcknowledgmentSchema>;
+
+export const AcknowledgmentListSchema = z.array(AcknowledgmentSchema);
+
+/**
+ * Normalize a Figma node id into `:`-separated form so callers can pass
+ * either URL-style (`123-456`) or Plugin-API-style (`123:456`) ids and the
+ * engine matches them consistently. Non-instance ids stay unchanged; the
+ * `I…;…` instance-child format keeps its semicolon — only `-` → `:`
+ * happens.
+ */
+export function normalizeNodeId(id: string): string {
+  return id.replace(/-/g, ":");
+}

--- a/src/core/engine/rule-engine.test.ts
+++ b/src/core/engine/rule-engine.test.ts
@@ -459,3 +459,69 @@ describe("analyzeFile", () => {
     expect(result.issues.length).toBe(0);
   });
 });
+
+// ─── Acknowledgments (#371) ──────────────────────────────────────────────────
+
+describe("RuleEngine.analyze — acknowledgments", () => {
+  // Build a document where two leaf frames produce non-semantic-name violations.
+  // We then mark one of them as acknowledged and assert only that one carries
+  // the flag — the other stays unacknowledged.
+  function buildMultiViolationFile(): { file: AnalysisFile; targetNodeIds: string[] } {
+    const child1 = makeNode({ id: "10:1", name: "Frame 1", type: "FRAME" });
+    const child2 = makeNode({ id: "10:2", name: "Frame 2", type: "FRAME" });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [child1, child2],
+    });
+    return { file: makeFile({ document: doc }), targetNodeIds: [child1.id, child2.id] };
+  }
+
+  it("flags issues whose (nodeId, ruleId) match an acknowledgment", () => {
+    const { file, targetNodeIds } = buildMultiViolationFile();
+    const result = analyzeFile(file, {
+      acknowledgments: [{ nodeId: targetNodeIds[0]!, ruleId: "non-semantic-name" }],
+    });
+
+    const naming = result.issues.filter(
+      (i) => i.violation.ruleId === "non-semantic-name"
+    );
+    expect(naming.length).toBeGreaterThanOrEqual(2);
+    const acked = naming.find((i) => i.violation.nodeId === targetNodeIds[0]);
+    const unacked = naming.find((i) => i.violation.nodeId === targetNodeIds[1]);
+    expect(acked?.acknowledged).toBe(true);
+    expect(unacked?.acknowledged).toBeUndefined();
+  });
+
+  it("normalizes acknowledgment nodeIds (URL form `-` matches Plugin form `:`)", () => {
+    const { file, targetNodeIds } = buildMultiViolationFile();
+    const urlForm = targetNodeIds[0]!.replace(/:/g, "-");
+    const result = analyzeFile(file, {
+      acknowledgments: [{ nodeId: urlForm, ruleId: "non-semantic-name" }],
+    });
+
+    const acked = result.issues.find(
+      (i) => i.violation.nodeId === targetNodeIds[0] && i.violation.ruleId === "non-semantic-name"
+    );
+    expect(acked?.acknowledged).toBe(true);
+  });
+
+  it("ignores acknowledgments that do not match any issue", () => {
+    const { file } = buildMultiViolationFile();
+    const result = analyzeFile(file, {
+      acknowledgments: [{ nodeId: "999:999", ruleId: "non-semantic-name" }],
+    });
+
+    const anyAcked = result.issues.some((i) => i.acknowledged === true);
+    expect(anyAcked).toBe(false);
+  });
+
+  it("leaves issues unflagged when no acknowledgments are passed", () => {
+    const { file } = buildMultiViolationFile();
+    const result = analyzeFile(file);
+
+    const anyAcked = result.issues.some((i) => i.acknowledged === true);
+    expect(anyAcked).toBe(false);
+  });
+});

--- a/src/core/engine/rule-engine.ts
+++ b/src/core/engine/rule-engine.ts
@@ -9,9 +9,21 @@ import type {
 import { supportsDepthWeight } from "../contracts/rule.js";
 import { ruleRegistry } from "../rules/rule-registry.js";
 import { RULE_CONFIGS } from "../rules/rule-config.js";
+import {
+  normalizeNodeId,
+  type Acknowledgment,
+} from "../contracts/acknowledgment.js";
 
 /**
- * Analysis issue with calculated score and metadata
+ * Analysis issue with calculated score and metadata.
+ *
+ * `acknowledged` (#371) — set when the analysis engine receives an
+ * `acknowledgments` list (typically read from canicode-authored Figma
+ * annotations) whose `(nodeId, ruleId)` matches this issue. Acknowledged
+ * issues still surface in the result (so code-gen retains the context) but
+ * contribute half their normal weight to the density score, so the grade
+ * reflects "the designer has a plan for this" instead of treating the rule
+ * as fully unaddressed.
  */
 export interface AnalysisIssue {
   violation: RuleViolation;
@@ -20,6 +32,7 @@ export interface AnalysisIssue {
   depth: number;
   maxDepth: number;
   calculatedScore: number;
+  acknowledged?: boolean;
 }
 
 /**
@@ -54,6 +67,14 @@ export interface RuleEngineOptions {
   targetNodeId?: string;
   excludeNodeNames?: string[];
   excludeNodeTypes?: string[];
+  /**
+   * `(nodeId, ruleId)` pairs sourced from canicode-authored Figma annotations
+   * (#371). Issues whose violation matches an entry are flagged
+   * `acknowledged: true` and contribute half their normal weight to the
+   * density score in `calculateScores`. nodeId may be passed in URL form
+   * (`123-456`) or Plugin-API form (`123:456`) — both normalize to `:`.
+   */
+  acknowledgments?: Acknowledgment[];
 }
 
 /**
@@ -136,6 +157,7 @@ export class RuleEngine {
   private targetNodeId: string | undefined;
   private excludeNamePattern: RegExp | null;
   private excludeNodeTypes: Set<string> | null;
+  private acknowledgments: ReadonlySet<string>;
 
   constructor(options: RuleEngineOptions = {}) {
     this.configs = options.configs ?? RULE_CONFIGS;
@@ -150,6 +172,11 @@ export class RuleEngine {
     this.excludeNodeTypes = options.excludeNodeTypes && options.excludeNodeTypes.length > 0
       ? new Set(options.excludeNodeTypes)
       : null;
+    this.acknowledgments = new Set(
+      (options.acknowledgments ?? []).map(
+        (a) => `${normalizeNodeId(a.nodeId)}::${a.ruleId}`
+      )
+    );
   }
 
   /**
@@ -193,6 +220,15 @@ export class RuleEngine {
       undefined,
       undefined
     );
+
+    if (this.acknowledgments.size > 0) {
+      for (const issue of issues) {
+        const key = `${normalizeNodeId(issue.violation.nodeId)}::${issue.violation.ruleId}`;
+        if (this.acknowledgments.has(key)) {
+          issue.acknowledged = true;
+        }
+      }
+    }
 
     return {
       file,

--- a/src/core/engine/scoring.test.ts
+++ b/src/core/engine/scoring.test.ts
@@ -292,6 +292,57 @@ describe("calculateScores", () => {
     expect(scores.byCategory["pixel-critical"].bySeverity["missing-info"]).toBe(0);
     expect(scores.byCategory["pixel-critical"].bySeverity.suggestion).toBe(0);
   });
+
+  it("acknowledged issues contribute half weight to density (#371)", () => {
+    const baseIssue = (): AnalysisIssue =>
+      makeIssue({ ruleId: "no-auto-layout", category: "pixel-critical", severity: "blocking", score: -10 });
+
+    const allUnack = calculateScores(makeResult([baseIssue(), baseIssue(), baseIssue(), baseIssue()], 100));
+    // 4 issues × 1.0 weight each → sqrt(4) = 2 → score 10 × 2 = 20
+    expect(allUnack.byCategory["pixel-critical"].weightedIssueCount).toBeCloseTo(20, 1);
+
+    const ackOne = baseIssue();
+    ackOne.acknowledged = true;
+    const ackTwo = baseIssue();
+    ackTwo.acknowledged = true;
+    const allAck = calculateScores(makeResult([ackOne, ackTwo, baseIssue(), baseIssue()], 100));
+    // 2 acknowledged × 0.5 + 2 unack × 1.0 = 3.0 → sqrt(3) → score 10 × sqrt(3) ≈ 17.32
+    expect(allAck.byCategory["pixel-critical"].weightedIssueCount).toBeCloseTo(10 * Math.sqrt(3), 1);
+    // Density score reflects the lighter weight — must be strictly higher
+    expect(allAck.byCategory["pixel-critical"].densityScore).toBeGreaterThan(
+      allUnack.byCategory["pixel-critical"].densityScore
+    );
+  });
+
+  it("acknowledged issues are counted in summary.totalIssues and summary.acknowledgedCount (#371)", () => {
+    const ack = makeIssue({ ruleId: "raw-value", category: "token-management", severity: "missing-info" });
+    ack.acknowledged = true;
+    const issues = [
+      ack,
+      makeIssue({ ruleId: "no-auto-layout", category: "pixel-critical", severity: "blocking" }),
+    ];
+    const scores = calculateScores(makeResult(issues));
+
+    expect(scores.summary.totalIssues).toBe(2);
+    expect(scores.summary.acknowledgedCount).toBe(1);
+    expect(scores.summary.blocking).toBe(1);
+    expect(scores.summary.missingInfo).toBe(1);
+  });
+
+  it("formatScoreSummary surfaces acknowledged/unaddressed split when count > 0 (#371)", () => {
+    const ack = makeIssue({ ruleId: "raw-value", category: "token-management", severity: "missing-info" });
+    ack.acknowledged = true;
+    const scores = calculateScores(makeResult([ack, makeIssue({ ruleId: "no-auto-layout", category: "pixel-critical", severity: "blocking" })]));
+    expect(formatScoreSummary(scores)).toContain("Total: 2 (1 acknowledged via canicode annotations / 1 unaddressed)");
+  });
+
+  it("formatScoreSummary keeps the simple Total line when no acknowledgments", () => {
+    const scores = calculateScores(makeResult([
+      makeIssue({ ruleId: "no-auto-layout", category: "pixel-critical", severity: "blocking" }),
+    ]));
+    expect(formatScoreSummary(scores)).toContain("Total: 1");
+    expect(formatScoreSummary(scores)).not.toContain("acknowledged");
+  });
 });
 
 // ─── Grade boundaries ─────────────────────────────────────────────────────────
@@ -580,6 +631,34 @@ describe("buildResultJson", () => {
       isInstanceChild: true,
       sourceChildId: "2299:23057",
     });
+  });
+
+  it("surfaces acknowledgedCount on the JSON top level and per-issue acknowledged: true (#371)", () => {
+    const ack = makeIssue({ ruleId: "raw-value", category: "token-management", severity: "missing-info" });
+    ack.acknowledged = true;
+    const unack = makeIssue({ ruleId: "no-auto-layout", category: "pixel-critical", severity: "blocking" });
+
+    const result = makeResult([ack, unack]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+    const issues = json.issues as Array<Record<string, unknown>>;
+
+    expect(json.acknowledgedCount).toBe(1);
+    expect(issues[0]).toMatchObject({ ruleId: "raw-value", acknowledged: true });
+    expect(issues[1]).toMatchObject({ ruleId: "no-auto-layout" });
+    expect(issues[1]).not.toHaveProperty("acknowledged");
+  });
+
+  it("acknowledgedCount is 0 and per-issue field omitted when no acknowledgments", () => {
+    const result = makeResult([
+      makeIssue({ ruleId: "no-auto-layout", category: "pixel-critical", severity: "blocking" }),
+    ]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+    const issues = json.issues as Array<Record<string, unknown>>;
+
+    expect(json.acknowledgedCount).toBe(0);
+    expect(issues[0]).not.toHaveProperty("acknowledged");
   });
 });
 

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -41,6 +41,15 @@ export interface ScoreReport {
     missingInfo: number;
     suggestion: number;
     nodeCount: number;
+    /**
+     * Number of issues marked `acknowledged` by an upstream
+     * acknowledgments list (#371). Acknowledged issues are still counted in
+     * `totalIssues` and the per-severity tallies — the count here is purely
+     * additive context so consumers can render
+     * `N issues — A acknowledged / N-A unaddressed`. They contribute half
+     * weight to the density score upstream.
+     */
+    acknowledgedCount: number;
   };
 }
 
@@ -205,9 +214,15 @@ export function calculateScores(
     categoryScores[category].bySeverity[severity]++;
     uniqueRulesPerCategory.get(category)!.add(ruleId);
     ruleScorePerCategory.get(category)!.set(ruleId, Math.abs(issue.config.score));
-    // Accumulate per-rule issue count (using |calculatedScore| as weight unit)
+    // Accumulate per-rule issue count using a per-issue weight: 1.0 for
+    // unacknowledged issues, 0.5 for acknowledged ones (#371). The sqrt
+    // damping below treats this sum as the "occurrence count" so the
+    // half-weight flows through to density without changing the formula.
+    // Diversity is left untouched — acknowledgment is per-issue, not
+    // per-rule, and the rule still represents a kind of problem.
     const ruleCountMap = ruleIssueCountPerCategory.get(category)!;
-    ruleCountMap.set(ruleId, (ruleCountMap.get(ruleId) ?? 0) + 1);
+    const weight = issue.acknowledged === true ? 0.5 : 1;
+    ruleCountMap.set(ruleId, (ruleCountMap.get(ruleId) ?? 0) + weight);
   }
 
   // Compute weightedIssueCount with sqrt damping per rule (#226).
@@ -286,6 +301,7 @@ export function calculateScores(
     missingInfo: 0,
     suggestion: 0,
     nodeCount,
+    acknowledgedCount: 0,
   };
 
   for (const issue of result.issues) {
@@ -303,6 +319,7 @@ export function calculateScores(
         summary.suggestion++;
         break;
     }
+    if (issue.acknowledged === true) summary.acknowledgedCount++;
   }
 
   return {
@@ -367,7 +384,15 @@ export function formatScoreSummary(report: ScoreReport): string {
   lines.push(`  Risk: ${report.summary.risk}`);
   lines.push(`  Missing Info: ${report.summary.missingInfo}`);
   lines.push(`  Suggestion: ${report.summary.suggestion}`);
-  lines.push(`  Total: ${report.summary.totalIssues}`);
+  if (report.summary.acknowledgedCount > 0) {
+    const unaddressed =
+      report.summary.totalIssues - report.summary.acknowledgedCount;
+    lines.push(
+      `  Total: ${report.summary.totalIssues} (${report.summary.acknowledgedCount} acknowledged via canicode annotations / ${unaddressed} unaddressed)`
+    );
+  } else {
+    lines.push(`  Total: ${report.summary.totalIssues}`);
+  }
 
   return lines.join("\n");
 }
@@ -430,6 +455,7 @@ export function buildResultJson(
       ...(applyContext.sourceChildId !== undefined
         ? { sourceChildId: applyContext.sourceChildId }
         : {}),
+      ...(issue.acknowledged === true ? { acknowledged: true as const } : {}),
     };
   });
 
@@ -441,6 +467,7 @@ export function buildResultJson(
     nodeCount: result.nodeCount,
     maxDepth: result.maxDepth,
     issueCount: result.issues.length,
+    acknowledgedCount: scores.summary.acknowledgedCount,
     isReadyForCodeGen: isReadyForCodeGen(scores.overall.grade),
     blockingIssueCount: scores.summary.blocking,
     scores: {

--- a/src/core/roundtrip/index.ts
+++ b/src/core/roundtrip/index.ts
@@ -10,3 +10,7 @@ export {
 } from "./apply-property-mod.js";
 export { probeDefinitionWritability } from "./probe-definition-writability.js";
 export type { DefinitionWritabilityProbe } from "./probe-definition-writability.js";
+export {
+  extractAcknowledgmentsFromNode,
+  readCanicodeAcknowledgments,
+} from "./read-acknowledgments.js";

--- a/src/core/roundtrip/read-acknowledgments.test.ts
+++ b/src/core/roundtrip/read-acknowledgments.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractAcknowledgmentsFromNode,
+  readCanicodeAcknowledgments,
+} from "./read-acknowledgments.js";
+import type {
+  AnnotationEntry,
+  CanicodeCategories,
+  FigmaNode,
+} from "./types.js";
+
+function makeNode(
+  id: string,
+  annotations: AnnotationEntry[],
+  children?: FigmaNode[]
+): FigmaNode {
+  const node: FigmaNode = {
+    id,
+    name: id,
+    type: "FRAME",
+    annotations,
+  };
+  if (children) (node as { children?: FigmaNode[] }).children = children;
+  return node;
+}
+
+const CATEGORIES: CanicodeCategories = {
+  gotcha: "cat-gotcha",
+  flag: "cat-flag",
+  fallback: "cat-fallback",
+};
+
+describe("extractAcknowledgmentsFromNode", () => {
+  it("returns empty for null / undefined / non-annotated nodes", () => {
+    expect(extractAcknowledgmentsFromNode(null)).toEqual([]);
+    expect(extractAcknowledgmentsFromNode(undefined)).toEqual([]);
+    const noAnnotations = { id: "1:1", name: "x", type: "FRAME" } as FigmaNode;
+    expect(extractAcknowledgmentsFromNode(noAnnotations)).toEqual([]);
+  });
+
+  it("matches the post-#353 footer `— *<ruleId>*`", () => {
+    const node = makeNode("1:1", [
+      {
+        labelMarkdown: "**Q:** something\n**A:** answer\n\n— *missing-size-constraint*",
+        categoryId: "cat-gotcha",
+      },
+    ]);
+    expect(
+      extractAcknowledgmentsFromNode(node, new Set([CATEGORIES.gotcha]))
+    ).toEqual([{ nodeId: "1:1", ruleId: "missing-size-constraint" }]);
+  });
+
+  it("matches the legacy `**[canicode] <ruleId>**` prefix", () => {
+    const node = makeNode("2:2", [
+      {
+        labelMarkdown: "**[canicode] raw-value** body without footer",
+        categoryId: "cat-flag",
+      },
+    ]);
+    expect(
+      extractAcknowledgmentsFromNode(node, new Set([CATEGORIES.flag]))
+    ).toEqual([{ nodeId: "2:2", ruleId: "raw-value" }]);
+  });
+
+  it("requires the categoryId to be a canicode one when categoryIds are provided (false-positive guard)", () => {
+    const node = makeNode("3:3", [
+      // Looks like our footer, but the user wrote it themselves on a
+      // non-canicode category — must NOT be treated as an acknowledgment.
+      {
+        labelMarkdown: "Some user note ending — *missing-size-constraint*",
+        categoryId: "user-category",
+      },
+    ]);
+    expect(
+      extractAcknowledgmentsFromNode(
+        node,
+        new Set([CATEGORIES.gotcha, CATEGORIES.flag, CATEGORIES.fallback])
+      )
+    ).toEqual([]);
+  });
+
+  it("matches by footer alone when categoryIds are omitted (test-mode fallback)", () => {
+    const node = makeNode("4:4", [
+      {
+        labelMarkdown: "Note — *raw-value*",
+      },
+    ]);
+    expect(extractAcknowledgmentsFromNode(node)).toEqual([
+      { nodeId: "4:4", ruleId: "raw-value" },
+    ]);
+  });
+
+  it("returns one acknowledgment per recognised entry on the same node", () => {
+    const node = makeNode("5:5", [
+      {
+        labelMarkdown: "First — *missing-size-constraint*",
+        categoryId: "cat-gotcha",
+      },
+      {
+        labelMarkdown: "Second — *non-semantic-name*",
+        categoryId: "cat-flag",
+      },
+      {
+        labelMarkdown: "Unrelated user note",
+        categoryId: "cat-gotcha",
+      },
+    ]);
+    expect(
+      extractAcknowledgmentsFromNode(
+        node,
+        new Set([CATEGORIES.gotcha, CATEGORIES.flag])
+      )
+    ).toEqual([
+      { nodeId: "5:5", ruleId: "missing-size-constraint" },
+      { nodeId: "5:5", ruleId: "non-semantic-name" },
+    ]);
+  });
+
+  it("ignores mid-body asterisk pairs — only end-anchored footers count", () => {
+    const node = makeNode("6:6", [
+      {
+        labelMarkdown:
+          "Body mentions *not-a-rule* in the middle and ends — *raw-value*",
+        categoryId: "cat-flag",
+      },
+    ]);
+    expect(
+      extractAcknowledgmentsFromNode(node, new Set([CATEGORIES.flag]))
+    ).toEqual([{ nodeId: "6:6", ruleId: "raw-value" }]);
+  });
+
+  it("falls back to `label` when `labelMarkdown` is empty", () => {
+    const node = makeNode("7:7", [
+      {
+        label: "Plain note — *irregular-spacing*",
+        categoryId: "cat-gotcha",
+      },
+    ]);
+    expect(
+      extractAcknowledgmentsFromNode(node, new Set([CATEGORIES.gotcha]))
+    ).toEqual([{ nodeId: "7:7", ruleId: "irregular-spacing" }]);
+  });
+});
+
+describe("readCanicodeAcknowledgments", () => {
+  it("walks the subtree via figma.getNodeByIdAsync and accumulates per-node matches", async () => {
+    const grandchild = makeNode("3:3", [
+      { labelMarkdown: "deep — *non-semantic-name*", categoryId: "cat-flag" },
+    ]);
+    const child1 = makeNode(
+      "2:1",
+      [
+        {
+          labelMarkdown: "**Q:** … **A:** …\n\n— *missing-size-constraint*",
+          categoryId: "cat-gotcha",
+        },
+      ],
+      [grandchild]
+    );
+    const child2 = makeNode("2:2", [
+      // Non-canicode annotation — must not register.
+      { labelMarkdown: "user note ending — *raw-value*", categoryId: "user-category" },
+    ]);
+    const root = makeNode("1:1", [], [child1, child2]);
+
+    const figma = {
+      getNodeByIdAsync: async (id: string) => (id === "1:1" ? root : null),
+    };
+    (globalThis as { figma?: unknown }).figma = figma;
+
+    const acks = await readCanicodeAcknowledgments("1:1", CATEGORIES);
+
+    expect(acks).toEqual([
+      { nodeId: "2:1", ruleId: "missing-size-constraint" },
+      { nodeId: "3:3", ruleId: "non-semantic-name" },
+    ]);
+  });
+
+  it("returns an empty array when the root node cannot be resolved", async () => {
+    const figma = {
+      getNodeByIdAsync: async () => null,
+    };
+    (globalThis as { figma?: unknown }).figma = figma;
+
+    expect(await readCanicodeAcknowledgments("missing:1", CATEGORIES)).toEqual(
+      []
+    );
+  });
+
+  it("swallows per-node read errors so the rest of the sweep proceeds", async () => {
+    const noisyChild = makeNode("4:4", []);
+    Object.defineProperty(noisyChild, "annotations", {
+      get: () => {
+        throw new Error("locked node");
+      },
+    });
+    const goodChild = makeNode("5:5", [
+      { labelMarkdown: "ok — *raw-value*", categoryId: "cat-gotcha" },
+    ]);
+    const root = makeNode("1:1", [], [noisyChild, goodChild]);
+
+    const figma = {
+      getNodeByIdAsync: async () => root,
+    };
+    (globalThis as { figma?: unknown }).figma = figma;
+
+    const acks = await readCanicodeAcknowledgments("1:1", CATEGORIES);
+    expect(acks).toEqual([{ nodeId: "5:5", ruleId: "raw-value" }]);
+  });
+});

--- a/src/core/roundtrip/read-acknowledgments.ts
+++ b/src/core/roundtrip/read-acknowledgments.ts
@@ -1,0 +1,134 @@
+import type { Acknowledgment } from "../contracts/acknowledgment.js";
+import type {
+  AnnotationEntry,
+  CanicodeCategories,
+  FigmaGlobal,
+  FigmaNode,
+} from "./types.js";
+
+declare const figma: FigmaGlobal;
+
+// Stable markers planted by `upsertCanicodeAnnotation` so re-analyze can
+// recognise canicode-authored annotations and treat the underlying issue as
+// `acknowledged: true` (#371).
+//
+// - **New format (post-#353)** — the body always ends with the italic
+//   footer `— *<ruleId>*` (literal em-dash + space + asterisks). Anchor to
+//   end so a single annotation that mentions multiple rules in prose
+//   doesn't generate phantom matches mid-body.
+// - **Legacy format (pre-#353)** — older roundtrip runs left the body
+//   leading with `**[canicode] <ruleId>**`. Anchor to start for the same
+//   reason.
+const FOOTER_RE = /—\s+\*([A-Za-z0-9-]+)\*\s*$/;
+const LEGACY_PREFIX_RE = /^\*\*\[canicode\]\s+([A-Za-z0-9-]+)\*\*/;
+
+/**
+ * Pure synchronous helper. Inspects one node's annotations and returns the
+ * `(nodeId, ruleId)` pairs that look like canicode-authored acknowledgments.
+ *
+ * Behaviour:
+ * - When `canicodeCategoryIds` is provided, an entry must BOTH carry a
+ *   `categoryId` in that set AND have a recognisable footer/prefix to count.
+ *   This is the production path — the categoryId guard prevents
+ *   false-positives from user-written annotations whose prose happens to end
+ *   with an italic kebab-case word.
+ * - When `canicodeCategoryIds` is omitted, footer/prefix matching alone is
+ *   sufficient. Useful for unit tests and for sessions that haven't loaded
+ *   the category map yet.
+ *
+ * Returns one acknowledgment per recognised entry. A node with multiple
+ * canicode annotations (different ruleIds on the same node) yields multiple
+ * acknowledgments.
+ */
+export function extractAcknowledgmentsFromNode(
+  node: FigmaNode | null | undefined,
+  canicodeCategoryIds?: ReadonlySet<string>
+): Acknowledgment[] {
+  if (!node || !("annotations" in node)) return [];
+  const annotations = (node.annotations ?? []) as readonly AnnotationEntry[];
+  if (annotations.length === 0) return [];
+
+  const out: Acknowledgment[] = [];
+  for (const a of annotations) {
+    const text =
+      (typeof a.labelMarkdown === "string" && a.labelMarkdown.length > 0
+        ? a.labelMarkdown
+        : "") ||
+      (typeof a.label === "string" && a.label.length > 0 ? a.label : "");
+    if (!text) continue;
+
+    if (canicodeCategoryIds) {
+      if (!a.categoryId || !canicodeCategoryIds.has(a.categoryId)) continue;
+    }
+
+    const ruleId = extractRuleId(text);
+    if (!ruleId) continue;
+
+    out.push({ nodeId: node.id, ruleId });
+  }
+  return out;
+}
+
+function extractRuleId(text: string): string | null {
+  const footer = FOOTER_RE.exec(text);
+  if (footer) return footer[1] ?? null;
+  const legacy = LEGACY_PREFIX_RE.exec(text);
+  if (legacy) return legacy[1] ?? null;
+  return null;
+}
+
+/**
+ * Async tree walker — runs INSIDE a `use_figma` batch. Loads the root node
+ * via `figma.getNodeByIdAsync`, recurses through `children`, and accumulates
+ * one `(nodeId, ruleId)` per recognised canicode annotation.
+ *
+ * Pass the categories from `ensureCanicodeCategories()` so the walker can
+ * gate on `categoryId` instead of footer text alone — see the pure helper
+ * above for the rationale.
+ *
+ * Returns an empty array when the root node cannot be resolved (e.g.
+ * stale id from a previous session). Errors thrown by individual node
+ * reads are swallowed so one bad node doesn't abort the whole sweep.
+ */
+export async function readCanicodeAcknowledgments(
+  rootNodeId: string,
+  categories?: CanicodeCategories | undefined
+): Promise<Acknowledgment[]> {
+  const root = await figma.getNodeByIdAsync(rootNodeId);
+  if (!root) return [];
+
+  const canicodeCategoryIds = categories
+    ? new Set(
+        [
+          categories.gotcha,
+          categories.flag,
+          categories.fallback,
+          categories.legacyAutoFix,
+        ].filter((id): id is string => typeof id === "string" && id.length > 0)
+      )
+    : undefined;
+
+  const out: Acknowledgment[] = [];
+  walk(root, canicodeCategoryIds, out);
+  return out;
+}
+
+function walk(
+  node: FigmaNode,
+  canicodeCategoryIds: ReadonlySet<string> | undefined,
+  out: Acknowledgment[]
+): void {
+  try {
+    const local = extractAcknowledgmentsFromNode(node, canicodeCategoryIds);
+    for (const a of local) out.push(a);
+  } catch {
+    // Annotation reads can throw on locked / external nodes; swallow so the
+    // sweep covers as much of the subtree as possible.
+  }
+  const children = (node as { children?: unknown }).children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      if (child && typeof child === "object") walk(child as FigmaNode, canicodeCategoryIds, out);
+    }
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -19,6 +19,7 @@ import type { RuleConfig, RuleId } from "../core/contracts/rule.js";
 import { initMonitoring, trackEvent, trackError, shutdownMonitoring, EVENTS } from "../core/monitoring/index.js";
 import { POSTHOG_API_KEY as BUILTIN_PH_KEY, SENTRY_DSN as BUILTIN_SENTRY_DSN } from "../core/monitoring/keys.js";
 import { getTelemetryEnabled, getPosthogApiKey, getSentryDsn, getDeviceId } from "../core/engine/config-store.js";
+import { AcknowledgmentSchema } from "../core/contracts/acknowledgment.js";
 
 // Load .env for FIGMA_TOKEN (quiet: suppress dotenv's stdout banner — MCP uses stdout for JSON-RPC)
 config({ quiet: true });
@@ -46,6 +47,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     targetNodeId: z.string().optional().describe("Scope analysis to a specific node ID"),
     configPath: z.string().optional().describe("Path to config JSON file for rule overrides"),
     openReport: z.boolean().optional().describe("Open the generated HTML report in the user's browser. Defaults to false — opt in only when a visible report is the explicit user request (#365). The HTML file is always written to disk regardless."),
+    acknowledgments: z.array(AcknowledgmentSchema).optional().describe("(#371) Pre-resolved [{ nodeId, ruleId }] pairs harvested from canicode-authored Figma annotations (e.g. via the `readCanicodeAcknowledgments` Plugin helper inside a use_figma batch). Matching issues are flagged `acknowledged: true` and contribute half weight to the density score so re-analyze surfaces movement after a roundtrip even under ADR-012's annotate-by-default policy."),
   },
   {
     readOnlyHint: false,
@@ -53,7 +55,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     openWorldHint: true,
     title: "Analyze Figma Design",
   },
-  async ({ input, token, preset, targetNodeId, configPath, openReport }) => {
+  async ({ input, token, preset, targetNodeId, configPath, openReport, acknowledgments }) => {
     trackEvent(EVENTS.MCP_TOOL_CALLED, { tool: "analyze" });
     try {
       // Fetch via REST API or load from fixture
@@ -73,6 +75,9 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
       const result = analyzeFile(file, {
         configs: configs as Record<RuleId, RuleConfig>,
         ...(effectiveNodeId ? { targetNodeId: effectiveNodeId } : {}),
+        ...(acknowledgments && acknowledgments.length > 0
+          ? { acknowledgments }
+          : {}),
       });
 
       const scores = calculateScores(result, configs as Record<RuleId, RuleConfig>);


### PR DESCRIPTION
Closes #371

## Why

Round-tripping currently writes Figma annotations for every gotcha that falls into the annotate / definition-write branches, but the follow-up `analyze` re-run treats those nodes as if nothing had changed. The grade only moves when the underlying property actually changes, so the wrap-up reads "Grade: C → C" even when a dozen issues now carry an authoritative designer note. From the user's side there is no visible delta — the annotation work feels invisible.

## What

Wires a side channel from the Plugin API back into the analysis pipeline so canicode-authored annotations are surfaced as **acknowledgments** during re-analysis.

### New contract (`src/core/contracts/acknowledgment.ts`)

- `AcknowledgmentSchema` = `{ nodeId, ruleId }`.
- `normalizeNodeId` converts Plugin-API ids (`123:45`) and REST ids (`123-45`) to the same key so the engine can match either input source.

### Plugin API helpers (`src/core/roundtrip/read-acknowledgments.ts`)

- `extractAcknowledgmentsFromNode(node, canicodeCategoryIds?)` — synchronous pure helper. Reads one node's annotations and returns one entry per markdown footer that matches the canicode pattern, gated by the canicode `categoryId` set returned from `ensureCanicodeCategories`.
- `readCanicodeAcknowledgments(rootNodeId, categories?)` — async tree walk. Loads `rootNodeId` via `figma.getNodeByIdAsync`, recurses through `children`, and accumulates entries.
- Recognised patterns:
  - **New**: trailing `— *<ruleId>*` footer (the format Step 4 writes).
  - **Legacy**: `**[canicode] <ruleId>**` prefix (pre-#355 roundtrips), so older files still benefit.
- Errors on individual nodes are swallowed so locked / external nodes don't abort the sweep.

### Engine + scoring (`src/core/engine/{rule-engine,scoring}.ts`)

- `RuleEngine` accepts an optional `acknowledgments` list, normalises the keys into a `Set`, and stamps `acknowledged: true` on any matching `AnalysisIssue`.
- `calculateScores` weights acknowledged issues at **0.5×** for the density score so the grade can move the way the user expects, while still surfacing the issue in reports.
- `summary.acknowledgedCount` joins the existing per-severity counts.
- `formatScoreSummary` shows `Total: N (A acknowledged via canicode annotations / B unaddressed)` when `acknowledgedCount > 0`.
- `buildResultJson` exposes `acknowledgedCount` at the top level and flags each acknowledged issue with `acknowledged: true`.

### Inputs

- **MCP**: `analyze` tool gains `acknowledgments: Array<{ nodeId, ruleId }>` (validated against `AcknowledgmentSchema`).
- **CLI**: `canicode analyze --acknowledgments <path>` reads a JSON file in the same shape.

### Skill flow (`.claude/skills/canicode-roundtrip/SKILL.md`)

Step 5 is split into two stages:

- **5a — Harvest**: `use_figma` batch calls `CanICodeRoundtrip.readCanicodeAcknowledgments(rootNodeId)` against the same root the analysis used.
- **5b — Re-analyze**: passes the harvested array straight to the `analyze` tool.

The wrap-up templates also split the remaining bucket so the user can see the delta:

```
V issues remaining
   ↳ V_ack acknowledged via canicode annotations (carried into code-gen)
   ↳ V_open unaddressed (no annotation — your follow-up backlog)
```

(Drops the split lines when `V_ack == 0` to keep the older minimal output for the no-annotation case.)

### Bundle

`helpers.js` is rebuilt so the Plugin-API helpers are bundled into the roundtrip skill IIFE next to the existing `probeDefinitionWritability` / `applyPropertyMod` exports.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test:run` — 912 / 912 (new tests cover the engine flag, the 0.5× density weighting, the JSON / summary output, the footer/legacy/categoryId match logic, and the tree-walk).
- [ ] Smoke: roundtrip on a real Figma section, confirm Step 5 shows non-zero `acknowledgedCount` and the wrap-up renders `V_ack / V_open`.

Made with [Cursor](https://cursor.com)