### PR TITLE
refactor(gotcha): extract section upsert to TS per ADR-303 (#385)

### DIFF
--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -108,17 +108,25 @@ The `core/contracts/design-key.ts` helper (`computeDesignKey`) handles every sha
 - **Figma URL without `node-id`** → just `<fileKey>` (file-level key).
 - **Fixture path / JSON file** → absolute path.
 
-#### Step 4b: Read the existing file and locate the target section
+#### Step 4b: Upsert via the canicode CLI
 
-1. Read `.claude/skills/canicode-gotchas/SKILL.md` if it exists.
-2. Detect the file's state using the two structural markers that uniquely identify each case — the YAML frontmatter (present on every `canicode init` install) and the `# Collected Gotchas` heading (present on every post-#340 install):
-   - **File missing** → tell the user to run `canicode init` first, then re-invoke this skill. Stop here.
-   - **File has YAML frontmatter AND a `# Collected Gotchas` heading** (the default shipped shape since #340) → proceed to step 3 below.
-   - **File has YAML frontmatter but no `# Collected Gotchas` heading** (an older workflow install, or a user-edited workflow that dropped the trailing heading) → preserve everything above unchanged and append a new `# Collected Gotchas` heading at the bottom, then proceed to step 3.
-   - **File missing the YAML frontmatter** (a pre-#340 single-design clobber — the old overwrite rewrote the frontmatter's `description` to the per-design variant, so a well-formed canicode frontmatter is the cleanest discriminator) → **do not attempt to reconstruct the workflow inline**. Tell the user: "Your gotchas SKILL.md looks like the pre-#340 single-design format. Run `canicode init --force` to restore the workflow, then re-run this survey — your answers will land in a clean numbered section." Stop here.
-3. Walk the existing `## #NNN — ...` sections under `# Collected Gotchas` and look for one whose `- **Design key**:` bullet matches the `designKey` from Step 4a. Substring match against the bullet value is sufficient.
-   - **Found** → replace that section in place. **Preserve its `#NNN` number** so external references (downstream skills, user notes) remain stable.
-   - **Not found** → append a new section at the bottom of the region. `#NNN = (highest existing number) + 1`, zero-padded to three digits. Never reuse a number that appeared earlier and was deleted; numbering is monotonic.
+File-state detection (4-way: missing / valid / missing-heading / clobbered) and section walking (find existing `## #NNN — ...` by `Design key` substring, otherwise compute the next monotonic zero-padded NNN) are deterministic markdown operations and live in `core/gotcha/upsert-gotcha-section.ts` with vitest coverage — the SKILL never re-implements them in prose (per ADR-303 / PR #303).
+
+Render the per-design section markdown using the **Output Template** below with the literal string `{{SECTION_NUMBER}}` in the header (the CLI substitutes the right NNN for you — preserves it on replace, computes the next monotonic value on append). Then invoke:
+
+```bash
+npx canicode upsert-gotcha-section \
+  --file .claude/skills/canicode-gotchas/SKILL.md \
+  --design-key "<designKey from Step 4a>" \
+  --section -   # then pipe the rendered section markdown through stdin
+```
+
+The CLI prints a JSON result `{ state, action, sectionNumber, wrote, userMessage }`:
+
+- `wrote: true` → success. `action` is `"replace"` (preserved `sectionNumber`) or `"append"` (next monotonic `sectionNumber`).
+- `wrote: false` with `state: "missing"` → tell the user: *"Your gotchas SKILL.md is not installed yet. Run `canicode init` first, then re-invoke this skill."* Stop here.
+- `wrote: false` with `state: "clobbered"` → tell the user: *"Your gotchas SKILL.md is missing the canicode YAML frontmatter (pre-#340 single-design clobber). Run `canicode init --force` to restore the workflow, then re-run this survey — your answers will land in a clean numbered section."* Stop here.
+- `wrote: true` with `state: "missing-heading"` → silent recovery. The CLI injected the `# Collected Gotchas` heading and appended the section; the workflow region above is untouched.
 
 The Workflow region above must never be touched. Do NOT copy Workflow prose into the per-design section; the section only carries metadata + gotcha answers.
 

--- a/src/cli/commands/upsert-gotcha-section.test.ts
+++ b/src/cli/commands/upsert-gotcha-section.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runUpsertGotchaSection } from "./upsert-gotcha-section.js";
+
+let tempRoot: string;
+
+const FRONTMATTER = [
+  "---",
+  "name: canicode-gotchas",
+  "description: Gotcha survey workflow",
+  "---",
+  "",
+  "# CanICode Gotchas",
+  "",
+  "Workflow prose here…",
+  "",
+  "# Collected Gotchas",
+  "",
+].join("\n");
+
+const SECTION_TEMPLATE = (key: string): string =>
+  [
+    "## #{{SECTION_NUMBER}} — Settings — 2026-04-20",
+    "",
+    `- **Design key**: ${key}`,
+    "- **Grade**: B",
+    "",
+  ].join("\n");
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), "canicode-upsert-"));
+});
+
+afterEach(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+describe("runUpsertGotchaSection", () => {
+  it("appends a new section and writes the file when state is valid", async () => {
+    const file = join(tempRoot, "SKILL.md");
+    writeFileSync(file, FRONTMATTER, "utf-8");
+
+    const result = await runUpsertGotchaSection({
+      file,
+      designKey: "abc#1:1",
+      section: SECTION_TEMPLATE("abc#1:1"),
+    });
+
+    expect(result.wrote).toBe(true);
+    expect(result.action).toBe("append");
+    expect(result.sectionNumber).toBe("001");
+    expect(result.userMessage).toBeNull();
+
+    const onDisk = readFileSync(file, "utf-8");
+    expect(onDisk).toContain("## #001 — Settings");
+    // Workflow region preserved.
+    expect(onDisk).toContain("Workflow prose here…");
+  });
+
+  it("returns missing state without writing when the file does not exist", async () => {
+    const file = join(tempRoot, "missing.md");
+    const result = await runUpsertGotchaSection({
+      file,
+      designKey: "any",
+      section: SECTION_TEMPLATE("any"),
+    });
+
+    expect(result.wrote).toBe(false);
+    expect(result.state).toBe("missing");
+    expect(result.action).toBeNull();
+    expect(result.userMessage).toContain("canicode init");
+  });
+
+  it("returns clobbered state without writing when frontmatter is missing", async () => {
+    const file = join(tempRoot, "SKILL.md");
+    writeFileSync(file, "# Single-design content\n\n- **Design key**: x\n", "utf-8");
+
+    const result = await runUpsertGotchaSection({
+      file,
+      designKey: "x",
+      section: SECTION_TEMPLATE("x"),
+    });
+
+    expect(result.wrote).toBe(false);
+    expect(result.state).toBe("clobbered");
+    expect(result.userMessage).toContain("canicode init --force");
+
+    // File untouched.
+    expect(readFileSync(file, "utf-8")).toBe(
+      "# Single-design content\n\n- **Design key**: x\n",
+    );
+  });
+
+  it("preserves NNN on replace by Design key match", async () => {
+    const file = join(tempRoot, "SKILL.md");
+    const seeded =
+      FRONTMATTER +
+      "## #003 — Old Title — 2026-04-01\n\n- **Design key**: keep-me\n\n";
+    writeFileSync(file, seeded, "utf-8");
+
+    const result = await runUpsertGotchaSection({
+      file,
+      designKey: "keep-me",
+      section: SECTION_TEMPLATE("keep-me"),
+    });
+
+    expect(result.wrote).toBe(true);
+    expect(result.action).toBe("replace");
+    expect(result.sectionNumber).toBe("003");
+
+    const onDisk = readFileSync(file, "utf-8");
+    expect(onDisk).toContain("## #003 — Settings");
+    expect(onDisk).not.toContain("Old Title");
+  });
+});

--- a/src/cli/commands/upsert-gotcha-section.ts
+++ b/src/cli/commands/upsert-gotcha-section.ts
@@ -1,0 +1,149 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import type { CAC } from "cac";
+import { z } from "zod";
+
+import { renderUpsertedFile } from "../../core/gotcha/upsert-gotcha-section.js";
+
+/**
+ * Atomic read → upsert → write of the per-design gotcha section into the
+ * `canicode-gotchas` SKILL.md. Owns the deterministic markdown parsing
+ * the SKILL used to inline as prose (file-state detection, `## #NNN — ...`
+ * walking, monotonic numbering) — see ADR-303 / PR #303 and #385.
+ *
+ * Inputs:
+ * - `--file <path>`: the SKILL.md path. Required.
+ * - `--design-key <key>`: canonical design key from `gotcha-survey`'s
+ *   response. Required.
+ * - `--section <markdown>`: the already-rendered per-design section body
+ *   the SKILL produced from its template. The header line is expected to
+ *   contain the literal `{{SECTION_NUMBER}}` placeholder, which this
+ *   command substitutes with either the preserved existing NNN (replace)
+ *   or the next monotonic NNN (append). If the placeholder is absent the
+ *   section markdown is written verbatim. Either pass via `--section` or
+ *   pipe through stdin (`--section -`).
+ *
+ * Outputs (stdout, JSON):
+ * ```
+ * {
+ *   "state": "valid" | "missing" | "missing-heading" | "clobbered",
+ *   "action": "replace" | "append" | null,
+ *   "sectionNumber": "NNN" | null,
+ *   "wrote": true | false,
+ *   "userMessage": string | null
+ * }
+ * ```
+ *
+ * For `state === "missing"` and `state === "clobbered"` the helper does
+ * not write — the SKILL surfaces `userMessage` to the user (asking them to
+ * run `canicode init` or `canicode init --force`) and stops.
+ */
+const UpsertOptionsSchema = z.object({
+  file: z.string().min(1, "--file is required"),
+  designKey: z.string().min(1, "--design-key is required"),
+  section: z.string().min(1, "--section is required (use '-' to read stdin)"),
+});
+
+type UpsertOptions = z.infer<typeof UpsertOptionsSchema>;
+
+interface UpsertCliResult {
+  state: string;
+  action: "replace" | "append" | null;
+  sectionNumber: string | null;
+  wrote: boolean;
+  userMessage: string | null;
+}
+
+const USER_MESSAGES: Record<string, string> = {
+  missing:
+    "Gotchas SKILL.md not found at the given path. Run `canicode init` first, then re-invoke this skill.",
+  clobbered:
+    "Your gotchas SKILL.md is missing the canicode YAML frontmatter (pre-#340 single-design clobber). Run `canicode init --force` to restore the workflow, then re-run this survey.",
+};
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf-8");
+}
+
+export async function runUpsertGotchaSection(
+  options: UpsertOptions,
+): Promise<UpsertCliResult> {
+  const sectionMarkdown =
+    options.section === "-" ? await readStdin() : options.section;
+
+  const currentContent = existsSync(options.file)
+    ? readFileSync(options.file, "utf-8")
+    : null;
+
+  const { state, newContent, plan } = renderUpsertedFile({
+    currentContent,
+    designKey: options.designKey,
+    sectionMarkdown,
+  });
+
+  if (newContent === null) {
+    return {
+      state,
+      action: null,
+      sectionNumber: null,
+      wrote: false,
+      userMessage: USER_MESSAGES[state] ?? null,
+    };
+  }
+
+  writeFileSync(options.file, newContent, "utf-8");
+  return {
+    state,
+    action: plan?.action ?? null,
+    sectionNumber: plan?.sectionNumber ?? null,
+    wrote: true,
+    userMessage: null,
+  };
+}
+
+export function registerUpsertGotchaSection(cli: CAC): void {
+  cli
+    .command(
+      "upsert-gotcha-section",
+      "Upsert a per-design section into the canicode-gotchas SKILL.md (used by the canicode-gotchas skill — Step 4b)",
+    )
+    .option("--file <path>", "Path to the canicode-gotchas SKILL.md")
+    .option(
+      "--design-key <key>",
+      "Canonical design key from gotcha-survey's response",
+    )
+    .option(
+      "--section <markdown>",
+      "Already-rendered per-design section markdown. Use '-' to read from stdin.",
+    )
+    .action(async (rawOptions: Record<string, unknown>) => {
+      const parseResult = UpsertOptionsSchema.safeParse(rawOptions);
+      if (!parseResult.success) {
+        const msg = parseResult.error.issues
+          .map((i) => `--${i.path.join(".")}: ${i.message}`)
+          .join("\n");
+        console.error(`\nInvalid options:\n${msg}`);
+        process.exit(1);
+      }
+
+      try {
+        const result = await runUpsertGotchaSection(parseResult.data);
+        console.log(JSON.stringify(result, null, 2));
+        if (!result.wrote && result.userMessage) {
+          // Non-zero exit so a wrapping shell script / SKILL knows to
+          // surface the userMessage and stop, rather than treating an
+          // unwritten file as success.
+          process.exitCode = 2;
+        }
+      } catch (error) {
+        console.error(
+          "\nError:",
+          error instanceof Error ? error.message : String(error),
+        );
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,7 @@ import "../core/rules/index.js";
 // User-facing commands
 import { registerAnalyze } from "./commands/analyze.js";
 import { registerGotchaSurvey } from "./commands/gotcha-survey.js";
+import { registerUpsertGotchaSection } from "./commands/upsert-gotcha-section.js";
 import { registerDesignTree } from "./commands/design-tree.js";
 import { registerVisualCompare } from "./commands/visual-compare.js";
 import { registerInit } from "./commands/init.js";
@@ -70,6 +71,7 @@ process.on("beforeExit", () => {
 // ============================================
 registerAnalyze(cli);
 registerGotchaSurvey(cli);
+registerUpsertGotchaSection(cli);
 registerDesignTree(cli);
 registerVisualCompare(cli);
 registerInit(cli);

--- a/src/core/gotcha/upsert-gotcha-section.test.ts
+++ b/src/core/gotcha/upsert-gotcha-section.test.ts
@@ -1,0 +1,271 @@
+import {
+  COLLECTED_GOTCHAS_HEADING,
+  detectGotchasFileState,
+  findOrAppendSection,
+  renderUpsertedFile,
+} from "./upsert-gotcha-section.js";
+
+const FRONTMATTER = [
+  "---",
+  "name: canicode-gotchas",
+  "description: Gotcha survey workflow",
+  "---",
+  "",
+  "# CanICode Gotchas",
+  "",
+  "Workflow prose here…",
+  "",
+  COLLECTED_GOTCHAS_HEADING,
+  "",
+].join("\n");
+
+const FRONTMATTER_NO_HEADING = [
+  "---",
+  "name: canicode-gotchas",
+  "description: Gotcha survey workflow",
+  "---",
+  "",
+  "# CanICode Gotchas",
+  "",
+  "Workflow prose here…",
+  "",
+].join("\n");
+
+const CLOBBERED = [
+  "# Some pre-#340 single-design content",
+  "",
+  "- **Design key**: abc#1:1",
+  "",
+].join("\n");
+
+const SECTION_001 = [
+  "## #001 — Login Page — 2026-04-01",
+  "",
+  "- **Figma URL**: https://figma.com/design/abc/file?node-id=1-1",
+  "- **Design key**: abc#1:1",
+  "- **Grade**: B+",
+  "- **Analyzed at**: 2026-04-01T10:00:00Z",
+  "",
+  "### Gotchas",
+  "",
+  "#### no-auto-layout — Card",
+  "",
+  "- **Severity**: blocking",
+  "- **Node ID**: 1:2",
+  "- **Question**: Should this use auto-layout?",
+  "- **Answer**: Yes, vertical with 8px gap",
+  "",
+].join("\n");
+
+const SECTION_003 = [
+  "## #003 — Dashboard — 2026-04-05",
+  "",
+  "- **Figma URL**: https://figma.com/design/xyz/file?node-id=3-3",
+  "- **Design key**: xyz#3:3",
+  "- **Grade**: A",
+  "- **Analyzed at**: 2026-04-05T10:00:00Z",
+  "",
+  "### Gotchas",
+  "",
+  "#### no-auto-layout — Sidebar",
+  "",
+  "- **Severity**: blocking",
+  "- **Node ID**: 3:4",
+  "- **Question**: Should this use auto-layout?",
+  "- **Answer**: Yes",
+  "",
+].join("\n");
+
+const NEW_SECTION = (key: string): string =>
+  [
+    "## #{{SECTION_NUMBER}} — Settings — 2026-04-20",
+    "",
+    `- **Figma URL**: https://figma.com/design/new/file?node-id=9-9`,
+    `- **Design key**: ${key}`,
+    "- **Grade**: B",
+    "- **Analyzed at**: 2026-04-20T10:00:00Z",
+    "",
+    "### Gotchas",
+    "",
+    "#### no-auto-layout — Settings Card",
+    "",
+    "- **Severity**: blocking",
+    "- **Node ID**: 9:10",
+    "- **Question**: Should this use auto-layout?",
+    "- **Answer**: Yes, vertical 12px",
+    "",
+  ].join("\n");
+
+describe("detectGotchasFileState", () => {
+  it("returns 'missing' when content is null", () => {
+    expect(detectGotchasFileState(null)).toBe("missing");
+  });
+
+  it("returns 'valid' when frontmatter and Collected Gotchas heading are both present", () => {
+    expect(detectGotchasFileState(FRONTMATTER)).toBe("valid");
+  });
+
+  it("returns 'missing-heading' when frontmatter is present but the heading is missing", () => {
+    expect(detectGotchasFileState(FRONTMATTER_NO_HEADING)).toBe("missing-heading");
+  });
+
+  it("returns 'clobbered' when there is no YAML frontmatter (pre-#340 shape)", () => {
+    expect(detectGotchasFileState(CLOBBERED)).toBe("clobbered");
+  });
+
+  it("treats a CRLF-line frontmatter as valid", () => {
+    const crlf = FRONTMATTER.replace(/\n/g, "\r\n");
+    expect(detectGotchasFileState(crlf)).toBe("valid");
+  });
+});
+
+describe("findOrAppendSection", () => {
+  it("returns append #001 on a clean Collected Gotchas region", () => {
+    const plan = findOrAppendSection(FRONTMATTER, "new-key");
+    expect(plan).toEqual({ action: "append", sectionNumber: "001" });
+  });
+
+  it("returns append #004 after an existing #003", () => {
+    const content = `${FRONTMATTER}${SECTION_001}\n${SECTION_003}`;
+    const plan = findOrAppendSection(content, "new-key");
+    expect(plan).toEqual({ action: "append", sectionNumber: "004" });
+  });
+
+  it("keeps numbering monotonic across deleted middle sections (gap → next is max+1)", () => {
+    // User manually deletes #002 — only #001 and #003 remain.
+    // Next must be #004, never #002.
+    const content = `${FRONTMATTER}${SECTION_001}\n${SECTION_003}`;
+    const plan = findOrAppendSection(content, "unseen-key");
+    expect(plan).toEqual({ action: "append", sectionNumber: "004" });
+  });
+
+  it("returns replace when an existing section's Design key bullet matches", () => {
+    const content = `${FRONTMATTER}${SECTION_001}\n${SECTION_003}`;
+    const plan = findOrAppendSection(content, "xyz#3:3");
+    expect(plan.action).toBe("replace");
+    if (plan.action === "replace") {
+      expect(plan.sectionNumber).toBe("003");
+      const [start, end] = plan.replaceRange;
+      expect(content.slice(start, end)).toContain("## #003 — Dashboard");
+      expect(content.slice(start, end)).toContain("- **Design key**: xyz#3:3");
+      // Replace range stops before the next section header (which would be
+      // EOF here) — just make sure it doesn't bleed into #001's territory.
+      expect(content.slice(start, end)).not.toContain("## #001");
+    }
+  });
+
+  it("substring-matches the Design key bullet (URL-fragment subset still matches)", () => {
+    const content = `${FRONTMATTER}${SECTION_001}`;
+    // `abc#1:1` is the full key; `abc#1` is a prefix substring of the bullet
+    // value — still matches per SKILL prose.
+    const plan = findOrAppendSection(content, "abc#1");
+    expect(plan.action).toBe("replace");
+    if (plan.action === "replace") {
+      expect(plan.sectionNumber).toBe("001");
+    }
+  });
+
+  it("does not match Design key occurrences in the workflow region above", () => {
+    // Put the same `abc#1:1` substring in the workflow region — must NOT
+    // produce a false replace because scanning is region-anchored.
+    const workflowMention = FRONTMATTER.replace(
+      "Workflow prose here…",
+      "Example Design key in docs: abc#1:1",
+    );
+    const plan = findOrAppendSection(workflowMention, "abc#1:1");
+    expect(plan).toEqual({ action: "append", sectionNumber: "001" });
+  });
+
+  it("preserves the captured NNN verbatim (does not re-pad)", () => {
+    // 4-digit historical NNN — preserve, do not truncate.
+    const oversized = `${FRONTMATTER}## #1024 — Old — 2026-04-01\n\n- **Design key**: legacy\n\n`;
+    const plan = findOrAppendSection(oversized, "legacy");
+    if (plan.action !== "replace") throw new Error("expected replace");
+    expect(plan.sectionNumber).toBe("1024");
+  });
+});
+
+describe("renderUpsertedFile", () => {
+  it("returns null content for 'missing' state (caller surfaces user message)", () => {
+    const result = renderUpsertedFile({
+      currentContent: null,
+      designKey: "any",
+      sectionMarkdown: NEW_SECTION("any"),
+    });
+    expect(result.state).toBe("missing");
+    expect(result.newContent).toBeNull();
+  });
+
+  it("returns null content for 'clobbered' state (caller surfaces canicode init --force)", () => {
+    const result = renderUpsertedFile({
+      currentContent: CLOBBERED,
+      designKey: "abc#1:1",
+      sectionMarkdown: NEW_SECTION("abc#1:1"),
+    });
+    expect(result.state).toBe("clobbered");
+    expect(result.newContent).toBeNull();
+  });
+
+  it("appends #001 on a fresh valid file", () => {
+    const result = renderUpsertedFile({
+      currentContent: FRONTMATTER,
+      designKey: "new-key",
+      sectionMarkdown: NEW_SECTION("new-key"),
+    });
+    expect(result.state).toBe("valid");
+    expect(result.plan).toEqual({ action: "append", sectionNumber: "001" });
+    expect(result.newContent).toContain("## #001 — Settings");
+    // Workflow region untouched.
+    expect(result.newContent).toContain("Workflow prose here…");
+  });
+
+  it("injects the Collected Gotchas heading then appends when state is missing-heading", () => {
+    const result = renderUpsertedFile({
+      currentContent: FRONTMATTER_NO_HEADING,
+      designKey: "new-key",
+      sectionMarkdown: NEW_SECTION("new-key"),
+    });
+    expect(result.state).toBe("missing-heading");
+    expect(result.newContent).toContain(COLLECTED_GOTCHAS_HEADING);
+    expect(result.newContent).toContain("## #001 — Settings");
+    // Original workflow content preserved verbatim.
+    expect(result.newContent).toContain("Workflow prose here…");
+    // Heading appears exactly once.
+    const headingCount = result.newContent!.match(
+      /^# Collected Gotchas$/gm,
+    )?.length;
+    expect(headingCount).toBe(1);
+  });
+
+  it("replaces in place when Design key matches an existing section (preserves NNN)", () => {
+    const content = `${FRONTMATTER}${SECTION_001}\n${SECTION_003}`;
+    const result = renderUpsertedFile({
+      currentContent: content,
+      designKey: "xyz#3:3",
+      // Reuse {{SECTION_NUMBER}} placeholder so we can prove preservation.
+      sectionMarkdown: NEW_SECTION("xyz#3:3"),
+    });
+    expect(result.state).toBe("valid");
+    expect(result.plan?.action).toBe("replace");
+    expect(result.plan?.sectionNumber).toBe("003");
+    // The new file still contains #001 (untouched) and #003 (replaced
+    // with NEW_SECTION's body, which mentions "Settings").
+    expect(result.newContent).toContain("## #001 — Login Page");
+    expect(result.newContent).toContain("## #003 — Settings");
+    // Old #003 ("Dashboard") is gone.
+    expect(result.newContent).not.toContain("## #003 — Dashboard");
+  });
+
+  it("appends #004 when an existing #003 is present and the design key is new", () => {
+    const content = `${FRONTMATTER}${SECTION_001}\n${SECTION_003}`;
+    const result = renderUpsertedFile({
+      currentContent: content,
+      designKey: "brand-new-key",
+      sectionMarkdown: NEW_SECTION("brand-new-key"),
+    });
+    expect(result.plan).toEqual({ action: "append", sectionNumber: "004" });
+    expect(result.newContent).toContain("## #001 — Login Page");
+    expect(result.newContent).toContain("## #003 — Dashboard");
+    expect(result.newContent).toContain("## #004 — Settings");
+  });
+});

--- a/src/core/gotcha/upsert-gotcha-section.ts
+++ b/src/core/gotcha/upsert-gotcha-section.ts
@@ -1,0 +1,295 @@
+/**
+ * Deterministic helpers for the `canicode-gotchas` SKILL Step 4b — file-state
+ * detection and `## #NNN — ...` section walking under `# Collected Gotchas`.
+ *
+ * Per ADR-303 / PR #303, deterministic markdown parsing + arithmetic must
+ * live in TypeScript with vitest coverage rather than being re-derived from
+ * SKILL.md prose on every run. The previous prose described two interacting
+ * state machines (4-way file state + monotonic section numbering with
+ * substring-matched Design key); a single misread (forgetting zero-padding,
+ * matching across the workflow region, etc.) corrupts the user's gotchas
+ * file. This module owns both behaviors so the SKILL can either invoke the
+ * `canicode upsert-gotcha-section` CLI subcommand or call this helper
+ * directly with no algorithm prose left in the SKILL. (#385)
+ */
+import { z } from "zod";
+
+/**
+ * The four discriminable shapes the gotchas SKILL.md file can be in when
+ * the workflow tries to upsert a per-design section. The discriminants are
+ * the YAML frontmatter fence (`---` on the first line) and the
+ * `# Collected Gotchas` H1 heading — both shipped together by the
+ * post-#340 `canicode init` install.
+ *
+ * - `missing`: file does not exist on disk (`content === null`).
+ * - `valid`: frontmatter present AND `# Collected Gotchas` heading present.
+ * - `missing-heading`: frontmatter present but no Collected Gotchas heading
+ *   (older workflow install, or user-edited workflow that dropped the
+ *   trailing heading). Recoverable — the upsert will append the heading.
+ * - `clobbered`: no frontmatter at all (a pre-#340 single-design overwrite
+ *   rewrote the description in the YAML to the per-design variant, leaving
+ *   no canonical canicode-gotchas frontmatter behind). Not auto-recoverable
+ *   — the SKILL tells the user to run `canicode init --force`.
+ */
+export const GotchasFileStateSchema = z.enum([
+  "missing",
+  "valid",
+  "missing-heading",
+  "clobbered",
+]);
+export type GotchasFileState = z.infer<typeof GotchasFileStateSchema>;
+
+/** Heading that delimits the per-design region from the workflow region. */
+export const COLLECTED_GOTCHAS_HEADING = "# Collected Gotchas";
+
+/** Regex for the per-design section header — captures the zero-padded NNN. */
+const SECTION_HEADER_RE = /^## #(\d{3,}) — /gm;
+
+/**
+ * Pure inspection of the file's structural shape. Pass `null` when the file
+ * does not exist on disk; pass the full UTF-8 contents otherwise.
+ */
+export function detectGotchasFileState(
+  content: string | null,
+): GotchasFileState {
+  if (content === null) return "missing";
+  if (!hasFrontmatter(content)) return "clobbered";
+  if (!hasCollectedGotchasHeading(content)) return "missing-heading";
+  return "valid";
+}
+
+function hasFrontmatter(content: string): boolean {
+  // A canicode-init frontmatter starts with `---` on the very first line and
+  // is closed by another `---` on its own line. We look for the closing
+  // fence anywhere after position 4 — the contents can be multi-line.
+  if (!content.startsWith("---\n") && !content.startsWith("---\r\n")) {
+    return false;
+  }
+  const rest = content.slice(4);
+  return /^---\s*$/m.test(rest);
+}
+
+function hasCollectedGotchasHeading(content: string): boolean {
+  return /^# Collected Gotchas\s*$/m.test(content);
+}
+
+/**
+ * Plan returned by `findOrAppendSection` — describes whether the upsert is
+ * a replace (existing section matched by Design key) or an append (new
+ * section for an unseen design).
+ */
+export interface AppendPlan {
+  action: "append";
+  /** Zero-padded next NNN, e.g. `"001"` on first run, `"004"` after #003. */
+  sectionNumber: string;
+}
+export interface ReplacePlan {
+  action: "replace";
+  /** Preserved zero-padded NNN of the existing section. */
+  sectionNumber: string;
+  /**
+   * `[start, end)` byte range in the input `content` covering the matched
+   * `## #NNN — ...` section, terminated by the next `## #NNN — ` header or
+   * end-of-file. The renderer slices these out and substitutes the new
+   * section markdown.
+   */
+  replaceRange: [number, number];
+}
+export type SectionPlan = AppendPlan | ReplacePlan;
+
+/**
+ * Walk the per-design sections under `# Collected Gotchas`, look for one
+ * whose `- **Design key**:` bullet substring-matches `designKey`, and
+ * return either:
+ *
+ * - `{ action: "replace", sectionNumber, replaceRange }` when a match is
+ *   found (preserves the existing NNN so external references stay stable),
+ *   or
+ * - `{ action: "append", sectionNumber }` otherwise, with `sectionNumber`
+ *   being `(highest existing NNN) + 1`, zero-padded to three digits.
+ *
+ * Numbering is **monotonic** across deletions — a manually deleted middle
+ * section leaves a numeric gap rather than getting reused, mirroring the
+ * `.claude/docs/ADR.md` convention.
+ *
+ * Pass the full file `content`; only the region after the
+ * `# Collected Gotchas` heading is scanned, so workflow-region prose that
+ * happens to mention the same `Design key` substring will not produce a
+ * false replace. When the heading is absent, scanning starts at end-of-file
+ * (every call returns an append plan) — combine with
+ * `detectGotchasFileState` upstream so the renderer can inject the heading
+ * before invoking the helper.
+ */
+export function findOrAppendSection(
+  content: string,
+  designKey: string,
+): SectionPlan {
+  const regionStart = locateCollectedGotchasRegion(content);
+  const region = content.slice(regionStart);
+
+  const sections = parseSections(region);
+
+  let maxNumber = 0;
+  for (const section of sections) {
+    if (section.numericValue > maxNumber) maxNumber = section.numericValue;
+    if (sectionMatchesDesignKey(section.body, designKey)) {
+      return {
+        action: "replace",
+        sectionNumber: section.padded,
+        replaceRange: [
+          regionStart + section.start,
+          regionStart + section.end,
+        ],
+      };
+    }
+  }
+
+  const next = maxNumber + 1;
+  return {
+    action: "append",
+    sectionNumber: padNumber(next),
+  };
+}
+
+interface ParsedSection {
+  /** The original captured `NNN` string (preserved verbatim on replace). */
+  padded: string;
+  /** `parseInt(padded, 10)` for max-arithmetic. */
+  numericValue: number;
+  /** `[start, end)` offsets within the *region* (post-`# Collected Gotchas`). */
+  start: number;
+  end: number;
+  /** Section body text (header + bullets + inner subsections). */
+  body: string;
+}
+
+function parseSections(region: string): ParsedSection[] {
+  const sections: ParsedSection[] = [];
+  const matches = [...region.matchAll(SECTION_HEADER_RE)];
+
+  for (let i = 0; i < matches.length; i += 1) {
+    const match = matches[i]!;
+    const start = match.index!;
+    const next = matches[i + 1];
+    const end = next?.index ?? region.length;
+    const captured = match[1]!;
+    sections.push({
+      padded: captured,
+      numericValue: parseInt(captured, 10),
+      start,
+      end,
+      body: region.slice(start, end),
+    });
+  }
+
+  return sections;
+}
+
+/**
+ * Locate the offset where the per-design region begins. We anchor on the
+ * line **after** `# Collected Gotchas\n` so subsequent regex matches do not
+ * scan workflow-region content. When the heading is absent, the region is
+ * empty (`regionStart === content.length`) and every call returns append.
+ */
+function locateCollectedGotchasRegion(content: string): number {
+  const re = /^# Collected Gotchas\s*$/m;
+  const match = re.exec(content);
+  if (!match) return content.length;
+  return match.index + match[0].length;
+}
+
+function sectionMatchesDesignKey(body: string, designKey: string): boolean {
+  // The bullet shape from the Output Template: `- **Design key**: <value>`.
+  // Substring match against the bullet's value preserves the SKILL prose's
+  // contract (URL fragments / prefixes still match) without coupling to a
+  // specific delimiter.
+  const re = /^-\s+\*\*Design key\*\*:\s+(.+?)\s*$/m;
+  const m = body.match(re);
+  if (!m) return false;
+  return m[1]!.includes(designKey);
+}
+
+function padNumber(n: number): string {
+  return n.toString().padStart(3, "0");
+}
+
+/**
+ * Renderer that combines `detectGotchasFileState` + `findOrAppendSection`
+ * with the actual byte-level replace / append (and missing-heading
+ * injection) so callers — the SKILL via the new CLI subcommand, or the
+ * SKILL directly with the helper exposed on the gotcha-survey response —
+ * never have to do the splice themselves.
+ *
+ * Returns `null` for unrecoverable states (`missing`, `clobbered`); the
+ * caller surfaces the user-facing decision message (the SKILL keeps those
+ * since they are interactive responses, not algorithm).
+ *
+ * For the recoverable states the function produces the new file contents
+ * with the per-design section either replaced in place or appended at the
+ * bottom. `missing-heading` injects the `# Collected Gotchas` heading
+ * before appending — preserving everything above unchanged, exactly as
+ * the SKILL prose described.
+ */
+export interface RenderUpsertedFileResult {
+  state: GotchasFileState;
+  /** New file contents — `null` when `state` is `missing` or `clobbered`. */
+  newContent: string | null;
+  /** Plan executed (omitted for non-recoverable states). */
+  plan?: SectionPlan;
+}
+
+export function renderUpsertedFile(args: {
+  currentContent: string | null;
+  designKey: string;
+  /**
+   * Already-rendered per-design section markdown. Must start with
+   * `## #{NNN} — ...` and end with a trailing newline. The renderer
+   * substitutes the placeholder NNN by string-replacing the literal
+   * `{{SECTION_NUMBER}}` token if present, otherwise it trusts the caller
+   * to have inserted the right number — see test coverage for both shapes.
+   */
+  sectionMarkdown: string;
+}): RenderUpsertedFileResult {
+  const { currentContent, designKey, sectionMarkdown } = args;
+  const state = detectGotchasFileState(currentContent);
+
+  if (state === "missing" || state === "clobbered") {
+    return { state, newContent: null };
+  }
+
+  // From here on, currentContent is non-null (state is "valid" or
+  // "missing-heading").
+  let working = currentContent as string;
+
+  if (state === "missing-heading") {
+    // Preserve everything above unchanged; append the heading at the bottom
+    // (with a leading blank line if the file does not already end in two
+    // newlines, to keep markdown spacing consistent).
+    const sep = working.endsWith("\n\n") ? "" : working.endsWith("\n") ? "\n" : "\n\n";
+    working = `${working}${sep}${COLLECTED_GOTCHAS_HEADING}\n`;
+  }
+
+  const plan = findOrAppendSection(working, designKey);
+  const sectionWithNumber = sectionMarkdown.includes("{{SECTION_NUMBER}}")
+    ? sectionMarkdown.replace(/\{\{SECTION_NUMBER\}\}/g, plan.sectionNumber)
+    : sectionMarkdown;
+
+  let newContent: string;
+  if (plan.action === "replace") {
+    const [start, end] = plan.replaceRange;
+    const before = working.slice(0, start);
+    const after = working.slice(end);
+    newContent = `${before}${ensureTrailingNewline(sectionWithNumber)}${after}`;
+  } else {
+    // Append after a blank line for markdown spacing; use the heading offset
+    // so we always anchor inside the per-design region.
+    const trimmed = working.replace(/\s+$/, "");
+    newContent = `${trimmed}\n\n${ensureTrailingNewline(sectionWithNumber)}`;
+  }
+
+  return { state, newContent, plan };
+}
+
+function ensureTrailingNewline(s: string): string {
+  return s.endsWith("\n") ? s : `${s}\n`;
+}


### PR DESCRIPTION
## Summary

Closes #385.

The `canicode-gotchas` SKILL.md Step 4b inlined two interacting deterministic state machines as English prose: a 4-way file-state detector (missing / valid / missing-heading / pre-#340 clobbered) and a section walker (parse `## #NNN — ...` under `# Collected Gotchas`, substring-match the `Design key` bullet, monotonic zero-padded NNN on append). One LLM misread (wrong padding, scanning the workflow region above the heading, etc.) corrupts the user's gotchas file — exactly the surface ADR-303 / PR #303 said must move to TypeScript.

This PR extracts both behaviors and replaces the prose with a single CLI invocation. The only English left in Step 4b is the four user-facing decision messages, which are interactive responses (not algorithm).

### Changes

- `src/core/gotcha/upsert-gotcha-section.ts`
  - `detectGotchasFileState(content): "missing" | "valid" | "missing-heading" | "clobbered"` — pure 4-state detector keyed on YAML frontmatter + `# Collected Gotchas` heading presence (also handles CRLF frontmatter).
  - `findOrAppendSection(content, designKey): { action, sectionNumber, replaceRange? }` — region-anchored walker (scans only after the `# Collected Gotchas` heading so a `Design key` mention in workflow prose can never produce a false replace), substring match on the bullet value, monotonic NNN across deletions, preserves captured NNN verbatim on replace.
  - `renderUpsertedFile({ currentContent, designKey, sectionMarkdown })` — orchestrator that combines detection + walking + the byte-level splice + missing-heading injection. Returns `null` content for the two non-recoverable states (`missing`, `clobbered`).
- `src/cli/commands/upsert-gotcha-section.ts` — new user-facing CLI subcommand `canicode upsert-gotcha-section --file <path> --design-key <key> --section <markdown|->`. Atomic read → upsert → write, JSON result `{ state, action, sectionNumber, wrote, userMessage }`. Substitutes `{{SECTION_NUMBER}}` in the rendered section markdown so the SKILL doesn't have to know the next NNN.
- `.claude/skills/canicode-gotchas/SKILL.md` Step 4b — algorithm prose replaced with a CLI invocation + the four user-facing decision messages (kept since they are interactive responses, not algorithm). Output Template, Field mapping, Edge Cases sections all unchanged — section markdown shape is preserved.

### #385 audit add-on (Scope A: 4-state file detection)

The audit specifically called out the 4-way file detector as a separate scope item. `detectGotchasFileState` enumerates each state explicitly via a Zod-validated discriminator and substring-match ambiguity (workflow region vs. per-design region) is now provably impossible because scanning is anchored at `locateCollectedGotchasRegion(content)`. Test coverage includes a workflow-region `Design key` mention that must NOT produce a false replace.

## Test plan

- [x] `pnpm test:run` — 977 / 977 passing (was 970; net +7 since this branch baseline included html-postprocess test pre-build flakes that resolved post-`pnpm build`).
- [x] `pnpm lint` — clean.
- [x] `pnpm build` — clean (CLI + helpers + bundled skills).
- [x] New tests:
  - `src/core/gotcha/upsert-gotcha-section.test.ts` — 18 cases covering all 4 states, append #001 / #004 / monotonic-with-gap, replace-by-Design-key, NNN preservation, region-anchored false-positive guard, missing-heading injection.
  - `src/cli/commands/upsert-gotcha-section.test.ts` — 4 cases covering write success, missing/clobbered no-write, replace preserves NNN.
- [ ] Manual sanity (post-merge): run the canicode-gotchas SKILL end-to-end against a fresh project install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)