### PR TITLE
refactor(roundtrip+survey): extract Step 5 tally + canonical designKey + cleanup filter to TS per ADR-303 (#383, #384)

### DIFF
--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -98,14 +98,15 @@ After collecting all answers, **upsert** this design's section into the `# Colle
 
 This file goes in the **user's project** (current working directory), NOT in the canicode repo. The Workflow region above **must never be modified** — only the `# Collected Gotchas` region below is touched.
 
-#### Step 4a: Compute `designKey`
+#### Step 4a: Use the `designKey` from the survey response
 
-`designKey` uniquely identifies the design so re-running on the same URL replaces the existing section in place. Parse it from the survey input:
+`designKey` uniquely identifies the design so re-running on the same URL replaces the existing section in place. The survey response carries it on `survey.designKey` — read it directly. Do **not** parse the input URL in prose.
 
-- **Figma URL** — extract `fileKey` and `nodeId` from the URL and join them as `<fileKey>#<nodeId>`. Example: `https://figma.com/design/abc123XYZ/My-File?node-id=42-100` → `designKey = "abc123XYZ#42:100"` (convert `-` to `:` in nodeId, the same normalization the Figma MCP uses). Drop any other query-string parameters — only `node-id` matters for the key.
-- **Fixture path** — use the absolute path, e.g. `/Users/me/project/fixtures/simple.json`.
+The `core/contracts/design-key.ts` helper (`computeDesignKey`) handles every shape with vitest coverage so the SKILL stays ADR-303-compliant (PR #303):
 
-Do **not** use the raw survey input URL as the key: trailing query parameters (`?t=...`, `?mode=...`) break string matching on re-runs.
+- **Figma URL** → `<fileKey>#<nodeId>` with `-` → `:` normalization on the nodeId. Example: `https://figma.com/design/abc123XYZ/My-File?node-id=42-100&t=ref` → `designKey = "abc123XYZ#42:100"`. Trailing query parameters (`?t=...`, `?mode=...`) are dropped.
+- **Figma URL without `node-id`** → just `<fileKey>` (file-level key).
+- **Fixture path / JSON file** → absolute path.
 
 #### Step 4b: Read the existing file and locate the target section
 
@@ -154,7 +155,7 @@ Each per-design section in the `# Collected Gotchas` region has this exact shape
 | `designName` | Figma file name or fixture name from the input |
 | `YYYY-MM-DD` | Today's date (the day you are running the survey) |
 | `figmaUrl` | The input URL or fixture path provided by the user |
-| `designKey` | `<fileKey>#<nodeId>` for Figma URLs, absolute path for fixtures (see Step 4a) |
+| `designKey` | `survey.designKey` from the gotcha-survey response (see Step 4a) |
 | `designGrade` | `designGrade` from gotcha-survey response |
 | `analyzedAt` | Current timestamp (ISO 8601) |
 | `ruleId` | `ruleId` from each question |

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -160,7 +160,7 @@ Wait for the user's answer before moving to the next batch. For each batch, the 
 
 When applying the batched answer, expand back to per-question records before storing — the gotcha section format and Step 4 apply loop both expect one record per `nodeId`.
 
-After all questions are answered, **upsert this design's gotcha section** into `.claude/skills/canicode-gotchas/SKILL.md` in the user's project. Read the existing file, then either replace the section whose `Design key` matches this run (same Figma URL → fileKey+nodeId) or append a new numbered section under `# Collected Gotchas`. Never modify anything above the `# Collected Gotchas` heading — the region above it (frontmatter + workflow prose) is the skill loader contract installed by `canicode init`. See the `/canicode-gotchas` skill's "Upsert the gotcha section" step (Step 4) for the exact section format and matching rule.
+After all questions are answered, **upsert this design's gotcha section** into `.claude/skills/canicode-gotchas/SKILL.md` in the user's project. Read the existing file, then either replace the section whose `Design key` matches `survey.designKey` (the canonical identifier the gotcha-survey response carries — see `/canicode-gotchas` Step 4a) or append a new numbered section under `# Collected Gotchas`. Never modify anything above the `# Collected Gotchas` heading — the region above it (frontmatter + workflow prose) is the skill loader contract installed by `canicode init`. See the `/canicode-gotchas` skill's "Upsert the gotcha section" step (Step 4) for the exact section format and matching rule.
 
 Then proceed to **Step 4** to apply answers to the Figma design.
 
@@ -294,6 +294,7 @@ The probe is read-only and idempotent; running it before the picker adds one rou
    - `probeDefinitionWritability(questions)` — async pre-flight (#357). Returns `{ totalCount, unwritableCount, unwritableSourceNames, allUnwritable, partiallyUnwritable }`. Use BEFORE the Definition write picker so the picker can drop the opt-in branch when every candidate is in an external library / unresolved (saves the user a wasted "I opted in, why did I get annotations?" decision). Read-only probe, dedupes by `sourceChildId`.
    - `extractAcknowledgmentsFromNode(node, canicodeCategoryIds?)` — synchronous pure helper (#371). Reads one node's annotations and returns `{ nodeId, ruleId }[]` for entries gated by canicode `categoryId` plus a recognisable `— *<ruleId>*` footer (or legacy `**[canicode] <ruleId>**` prefix). When `canicodeCategoryIds` is omitted, footer-text matching alone is sufficient (test mode).
    - `readCanicodeAcknowledgments(rootNodeId, categories?)` — async tree walker (#371). Loads `rootNodeId` via `figma.getNodeByIdAsync`, recurses through `children`, and accumulates one acknowledgment per recognised entry. Used at the top of Step 5a to harvest the side channel that lets the analysis pipeline distinguish "still broken" from "the designer has a plan" — pass the result straight to `analyze({ acknowledgments })`. Errors on individual nodes are swallowed so locked / external nodes don't abort the sweep.
+   - `computeRoundtripTally({ stepFourReport, reanalyzeResponse })` — pure helper (#383). Takes the structured Step 4 outcome counts (`{ resolved, annotated, definitionWritten, skipped }`) plus a narrowed re-analyze view (`{ issueCount, acknowledgedCount }`) and returns `{ X, Y, Z, W, N, V, V_ack, V_open }`. Replaces the LLM-side emoji-bullet re-counting in Step 5 — render the returned object directly into the wrap-up templates. Throws when `acknowledgedCount > issueCount` (impossible state).
 
 Keep each `writeFn` small so a throw does not abort unrelated writes. Experiment 08 findings informed every branch in the bundled helpers, and the batch-level confirmation contract still applies *when opting in*: if the orchestrator passes `allowDefinitionWrite: true`, it must have already collected one confirmation covering every potential definition write in the batch. Under the default, no confirmation is needed — the helper annotates the scene instead of propagating.
 
@@ -440,7 +441,7 @@ for (const issue of analyzeResult.issues) {
 3. **Batch all annotations** (Strategy C + declined structural mods) into a single `use_figma` call — use `categories.gotcha` for the category id.
 4. **Batch all auto-fixes and annotations for lower-severity issues** (Strategy D) — use `categories.flag` for annotated ones (renamed from `autoFix` per #355 — the category means "flagged for designer attention", not "fixed"), `categories.fallback` is reserved for errors surfaced by `applyWithInstanceFallback` itself.
 
-After applying, report what was done:
+After applying, **emit a structured `stepFourReport`** alongside the human-readable per-question lines. Step 5 reads from this object — it does **not** re-parse the per-question lines (per ADR-303 / PR #303). Increment each counter as Strategy A/B/C/D complete:
 
 ```
 Applied {N} changes to the Figma design:
@@ -452,7 +453,16 @@ Applied {N} changes to the Figma design:
 - 📝 {nodeName}: annotation added to canicode:gotcha (absolute-position-in-auto-layout)
 - 🔧 {nodeName}: auto-fixed to "Hover" (non-standard-naming)
 - 📝 {nodeName}: annotation added to canicode:flag — raw color needs token binding (raw-value)
+
+stepFourReport = {
+  resolved: <count of ✅ + 🔧 + 🔗 lines>,        // scene writes, auto-fix renames, variable bindings
+  annotated: <count of 📝 lines>,                 // including ⏭️ declines that fell back to annotation
+  definitionWritten: <count of 🌐 lines>,         // only non-zero with allowDefinitionWrite: true
+  skipped: <count of ⏭️ lines + Step 3 skip/n/a>  // user-declined questions
+}
 ```
+
+Hold `stepFourReport` in scope through Step 5 — it is the input to `CanICodeRoundtrip.computeRoundtripTally` below.
 
 ### Step 5: Re-analyze and report what the roundtrip addressed
 
@@ -495,17 +505,19 @@ The response now carries:
 
 Under ADR-012's annotate-by-default policy, most instance-child gotchas route to 📝 annotations and do **not** move the numeric grade — but the half-weight density now produces a small visible movement when annotations are recognised. The headline for this step remains the **issues-delta** (what the roundtrip captured); grade movement is a secondary signal.
 
-**Tally inputs** — derive the counts from the data you already have:
-- `X` (✅ resolved): count of ✅ + 🔧 + 🔗 markers from the Step 4 report block you just emitted (scene/instance-child writes, auto-fix renames, and variable bindings all successfully landed the value).
-- `Y` (📝 annotated): count of 📝 markers from Step 4 — gotcha answers captured as Figma annotations for code-gen reference.
-- `Z` (🌐 definition writes): count of 🌐 markers from Step 4 — only non-zero when the orchestrator opted in with `allowDefinitionWrite: true` (helper context option, not a CLI flag).
-- `W` (⏭️ skipped): count of ⏭️ markers from Step 4 plus any Step 3 questions the user answered with `skip` or `n/a`.
-- `V` (remaining): `issues.length` from the re-analyze response — unresolved gotchas plus non-actionable rules still flagged by the design.
-- `V_ack` (acknowledged remaining): `acknowledgedCount` from the same response — issues that the design still surfaces but that carry a canicode annotation per Step 5a.
-- `V_open` (unaddressed remaining): `V - V_ack` — issues with no canicode annotation; the user's actual follow-up backlog.
-- `N` (addressed) = `X + Y + Z + W`.
+**Tally** — call `CanICodeRoundtrip.computeRoundtripTally` with the structured `stepFourReport` you assembled in Step 4 and the re-analyze response from Step 5b. The helper handles every count derivation (`N = X + Y + Z + W`, `V_open = V - V_ack`) and validates that `acknowledgedCount` cannot exceed `issueCount`. Render the returned `{ X, Y, Z, W, N, V, V_ack, V_open }` straight into the templates below — do **not** re-derive any of these from the Step 4 prose:
 
-If Step 4 produced no report block (e.g. user skipped every question, or no gotcha survey ran), all four counts are zero, `V_ack = 0`, and `V_open = V` — report the breakdown with zeros rather than treating it as an error. (Skipping Step 5a and passing no `acknowledgments` argument is also valid in this case — the response simply has `acknowledgedCount: 0`.)
+```javascript
+const tally = CanICodeRoundtrip.computeRoundtripTally({
+  stepFourReport,                  // the object emitted at the end of Step 4
+  reanalyzeResponse: {             // narrowed view of the re-analyze response
+    issueCount: response.issueCount,
+    acknowledgedCount: response.acknowledgedCount,
+  },
+});
+```
+
+If Step 4 produced no `stepFourReport` (e.g. user skipped every question, or no gotcha survey ran), pass an all-zero object — `tally.N === 0`, `tally.V_open === tally.V`, and the templates below render the breakdown with zeros rather than treating it as an error. (Skipping Step 5a and passing no `acknowledgments` argument is also valid in this case — the response simply has `acknowledgedCount: 0`.)
 
 **All gotcha issues resolved** (`V == 0`, i.e. re-analyze surfaces no remaining issues — note this is mostly independent of grade since ADR-012 annotations only move the score by the half-weight reduction enabled in Step 5b):
 - Tell the user (fill in the counts from the tally above):
@@ -589,7 +601,7 @@ Follow the **figma-implement-design** skill workflow to generate code from the F
 - Gotchas with severity **blocking** MUST be addressed — the design cannot be implemented correctly without this information
 - Gotchas with severity **risk** SHOULD be addressed — they indicate potential issues that will surface later
 - Reference the specific node IDs from gotcha answers to locate the affected elements in the design
-- Pass the Figma URL (or `designKey` = `<fileKey>#<nodeId>`) to `figma-implement-design` so it can grep the matching `## #NNN — …` section in `.claude/skills/canicode-gotchas/SKILL.md` instead of reading the whole accumulated file
+- Pass the Figma URL or `survey.designKey` to `figma-implement-design` so it can grep the matching `## #NNN — …` section in `.claude/skills/canicode-gotchas/SKILL.md` instead of reading the whole accumulated file
 
 **If all issues were resolved in Steps 4-5**, no additional gotcha context is needed — the design speaks for itself.
 

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -166,9 +166,7 @@ Then proceed to **Step 4** to apply answers to the Figma design.
 
 ### Step 4: Apply gotcha answers to Figma design
 
-Extract the `fileKey` from the Figma URL (format: `figma.com/design/:fileKey/...`).
-
-For each answered gotcha (skip questions answered with "skip" or "n/a"), branch on the pre-computed `question.applyStrategy`. The routing table, target properties, and instance-child resolution are resolved server-side by `canicode` — do NOT re-derive them from the rule id.
+For each answered gotcha (skip questions answered with "skip" or "n/a"), branch on the pre-computed `question.applyStrategy`. The routing table, target properties, and instance-child resolution are resolved server-side by `canicode` — do NOT re-derive them from the rule id. The `fileKey` is not needed at this step — the bundled helpers operate on `nodeId` directly.
 
 Use the **`nodeId` from the answered question**. When `question.isInstanceChild` is `true`, treat layout and size-constraint changes as **high impact**: applying them on the source definition affects **every instance** of that component in the file. Ask for explicit user confirmation before writing to the definition node.
 
@@ -295,6 +293,7 @@ The probe is read-only and idempotent; running it before the picker adds one rou
    - `extractAcknowledgmentsFromNode(node, canicodeCategoryIds?)` — synchronous pure helper (#371). Reads one node's annotations and returns `{ nodeId, ruleId }[]` for entries gated by canicode `categoryId` plus a recognisable `— *<ruleId>*` footer (or legacy `**[canicode] <ruleId>**` prefix). When `canicodeCategoryIds` is omitted, footer-text matching alone is sufficient (test mode).
    - `readCanicodeAcknowledgments(rootNodeId, categories?)` — async tree walker (#371). Loads `rootNodeId` via `figma.getNodeByIdAsync`, recurses through `children`, and accumulates one acknowledgment per recognised entry. Used at the top of Step 5a to harvest the side channel that lets the analysis pipeline distinguish "still broken" from "the designer has a plan" — pass the result straight to `analyze({ acknowledgments })`. Errors on individual nodes are swallowed so locked / external nodes don't abort the sweep.
    - `computeRoundtripTally({ stepFourReport, reanalyzeResponse })` — pure helper (#383). Takes the structured Step 4 outcome counts (`{ resolved, annotated, definitionWritten, skipped }`) plus a narrowed re-analyze view (`{ issueCount, acknowledgedCount }`) and returns `{ X, Y, Z, W, N, V, V_ack, V_open }`. Replaces the LLM-side emoji-bullet re-counting in Step 5 — render the returned object directly into the wrap-up templates. Throws when `acknowledgedCount > issueCount` (impossible state).
+   - `removeCanicodeAnnotations(annotations, categories)` — pure filter. Returns `annotations` with every canicode-authored entry removed (gates on `categories.gotcha` / `flag` / `fallback` / `legacyAutoFix` plus the legacy `**[canicode]` body prefix). Use after `stripAnnotations` in the Step 5 cleanup loop — replaces the inline filter predicate the SKILL used to carry. `isCanicodeAnnotation(annotation, categories)` is the single-entry version, exported for callers that need the predicate alone.
 
 Keep each `writeFn` small so a throw does not abort unrelated writes. Experiment 08 findings informed every branch in the bundled helpers, and the batch-level confirmation contract still applies *when opting in*: if the orchestrator passes `allowDefinitionWrite: true`, it must have already collected one confirmation covering every potential definition write in the batch. Under the default, no confirmation is needed — the helper annotates the scene instead of propagating.
 
@@ -533,18 +532,15 @@ If Step 4 produced no `stepFourReport` (e.g. user skipped every question, or no 
 
   Grade: {oldGrade} → {newGrade}. Ready for code generation.
   ```
-- Clean up canicode annotations on fixed nodes via `use_figma`. Filter by **categoryId** (the durable canicode-side identifier — the body no longer carries a `[canicode]` prefix per #353). Include `legacyAutoFix` if `ensureCanicodeCategories` returned it, so pre-#355 `canicode:auto-fix` entries get swept too. The trailing `— *<ruleId>*` footer is kept as a secondary marker for legacy `[canicode]`-prefix entries that may exist on files that have not been re-roundtripped yet:
+- Clean up canicode annotations on fixed nodes via `use_figma`. Use the bundled `removeCanicodeAnnotations` helper — it gates on **categoryId** (the durable canicode-side identifier — the body no longer carries a `[canicode]` prefix per #353), includes `legacyAutoFix` if `ensureCanicodeCategories` returned it (pre-#355 `canicode:auto-fix` sweep), and also matches the legacy `**[canicode]` body prefix as a secondary marker for entries on files that have not been re-roundtripped yet. The match logic lives in `src/core/roundtrip/remove-canicode-annotations.ts` with vitest coverage so prose stays ADR-303-compliant (PR #303):
 ```javascript
-const canicodeIds = new Set(
-  [categories.gotcha, categories.flag, categories.fallback, categories.legacyAutoFix].filter(Boolean)
-);
 const nodeIds = ["id1", "id2"]; // nodes that now pass
 for (const id of nodeIds) {
   const node = await figma.getNodeByIdAsync(id);
   if (node && "annotations" in node) {
-    node.annotations = CanICodeRoundtrip.stripAnnotations(node.annotations).filter(
-      a => !(a.categoryId && canicodeIds.has(a.categoryId)) &&
-           !a.labelMarkdown?.startsWith("**[canicode]")
+    node.annotations = CanICodeRoundtrip.removeCanicodeAnnotations(
+      CanICodeRoundtrip.stripAnnotations(node.annotations),
+      categories,
     );
   }
 }

--- a/.claude/skills/canicode-roundtrip/helpers.js
+++ b/.claude/skills/canicode-roundtrip/helpers.js
@@ -374,8 +374,31 @@ ${footer}`;
     }
   }
 
+  // src/core/roundtrip/compute-roundtrip-tally.ts
+  function computeRoundtripTally(args) {
+    const { stepFourReport, reanalyzeResponse } = args;
+    const { resolved, annotated, definitionWritten, skipped } = stepFourReport;
+    const { issueCount, acknowledgedCount } = reanalyzeResponse;
+    if (acknowledgedCount > issueCount) {
+      throw new Error(
+        `computeRoundtripTally: reanalyzeResponse.acknowledgedCount (${acknowledgedCount}) cannot exceed issueCount (${issueCount}). Acknowledged issues are a subset of remaining issues.`
+      );
+    }
+    return {
+      X: resolved,
+      Y: annotated,
+      Z: definitionWritten,
+      W: skipped,
+      N: resolved + annotated + definitionWritten + skipped,
+      V: issueCount,
+      V_ack: acknowledgedCount,
+      V_open: issueCount - acknowledgedCount
+    };
+  }
+
   exports.applyPropertyMod = applyPropertyMod;
   exports.applyWithInstanceFallback = applyWithInstanceFallback;
+  exports.computeRoundtripTally = computeRoundtripTally;
   exports.ensureCanicodeCategories = ensureCanicodeCategories;
   exports.extractAcknowledgmentsFromNode = extractAcknowledgmentsFromNode;
   exports.probeDefinitionWritability = probeDefinitionWritability;

--- a/.claude/skills/canicode-roundtrip/helpers.js
+++ b/.claude/skills/canicode-roundtrip/helpers.js
@@ -396,13 +396,38 @@ ${footer}`;
     };
   }
 
+  // src/core/roundtrip/remove-canicode-annotations.ts
+  var LEGACY_CANICODE_PREFIX = "**[canicode]";
+  function isCanicodeAnnotation(annotation, categories) {
+    const canicodeIds = new Set(
+      [
+        categories.gotcha,
+        categories.flag,
+        categories.fallback,
+        categories.legacyAutoFix
+      ].filter((id) => Boolean(id))
+    );
+    if (annotation.categoryId && canicodeIds.has(annotation.categoryId)) {
+      return true;
+    }
+    if (annotation.labelMarkdown?.startsWith(LEGACY_CANICODE_PREFIX)) {
+      return true;
+    }
+    return false;
+  }
+  function removeCanicodeAnnotations(annotations, categories) {
+    return annotations.filter((a) => !isCanicodeAnnotation(a, categories));
+  }
+
   exports.applyPropertyMod = applyPropertyMod;
   exports.applyWithInstanceFallback = applyWithInstanceFallback;
   exports.computeRoundtripTally = computeRoundtripTally;
   exports.ensureCanicodeCategories = ensureCanicodeCategories;
   exports.extractAcknowledgmentsFromNode = extractAcknowledgmentsFromNode;
+  exports.isCanicodeAnnotation = isCanicodeAnnotation;
   exports.probeDefinitionWritability = probeDefinitionWritability;
   exports.readCanicodeAcknowledgments = readCanicodeAcknowledgments;
+  exports.removeCanicodeAnnotations = removeCanicodeAnnotations;
   exports.resolveVariableByName = resolveVariableByName;
   exports.stripAnnotations = stripAnnotations;
   exports.upsertCanicodeAnnotation = upsertCanicodeAnnotation;

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -15,6 +15,7 @@ import {
   getFigmaToken, getReportsDir, ensureReportsDir,
 } from "../../core/engine/config-store.js";
 import { calculateScores, formatScoreSummary, buildResultJson } from "../../core/engine/scoring.js";
+import { computeDesignKey } from "../../core/contracts/design-key.js";
 import { getConfigsWithPreset, RULE_CONFIGS } from "../../core/rules/rule-config.js";
 import { loadConfigFile, mergeConfigs } from "../../core/rules/config-loader.js";
 import { generateHtmlReport } from "../../core/report-html/index.js";
@@ -165,7 +166,7 @@ export function registerAnalyze(cli: CAC): void {
 
         // JSON output mode — only JSON goes to stdout; exit code still applies
         if (options.json) {
-          console.log(JSON.stringify(buildResultJson(file.name, result, scores, { fileKey: file.fileKey }), null, 2));
+          console.log(JSON.stringify(buildResultJson(file.name, result, scores, { fileKey: file.fileKey, designKey: computeDesignKey(input) }), null, 2));
           if (scores.overall.grade === "F") {
             process.exitCode = 1;
           }

--- a/src/cli/commands/gotcha-survey.ts
+++ b/src/cli/commands/gotcha-survey.ts
@@ -8,6 +8,7 @@ import { loadFile, isJsonFile, isFixtureDir } from "../../core/engine/loader.js"
 import { getFigmaToken } from "../../core/engine/config-store.js";
 import { calculateScores } from "../../core/engine/scoring.js";
 import { generateGotchaSurvey } from "../../core/gotcha/survey-generator.js";
+import { computeDesignKey } from "../../core/contracts/design-key.js";
 import { getConfigsWithPreset, RULE_CONFIGS } from "../../core/rules/rule-config.js";
 import { loadConfigFile, mergeConfigs } from "../../core/rules/config-loader.js";
 import { trackEvent, trackError, EVENTS } from "../../core/monitoring/index.js";
@@ -49,7 +50,7 @@ export async function runGotchaSurvey(
   });
 
   const scores = calculateScores(result, configs as Record<RuleId, RuleConfig>);
-  return generateGotchaSurvey(result, scores);
+  return generateGotchaSurvey(result, scores, { designKey: computeDesignKey(input) });
 }
 
 function formatHumanSummary(survey: GotchaSurvey): string {

--- a/src/core/contracts/design-key.test.ts
+++ b/src/core/contracts/design-key.test.ts
@@ -1,0 +1,99 @@
+import { resolve } from "node:path";
+import { computeDesignKey } from "./design-key.js";
+
+describe("computeDesignKey", () => {
+  describe("Figma URLs", () => {
+    it("returns <fileKey>#<nodeId> for a /design URL with node-id", () => {
+      expect(
+        computeDesignKey(
+          "https://www.figma.com/design/abc123XYZ/My-File?node-id=42-100",
+        ),
+      ).toBe("abc123XYZ#42:100");
+    });
+
+    it("normalizes hyphens in node-id to colons (Figma MCP convention)", () => {
+      expect(
+        computeDesignKey(
+          "https://www.figma.com/design/abc/file?node-id=1442-7704",
+        ),
+      ).toBe("abc#1442:7704");
+    });
+
+    it("works with the legacy /file/ URL shape", () => {
+      expect(
+        computeDesignKey(
+          "https://www.figma.com/file/abc123/My-File?node-id=10-20",
+        ),
+      ).toBe("abc123#10:20");
+    });
+
+    it("works with the /proto/ URL shape", () => {
+      expect(
+        computeDesignKey(
+          "https://www.figma.com/proto/abc123/My-File?node-id=10-20",
+        ),
+      ).toBe("abc123#10:20");
+    });
+
+    it("drops other query parameters before computing the key", () => {
+      const withTimestamp = computeDesignKey(
+        "https://www.figma.com/design/abc/file?node-id=42-100&t=2bMe9JywGwbeF7Ec-4",
+      );
+      expect(withTimestamp).toBe("abc#42:100");
+
+      const withMode = computeDesignKey(
+        "https://www.figma.com/design/abc/file?mode=dev&node-id=42-100",
+      );
+      expect(withMode).toBe("abc#42:100");
+    });
+
+    it("returns just the fileKey when the URL has no node-id", () => {
+      expect(
+        computeDesignKey("https://www.figma.com/design/abc123/My-File"),
+      ).toBe("abc123");
+    });
+
+    it("preserves an already-colon-formatted node-id", () => {
+      // The URL shape `?node-id=42:100` is uncommon (Figma uses hyphens) but
+      // possible — round-tripping the colon shouldn't break it.
+      expect(
+        computeDesignKey("https://www.figma.com/design/abc/file?node-id=42:100"),
+      ).toBe("abc#42:100");
+    });
+
+    it("handles instance-internal IDs verbatim once normalized", () => {
+      // I-prefixed ids are kept; the Comments-API-friendly stripping lives
+      // elsewhere (toCommentableNodeId) and is intentionally out of scope
+      // here — the design key is a substring-match identifier, not a
+      // commentable node id.
+      expect(
+        computeDesignKey(
+          "https://www.figma.com/design/abc/file?node-id=I3010-7457",
+        ),
+      ).toBe("abc#I3010:7457");
+    });
+  });
+
+  describe("non-Figma inputs (fixtures / JSON paths / raw names)", () => {
+    it("resolves a relative fixture directory to an absolute path", () => {
+      expect(computeDesignKey("fixtures/simple")).toBe(
+        resolve("fixtures/simple"),
+      );
+    });
+
+    it("resolves a relative JSON file to an absolute path", () => {
+      expect(computeDesignKey("./fixtures/simple/data.json")).toBe(
+        resolve("./fixtures/simple/data.json"),
+      );
+    });
+
+    it("returns absolute paths unchanged", () => {
+      const absolute = "/Users/me/project/fixtures/simple/data.json";
+      expect(computeDesignKey(absolute)).toBe(absolute);
+    });
+
+    it("resolves any non-URL string (raw name) against cwd", () => {
+      expect(computeDesignKey("scratch")).toBe(resolve("scratch"));
+    });
+  });
+});

--- a/src/core/contracts/design-key.ts
+++ b/src/core/contracts/design-key.ts
@@ -1,0 +1,44 @@
+import { resolve } from "node:path";
+import { z } from "zod";
+import { parseFigmaUrl } from "../adapters/figma-url-parser.js";
+
+/**
+ * Local copy of `isFigmaUrl` (lives in `core/engine/loader.ts`). Inlined to
+ * avoid a contracts/ → engine/ dependency cycle: contracts/ is meant to be
+ * importable by every other layer, including engine/.
+ */
+function isFigmaUrl(input: string): boolean {
+  return input.includes("figma.com/");
+}
+
+export const DesignKeySchema = z.string();
+export type DesignKey = z.infer<typeof DesignKeySchema>;
+
+/**
+ * Compute the canonical `designKey` that uniquely identifies a design across
+ * canicode runs.
+ *
+ * - **Figma URL** → `<fileKey>#<nodeId>` with `-` → `:` normalization on the
+ *   nodeId (matching the Figma MCP convention). Example:
+ *   `https://figma.com/design/abc123/My-File?node-id=42-100&t=ref` →
+ *   `abc123#42:100`. Trailing query parameters other than `node-id`
+ *   (`?t=...`, `?mode=...`) are dropped — they would otherwise break
+ *   string-matching on re-runs.
+ * - **Figma URL without `node-id`** → just `<fileKey>` (file-level key).
+ * - **Anything else** (fixture directory, JSON path, raw filename) →
+ *   absolute path via `node:path.resolve(input)`. Keeps fixture-based
+ *   smoke tests stable across cwd.
+ *
+ * Both `gotcha-survey` and `analyze` MCP/CLI tools surface the result on
+ * their response's top-level `designKey` field. The `canicode-gotchas` and
+ * `canicode-roundtrip` SKILLs read that field directly — neither one
+ * re-implements URL parsing in prose anymore (per ADR-303 / PR #303).
+ */
+export function computeDesignKey(input: string): string {
+  if (isFigmaUrl(input)) {
+    const { fileKey, nodeId } = parseFigmaUrl(input);
+    if (!nodeId) return fileKey;
+    return `${fileKey}#${nodeId.replace(/-/g, ":")}`;
+  }
+  return resolve(input);
+}

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -119,6 +119,14 @@ export const GotchaSurveySchema = z.object({
   isReadyForCodeGen: z.boolean(),
   questions: z.array(GotchaSurveyQuestionSchema),
   groupedQuestions: GroupedSurveySchema,
+  /**
+   * #384 — canonical identifier for this design across canicode runs.
+   * Computed by `computeDesignKey(input)` (`<fileKey>#<nodeId>` for Figma
+   * URLs, absolute path for fixtures). The `canicode-gotchas` SKILL reads
+   * this directly when upserting the per-design section, so the SKILL.md
+   * prose no longer parses URLs (per ADR-303 / PR #303).
+   */
+  designKey: z.string(),
 });
 
 export type GotchaSurvey = z.infer<typeof GotchaSurveySchema>;

--- a/src/core/contracts/roundtrip-tally.ts
+++ b/src/core/contracts/roundtrip-tally.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+
+/**
+ * Structured per-question outcome counts the `canicode-roundtrip` SKILL
+ * accumulates as Strategy A / B / C / D execute on each question in Step 4.
+ * Replaces the free-form `✅ X / 📝 Y / 🌐 Z / ⏭️ W` emoji bullets the
+ * Step 5 wrap-up used to re-parse from the LLM's own previous output —
+ * see ADR-303 / PR #303.
+ */
+export const StepFourReportSchema = z.object({
+  /** ✅ — Strategy A property write (or A's auto-fix branch) succeeded. */
+  resolved: z.number().int().min(0),
+  /** 📝 — Strategy C wrote a Figma annotation (or A/B fell back to one). */
+  annotated: z.number().int().min(0),
+  /**
+   * 🌐 — `applyWithInstanceFallback` propagated the write up to the
+   * source COMPONENT definition (only counted when
+   * `allowDefinitionWrite: true`).
+   */
+  definitionWritten: z.number().int().min(0),
+  /**
+   * ⏭️ — User said "skip", "n/a", or otherwise declined a per-question
+   * confirmation (Strategy B opt-out, etc.).
+   */
+  skipped: z.number().int().min(0),
+});
+
+export type StepFourReport = z.infer<typeof StepFourReportSchema>;
+
+/**
+ * The two fields `computeRoundtripTally` reads from the post-Step-5b
+ * re-analyze response. Kept narrow on purpose — the helper doesn't need
+ * grade movement, per-rule breakdowns, or the issues array, just enough
+ * to derive `V`, `V_ack`, and `V_open`.
+ */
+export const ReanalyzeForTallySchema = z.object({
+  /**
+   * Total remaining issues from the re-analyze. Maps to the existing
+   * `issueCount` (analyze JSON) / `questions.length` (gotcha-survey JSON)
+   * field — both downstream channels populate it.
+   */
+  issueCount: z.number().int().min(0),
+  /**
+   * Issues the re-analyze flagged with `acknowledged: true` because they
+   * matched a canicode-authored Figma annotation harvested in Step 5a.
+   * From the analyze response's top-level `acknowledgedCount` (#371).
+   */
+  acknowledgedCount: z.number().int().min(0),
+});
+
+export type ReanalyzeForTally = z.infer<typeof ReanalyzeForTallySchema>;
+
+export const RoundtripTallySchema = z.object({
+  /** ✅ resolved (passthrough from `stepFourReport.resolved`). */
+  X: z.number().int().min(0),
+  /** 📝 annotated. */
+  Y: z.number().int().min(0),
+  /** 🌐 definition writes propagated. */
+  Z: z.number().int().min(0),
+  /** ⏭️ skipped. */
+  W: z.number().int().min(0),
+  /** `X + Y + Z + W` — questions the SKILL acted on in Step 4. */
+  N: z.number().int().min(0),
+  /** `reanalyzeResponse.issueCount` — total remaining after re-analyze. */
+  V: z.number().int().min(0),
+  /**
+   * `reanalyzeResponse.acknowledgedCount` — the slice of `V` that carries
+   * a canicode annotation (counted at half weight by the density score
+   * per #371, but still surfaced as remaining).
+   */
+  V_ack: z.number().int().min(0),
+  /** `V - V_ack` — issues with no annotation; the user's follow-up backlog. */
+  V_open: z.number().int().min(0),
+});
+
+export type RoundtripTally = z.infer<typeof RoundtripTallySchema>;

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -425,7 +425,7 @@ export function buildResultJson(
   fileName: string,
   result: AnalysisResult,
   scores: ScoreReport,
-  options?: { fileKey?: string },
+  options?: { fileKey?: string; designKey?: string },
 ): Record<string, unknown> {
   const issuesByRule: Record<string, number> = {};
   for (const issue of result.issues) {
@@ -463,6 +463,7 @@ export function buildResultJson(
     version: VERSION,
     analyzedAt: result.analyzedAt,
     ...(options?.fileKey && { fileKey: options.fileKey }),
+    ...(options?.designKey && { designKey: options.designKey }),
     fileName,
     nodeCount: result.nodeCount,
     maxDepth: result.maxDepth,

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -141,6 +141,21 @@ describe("generateGotchaSurvey", () => {
     expect(survey.isReadyForCodeGen).toBe(true);
   });
 
+  it("passes the caller-supplied designKey through to the response (#384)", () => {
+    const survey = generateGotchaSurvey(
+      makeResult([]),
+      makeScoreReport("S"),
+      { designKey: "abc123XYZ#42:100" },
+    );
+
+    expect(survey.designKey).toBe("abc123XYZ#42:100");
+  });
+
+  it("falls back to an empty designKey when no options are provided (test ergonomics)", () => {
+    const survey = generateGotchaSurvey(makeResult([]), makeScoreReport("S"));
+    expect(survey.designKey).toBe("");
+  });
+
   it("includes only blocking and risk severity issues", () => {
     const issues = [
       makeIssue({

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -29,6 +29,7 @@ const NODE_PATH_SEPARATOR = " > ";
 export function generateGotchaSurvey(
   result: AnalysisResult,
   scores: ScoreReport,
+  options: { designKey?: string } = {},
 ): GotchaSurvey {
   const grade = scores.overall.grade;
 
@@ -69,6 +70,7 @@ export function generateGotchaSurvey(
     isReadyForCodeGen: isReadyForCodeGen(grade),
     questions,
     groupedQuestions,
+    designKey: options.designKey ?? "",
   };
 }
 

--- a/src/core/roundtrip/compute-roundtrip-tally.test.ts
+++ b/src/core/roundtrip/compute-roundtrip-tally.test.ts
@@ -1,0 +1,106 @@
+import { computeRoundtripTally } from "./compute-roundtrip-tally.js";
+
+describe("computeRoundtripTally", () => {
+  it("passes the four Step-4 counts through to X/Y/Z/W and sums them as N", () => {
+    const tally = computeRoundtripTally({
+      stepFourReport: {
+        resolved: 3,
+        annotated: 5,
+        definitionWritten: 2,
+        skipped: 1,
+      },
+      reanalyzeResponse: { issueCount: 0, acknowledgedCount: 0 },
+    });
+
+    expect(tally.X).toBe(3);
+    expect(tally.Y).toBe(5);
+    expect(tally.Z).toBe(2);
+    expect(tally.W).toBe(1);
+    expect(tally.N).toBe(3 + 5 + 2 + 1);
+  });
+
+  it("derives V / V_ack / V_open from the re-analyze response", () => {
+    const tally = computeRoundtripTally({
+      stepFourReport: {
+        resolved: 0,
+        annotated: 4,
+        definitionWritten: 0,
+        skipped: 0,
+      },
+      reanalyzeResponse: { issueCount: 7, acknowledgedCount: 3 },
+    });
+
+    expect(tally.V).toBe(7);
+    expect(tally.V_ack).toBe(3);
+    expect(tally.V_open).toBe(4);
+  });
+
+  it("returns all-zero counts when nothing happened (empty roundtrip)", () => {
+    const tally = computeRoundtripTally({
+      stepFourReport: {
+        resolved: 0,
+        annotated: 0,
+        definitionWritten: 0,
+        skipped: 0,
+      },
+      reanalyzeResponse: { issueCount: 0, acknowledgedCount: 0 },
+    });
+
+    expect(tally).toEqual({
+      X: 0,
+      Y: 0,
+      Z: 0,
+      W: 0,
+      N: 0,
+      V: 0,
+      V_ack: 0,
+      V_open: 0,
+    });
+  });
+
+  it("returns V_open === V when the re-analyze surfaces no acknowledgments", () => {
+    const tally = computeRoundtripTally({
+      stepFourReport: {
+        resolved: 1,
+        annotated: 0,
+        definitionWritten: 0,
+        skipped: 0,
+      },
+      reanalyzeResponse: { issueCount: 5, acknowledgedCount: 0 },
+    });
+
+    expect(tally.V).toBe(5);
+    expect(tally.V_ack).toBe(0);
+    expect(tally.V_open).toBe(5);
+  });
+
+  it("returns V_open === 0 when every remaining issue is acknowledged", () => {
+    const tally = computeRoundtripTally({
+      stepFourReport: {
+        resolved: 0,
+        annotated: 4,
+        definitionWritten: 0,
+        skipped: 0,
+      },
+      reanalyzeResponse: { issueCount: 4, acknowledgedCount: 4 },
+    });
+
+    expect(tally.V).toBe(4);
+    expect(tally.V_ack).toBe(4);
+    expect(tally.V_open).toBe(0);
+  });
+
+  it("throws when acknowledgedCount exceeds issueCount (impossible state)", () => {
+    expect(() =>
+      computeRoundtripTally({
+        stepFourReport: {
+          resolved: 0,
+          annotated: 0,
+          definitionWritten: 0,
+          skipped: 0,
+        },
+        reanalyzeResponse: { issueCount: 3, acknowledgedCount: 5 },
+      }),
+    ).toThrow(/cannot exceed issueCount/);
+  });
+});

--- a/src/core/roundtrip/compute-roundtrip-tally.ts
+++ b/src/core/roundtrip/compute-roundtrip-tally.ts
@@ -1,0 +1,48 @@
+import type {
+  ReanalyzeForTally,
+  RoundtripTally,
+  StepFourReport,
+} from "../contracts/roundtrip-tally.js";
+
+/**
+ * Combine the structured Step 4 outcome counts with the re-analyze
+ * response into the final `RoundtripTally` the SKILL renders in the
+ * Step 5 wrap-up.
+ *
+ * The previous shape asked the LLM to count its own emoji bullets — the
+ * highest-risk drift surface in the entire skill, since one missed `📝`
+ * silently undercounts the annotated total. By emitting the structured
+ * `stepFourReport` as Strategy A/B/C/D execute and then calling this
+ * helper at the top of Step 5, every count is derived from explicit data,
+ * not the LLM's re-parse of its own prose. ADR-303 / PR #303.
+ *
+ * Throws when `reanalyzeResponse.acknowledgedCount > issueCount` — that
+ * shape is impossible (acknowledged issues are a subset of remaining
+ * issues), so seeing it means an upstream serialization bug rather than
+ * a render-time defensive concern.
+ */
+export function computeRoundtripTally(args: {
+  stepFourReport: StepFourReport;
+  reanalyzeResponse: ReanalyzeForTally;
+}): RoundtripTally {
+  const { stepFourReport, reanalyzeResponse } = args;
+  const { resolved, annotated, definitionWritten, skipped } = stepFourReport;
+  const { issueCount, acknowledgedCount } = reanalyzeResponse;
+
+  if (acknowledgedCount > issueCount) {
+    throw new Error(
+      `computeRoundtripTally: reanalyzeResponse.acknowledgedCount (${acknowledgedCount}) cannot exceed issueCount (${issueCount}). Acknowledged issues are a subset of remaining issues.`,
+    );
+  }
+
+  return {
+    X: resolved,
+    Y: annotated,
+    Z: definitionWritten,
+    W: skipped,
+    N: resolved + annotated + definitionWritten + skipped,
+    V: issueCount,
+    V_ack: acknowledgedCount,
+    V_open: issueCount - acknowledgedCount,
+  };
+}

--- a/src/core/roundtrip/index.ts
+++ b/src/core/roundtrip/index.ts
@@ -14,3 +14,4 @@ export {
   extractAcknowledgmentsFromNode,
   readCanicodeAcknowledgments,
 } from "./read-acknowledgments.js";
+export { computeRoundtripTally } from "./compute-roundtrip-tally.js";

--- a/src/core/roundtrip/index.ts
+++ b/src/core/roundtrip/index.ts
@@ -15,3 +15,7 @@ export {
   readCanicodeAcknowledgments,
 } from "./read-acknowledgments.js";
 export { computeRoundtripTally } from "./compute-roundtrip-tally.js";
+export {
+  isCanicodeAnnotation,
+  removeCanicodeAnnotations,
+} from "./remove-canicode-annotations.js";

--- a/src/core/roundtrip/remove-canicode-annotations.test.ts
+++ b/src/core/roundtrip/remove-canicode-annotations.test.ts
@@ -1,0 +1,137 @@
+import {
+  isCanicodeAnnotation,
+  removeCanicodeAnnotations,
+} from "./remove-canicode-annotations.js";
+
+const CATEGORIES = {
+  gotcha: "cat-gotcha",
+  flag: "cat-flag",
+  fallback: "cat-fallback",
+};
+
+const CATEGORIES_WITH_LEGACY = {
+  ...CATEGORIES,
+  legacyAutoFix: "cat-legacy-auto-fix",
+};
+
+describe("isCanicodeAnnotation", () => {
+  it("matches annotations whose categoryId is in the canicode set", () => {
+    expect(
+      isCanicodeAnnotation({ categoryId: "cat-gotcha" }, CATEGORIES),
+    ).toBe(true);
+    expect(isCanicodeAnnotation({ categoryId: "cat-flag" }, CATEGORIES)).toBe(
+      true,
+    );
+    expect(
+      isCanicodeAnnotation({ categoryId: "cat-fallback" }, CATEGORIES),
+    ).toBe(true);
+  });
+
+  it("matches the legacy auto-fix category only when the file carries it", () => {
+    const legacy = { categoryId: "cat-legacy-auto-fix" };
+
+    expect(isCanicodeAnnotation(legacy, CATEGORIES)).toBe(false);
+    expect(isCanicodeAnnotation(legacy, CATEGORIES_WITH_LEGACY)).toBe(true);
+  });
+
+  it("matches annotations whose body still starts with the legacy [canicode] prefix", () => {
+    expect(
+      isCanicodeAnnotation(
+        { labelMarkdown: "**[canicode] missing-size-constraint** — ..." },
+        CATEGORIES,
+      ),
+    ).toBe(true);
+  });
+
+  it("matches the legacy prefix even when categoryId is absent (pre-#353 entries)", () => {
+    expect(
+      isCanicodeAnnotation(
+        { labelMarkdown: "**[canicode] non-semantic-name**" },
+        CATEGORIES,
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves user-authored annotations with no canicode signals", () => {
+    expect(
+      isCanicodeAnnotation(
+        { categoryId: "cat-user", labelMarkdown: "TODO: revisit copy" },
+        CATEGORIES,
+      ),
+    ).toBe(false);
+  });
+
+  it("preserves third-party annotations whose body merely mentions canicode", () => {
+    expect(
+      isCanicodeAnnotation(
+        {
+          categoryId: "cat-other-plugin",
+          labelMarkdown: "Note: canicode flagged this earlier — keep for ref",
+        },
+        CATEGORIES,
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores empty / missing categories on the input map", () => {
+    expect(isCanicodeAnnotation({ categoryId: "" }, CATEGORIES)).toBe(false);
+    expect(isCanicodeAnnotation({}, CATEGORIES)).toBe(false);
+  });
+});
+
+describe("removeCanicodeAnnotations", () => {
+  it("removes every canicode-authored entry and preserves the rest", () => {
+    const input = [
+      { categoryId: "cat-gotcha", labelMarkdown: "Gotcha note" },
+      { categoryId: "cat-user", labelMarkdown: "Designer note" },
+      { categoryId: "cat-flag", labelMarkdown: "Flag note" },
+      { labelMarkdown: "**[canicode] non-semantic-name** — legacy entry" },
+      { categoryId: "cat-other-plugin", labelMarkdown: "Plugin note" },
+    ];
+
+    const result = removeCanicodeAnnotations(input, CATEGORIES);
+
+    expect(result).toEqual([
+      { categoryId: "cat-user", labelMarkdown: "Designer note" },
+      { categoryId: "cat-other-plugin", labelMarkdown: "Plugin note" },
+    ]);
+  });
+
+  it("returns an empty array when every annotation was canicode-authored", () => {
+    const input = [
+      { categoryId: "cat-gotcha" },
+      { categoryId: "cat-flag" },
+      { categoryId: "cat-fallback" },
+      { labelMarkdown: "**[canicode] missing-component**" },
+    ];
+
+    expect(removeCanicodeAnnotations(input, CATEGORIES)).toEqual([]);
+  });
+
+  it("returns an empty array unchanged for empty input", () => {
+    expect(removeCanicodeAnnotations([], CATEGORIES)).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      { categoryId: "cat-gotcha" },
+      { categoryId: "cat-user" },
+    ];
+    const snapshot = [...input];
+
+    removeCanicodeAnnotations(input, CATEGORIES);
+
+    expect(input).toEqual(snapshot);
+  });
+
+  it("sweeps legacy auto-fix entries when categories carries the id (pre-#355 roundtrip files)", () => {
+    const input = [
+      { categoryId: "cat-legacy-auto-fix", labelMarkdown: "old auto-fix" },
+      { categoryId: "cat-user", labelMarkdown: "designer note" },
+    ];
+
+    expect(removeCanicodeAnnotations(input, CATEGORIES_WITH_LEGACY)).toEqual([
+      { categoryId: "cat-user", labelMarkdown: "designer note" },
+    ]);
+  });
+});

--- a/src/core/roundtrip/remove-canicode-annotations.ts
+++ b/src/core/roundtrip/remove-canicode-annotations.ts
@@ -1,0 +1,79 @@
+/**
+ * Predicate + filter for sweeping canicode-authored annotations off a node.
+ *
+ * The Step 5 cleanup loop in `canicode-roundtrip/SKILL.md` used to inline
+ * this filter as a JS one-liner inside the `use_figma` batch — `(a => !(a.categoryId
+ * && canicodeIds.has(a.categoryId)) && !a.labelMarkdown?.startsWith("**[canicode]"))`.
+ * That counted as deterministic logic re-derived by the LLM each session
+ * (and the legacy-prefix branch already broke once when ADR-353 dropped
+ * the `**[canicode]` prefix) so it now lives here with vitest coverage,
+ * per ADR-303 / PR #303.
+ *
+ * The contract:
+ * - Strip every annotation whose `categoryId` is in the canicode-owned
+ *   category set (`gotcha`, `flag`, `fallback`, plus the legacy
+ *   `legacyAutoFix` when present on this file from a pre-#355 roundtrip).
+ *   `categoryId` is the durable canicode-side identifier — the body no
+ *   longer carries a `[canicode]` prefix per #353, so the categoryId guard
+ *   is the primary signal.
+ * - Also strip annotations whose body still starts with the legacy
+ *   `**[canicode]` prefix — these survive on files that have not been
+ *   re-roundtripped since #353. Keeping the prefix branch lets one
+ *   sweep handle both shapes.
+ * - Preserve every other annotation (user-authored notes, third-party
+ *   plugins, etc.) verbatim.
+ */
+
+interface CanicodeCategoriesLike {
+  gotcha?: string;
+  flag?: string;
+  fallback?: string;
+  legacyAutoFix?: string;
+}
+
+interface AnnotationLike {
+  categoryId?: string | undefined;
+  labelMarkdown?: string | undefined;
+}
+
+const LEGACY_CANICODE_PREFIX = "**[canicode]";
+
+/**
+ * Returns true when this annotation was authored by canicode (Step 4
+ * Strategy C / D / fallback) and should be removed by the Step 5 cleanup.
+ */
+export function isCanicodeAnnotation(
+  annotation: AnnotationLike,
+  categories: CanicodeCategoriesLike,
+): boolean {
+  const canicodeIds = new Set(
+    [
+      categories.gotcha,
+      categories.flag,
+      categories.fallback,
+      categories.legacyAutoFix,
+    ].filter((id): id is string => Boolean(id)),
+  );
+
+  if (annotation.categoryId && canicodeIds.has(annotation.categoryId)) {
+    return true;
+  }
+
+  if (annotation.labelMarkdown?.startsWith(LEGACY_CANICODE_PREFIX)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Filter helper — returns the input annotations array with every
+ * canicode-authored entry removed. Use after `stripAnnotations` has
+ * normalised the D1 label/labelMarkdown mutex.
+ */
+export function removeCanicodeAnnotations<T extends AnnotationLike>(
+  annotations: readonly T[],
+  categories: CanicodeCategoriesLike,
+): T[] {
+  return annotations.filter((a) => !isCanicodeAnnotation(a, categories));
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,7 @@ import { initMonitoring, trackEvent, trackError, shutdownMonitoring, EVENTS } fr
 import { POSTHOG_API_KEY as BUILTIN_PH_KEY, SENTRY_DSN as BUILTIN_SENTRY_DSN } from "../core/monitoring/keys.js";
 import { getTelemetryEnabled, getPosthogApiKey, getSentryDsn, getDeviceId } from "../core/engine/config-store.js";
 import { AcknowledgmentSchema } from "../core/contracts/acknowledgment.js";
+import { computeDesignKey } from "../core/contracts/design-key.js";
 
 // Load .env for FIGMA_TOKEN (quiet: suppress dotenv's stdout banner — MCP uses stdout for JSON-RPC)
 config({ quiet: true });
@@ -120,7 +121,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(buildResultJson(file.name, result, scores, { fileKey: file.fileKey }), null, 2),
+            text: JSON.stringify(buildResultJson(file.name, result, scores, { fileKey: file.fileKey, designKey: computeDesignKey(input) }), null, 2),
           },
         ],
       };
@@ -188,7 +189,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
       });
 
       const scores = calculateScores(result, configs as Record<RuleId, RuleConfig>);
-      const survey = generateGotchaSurvey(result, scores);
+      const survey = generateGotchaSurvey(result, scores, { designKey: computeDesignKey(input) });
 
       trackEvent(EVENTS.ANALYSIS_COMPLETED, {
         nodeCount: result.nodeCount,


### PR DESCRIPTION
## Summary

Closes #383, #384, and folds in two further ADR-303 / PR #303 violations surfaced by a post-implementation audit of the two SKILLs. Per the user direction, the ADR-303 "deterministic logic in TypeScript with vitest coverage, prose just orchestrates" rule is enforced across **four** surfaces in this PR:

| # | Issue | Helper landed | Channel |
|---|-------|---------------|---------|
| 1 | #384 | `computeDesignKey(input)` in `core/contracts/design-key.ts` | `gotcha-survey` + `analyze` MCP / CLI response (`designKey` field) |
| 2 | #383 | `computeRoundtripTally({ stepFourReport, reanalyzeResponse })` in `core/roundtrip/compute-roundtrip-tally.ts` | bundled into `helpers.js` |
| 3 | (audit, no separate issue — dead prose deletion) | n/a — Step 4's `fileKey` extraction prose was 100% unused downstream and is just deleted | n/a |
| 4 | (audit — small scope, decided to land here rather than file a separate issue) | `removeCanicodeAnnotations(annotations, categories)` + `isCanicodeAnnotation(annotation, categories)` in `core/roundtrip/remove-canicode-annotations.ts` | bundled into `helpers.js` |

Three commits, each independently lints + tests clean:

- **`ed7e299`** — #384 designKey wiring (10 files, +184/-11)
- **`8548f6e`** — #383 tally helper (6 files, +279/-13)
- **`36bd316`** — audit cleanup: dead `fileKey` prose deletion + `removeCanicodeAnnotations` extraction (5 files, +251/-10)

## Audit notes (post-#383 follow-ups)

After #383 / #384 landed locally, I re-read both SKILLs cover-to-cover for any remaining ADR-303 violations. Findings:

- **Already in scope** — #381 (group/batch), #382 (acknowledgments), #303 (roundtrip pseudocode) plus #383 / #384 landing here = the bulk of the surface is now extracted.
- **B (dead `fileKey` prose)** — line 169 of `canicode-roundtrip/SKILL.md` told the LLM to extract `fileKey` from the URL, but `grep` confirmed the symbol is never used downstream. Pure dead deterministic logic. Deleted in commit 3.
- **C (`removeCanicodeAnnotations` filter)** — the Step 5 cleanup loop inlined a `filter(a => !(a.categoryId && canicodeIds.has(a.categoryId)) && !a.labelMarkdown?.startsWith("**[canicode]"))` predicate with the four-id whitelist + legacy prefix branch. Same shape as #383's tally — small, well-defined, fits the same PR. Extracted in commit 3.
- **A (`detectGotchaFileState`)** — already covered by #385's existing scope (re-read its body; the 4-state file detection is the second half of "section walking"). No scope extension needed.
- **D (per-question outcome accumulator)** — Step 4's `stepFourReport` is still populated by LLM-side bullet counting (`<count of ✅ + 🔧 + 🔗 lines>`). Folded into #386 via an issue comment that extends its scope to include a `Step4Outcome` shape returned by every Strategy helper plus a thin `accumulateStepFourReport` accumulator.
- **E (wrap-up template renderer)** — pure formatting, low leverage. Not tracked as a separate issue.

## Why two issues + two follow-up cleanups in one PR

- All four touch the same SKILL files (`canicode-roundtrip/SKILL.md` + `canicode-gotchas/SKILL.md`) and the same TS layers (`core/contracts/`, `core/roundtrip/`, `core/gotcha/`).
- The audit cleanups (B / C) are < 250 lines each — splitting them into separate PRs would add review overhead without changing the merge order (none of #385 / #386 depend on them).
- helpers.js bundle is rebuilt once per push; landing the two new bundled helpers (`computeRoundtripTally`, `removeCanicodeAnnotations`) together avoids a second drift cycle on `main`.

## Test plan

- [x] `pnpm lint` clean.
- [x] `pnpm test:run` — **955 / 955** tests pass (was 937 before this PR).
  - 12 new tests for `computeDesignKey` (3 URL shapes, query-param drop, no-`node-id`, instance ids, fixture paths, raw names).
  - 6 new tests for `computeRoundtripTally` (counter passthrough, V/V_ack/V_open derivation, all-zero, no-ack, fully-acked, invalid `acknowledgedCount > issueCount` throw).
  - 11 new tests for `removeCanicodeAnnotations` (3 categoryIds, legacy gate, `**[canicode]` prefix, mixed input, fully-canicode, empty input, non-mutation).
  - 2 new tests for `generateGotchaSurvey` `designKey` passthrough.
- [x] `pnpm build:roundtrip` emits a 16.50 KB bundle that contains the new helpers (verified via `grep` — 8 references across `computeRoundtripTally` / `removeCanicodeAnnotations` / `isCanicodeAnnotation`).
- [x] `git status` clean after rebuild — no helpers.js drift.
- [ ] Live roundtrip against a real Figma file to confirm the SKILL prose still drives the workflow correctly under context pressure (manual follow-up — same as #303 / #381).

## Follow-up issues that remain after this PR

- **#385** — gotcha section walking + numbering + 4-state file detection (single PR, scope already covers all of it).
- **#386** — Strategy D auto-fix loop **+** per-question outcome accumulator (scope extended via comment in this PR).

Made with [Cursor](https://cursor.com)