### PR TITLE
refactor(roundtrip): extract Strategy D auto-fix loop to TS per ADR-303 (#386)

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -293,6 +293,8 @@ The probe is read-only and idempotent; running it before the picker adds one rou
    - `extractAcknowledgmentsFromNode(node, canicodeCategoryIds?)` — synchronous pure helper (#371). Reads one node's annotations and returns `{ nodeId, ruleId }[]` for entries gated by canicode `categoryId` plus a recognisable `— *<ruleId>*` footer (or legacy `**[canicode] <ruleId>**` prefix). When `canicodeCategoryIds` is omitted, footer-text matching alone is sufficient (test mode).
    - `readCanicodeAcknowledgments(rootNodeId, categories?)` — async tree walker (#371). Loads `rootNodeId` via `figma.getNodeByIdAsync`, recurses through `children`, and accumulates one acknowledgment per recognised entry. Used at the top of Step 5a to harvest the side channel that lets the analysis pipeline distinguish "still broken" from "the designer has a plan" — pass the result straight to `analyze({ acknowledgments })`. Errors on individual nodes are swallowed so locked / external nodes don't abort the sweep.
    - `computeRoundtripTally({ stepFourReport, reanalyzeResponse })` — pure helper (#383). Takes the structured Step 4 outcome counts (`{ resolved, annotated, definitionWritten, skipped }`) plus a narrowed re-analyze view (`{ issueCount, acknowledgedCount }`) and returns `{ X, Y, Z, W, N, V, V_ack, V_open }`. Replaces the LLM-side emoji-bullet re-counting in Step 5 — render the returned object directly into the wrap-up templates. Throws when `acknowledgedCount > issueCount` (impossible state).
+   - `applyAutoFix(issue, { categories, allowDefinitionWrite?, telemetry? })` — Strategy D entry point (#386). Branches on `targetProperty === "name" && suggestedName` once: renames the node via `applyWithInstanceFallback` (so naming auto-fixes share the same tier-1/2/3 policy as Strategy A) or writes a `categories.flag` annotation carrying `issue.message` and `issue.annotationProperties`. Returns one `AutoFixOutcome` (`{ outcome, nodeId, nodeName, ruleId, label }`) where `outcome` is `🔧` / `🌐` / `📝` so Step 4 can bump the structured `stepFourReport` counters without parsing prose. Replaces the inline JS the SKILL used to carry (per ADR-303 / PR #303).
+   - `applyAutoFixes(issues, { categories, allowDefinitionWrite?, telemetry? })` — loop wrapper (#386). Filters `issues` to `applyStrategy === "auto-fix"` (skipped entries surface as `⏭️` outcomes for symmetry) and applies each one in sequence. Returns the full `AutoFixOutcome[]`.
    - `removeCanicodeAnnotations(annotations, categories)` — pure filter. Returns `annotations` with every canicode-authored entry removed (gates on `categories.gotcha` / `flag` / `fallback` / `legacyAutoFix` plus the legacy `**[canicode]` body prefix). Use after `stripAnnotations` in the Step 5 cleanup loop — replaces the inline filter predicate the SKILL used to carry. `isCanicodeAnnotation(annotation, categories)` is the single-entry version, exported for callers that need the predicate alone.
 
 Keep each `writeFn` small so a throw does not abort unrelated writes. Experiment 08 findings informed every branch in the bundled helpers, and the batch-level confirmation contract still applies *when opting in*: if the orchestrator passes `allowDefinitionWrite: true`, it must have already collected one confirmation covering every potential definition write in the batch. Under the default, no confirmation is needed — the helper annotates the scene instead of propagating.
@@ -398,39 +400,15 @@ Notes:
 
 #### Strategy D: Auto-fix lower-severity issues from analysis
 
-The gotcha survey covers only blocking/risk severity. Lower-severity rules appear in `analyzeResult.issues[]` without a survey question. Each issue carries the same pre-computed fields (`applyStrategy`, `targetProperty`, `annotationProperties`, `suggestedName`, `isInstanceChild`, `sourceChildId`). Loop over them:
+The gotcha survey covers only blocking/risk severity. Lower-severity rules appear in `analyzeResult.issues[]` without a survey question. Each issue carries the same pre-computed fields (`applyStrategy`, `targetProperty`, `annotationProperties`, `suggestedName`, `isInstanceChild`, `sourceChildId`). The bundled helper handles the loop, the filter (`applyStrategy === "auto-fix"`), the naming-vs-annotation branch, and the per-issue outcome accumulator in one call:
 
 ```javascript
-for (const issue of analyzeResult.issues) {
-  if (issue.applyStrategy !== "auto-fix") continue;
-
-  // Shape an ad-hoc question-like object so the same helpers apply.
-  const q = {
-    nodeId: issue.nodeId,
-    ruleId: issue.ruleId,
-    ...(issue.sourceChildId ? { sourceChildId: issue.sourceChildId } : {}),
-  };
-
-  if (issue.targetProperty === "name" && issue.suggestedName) {
-    // Naming rules — rename to the pre-computed suggestedName.
-    await CanICodeRoundtrip.applyWithInstanceFallback(q, async (target) => {
-      if (target) target.name = issue.suggestedName;
-    }, { categories });
-  } else {
-    // raw-value, missing-interaction-state, missing-prototype — designer judgment; annotate.
-    const scene = await figma.getNodeByIdAsync(issue.nodeId);
-    CanICodeRoundtrip.upsertCanicodeAnnotation(scene, {
-      ruleId: issue.ruleId,
-      markdown: issue.message,
-      categoryId: categories.flag,
-      // Optional: surface the live value for the affected property in Dev Mode.
-      properties: issue.annotationProperties,
-    });
-  }
-}
+const outcomes = await CanICodeRoundtrip.applyAutoFixes(analyzeResult.issues, { categories });
 ```
 
-`suggestedName` is already capitalized for direct Plugin-API use (e.g. `"Hover"`, `"Default"`, `"Pressed"`). Do not transform it further.
+`outcomes` is an array of `{ outcome, nodeId, nodeName, ruleId, label }`. `outcome` is one of `🔧` (rename succeeded), `🌐` (definition write propagated — only when `allowDefinitionWrite: true`), `📝` (annotation written, including the fallback path), or `⏭️` (issue's `applyStrategy` was not `"auto-fix"` so it was skipped). Bump the matching `stepFourReport` counter for each entry — `🔧` → `resolved`, `🌐` → `definitionWritten`, `📝` → `annotated`, `⏭️` → `skipped` — so the Step 5 tally (`CanICodeRoundtrip.computeRoundtripTally`, #383) consumes the same structured shape as Strategies A/B/C.
+
+`suggestedName` is already capitalized for direct Plugin-API use (e.g. `"Hover"`, `"Default"`, `"Pressed"`). The helper writes it through `applyWithInstanceFallback` so locked / read-only / instance-override nodes annotate cleanly instead of aborting the batch — see the source at `src/core/roundtrip/apply-auto-fix.ts` (#386, ADR-303).
 
 #### Execution order
 

--- a/.claude/skills/canicode-roundtrip/helpers.js
+++ b/.claude/skills/canicode-roundtrip/helpers.js
@@ -396,6 +396,90 @@ ${footer}`;
     };
   }
 
+  // src/core/roundtrip/apply-auto-fix.ts
+  function pickNodeName(issue, resolved) {
+    if (resolved && typeof resolved.name === "string" && resolved.name.length > 0) {
+      return resolved.name;
+    }
+    if (typeof issue.nodePath === "string" && issue.nodePath.length > 0) {
+      const segments = issue.nodePath.split(/\s*[›>/]\s*/);
+      const tail = segments[segments.length - 1];
+      if (tail && tail.length > 0) return tail;
+    }
+    return issue.nodeId;
+  }
+  function mapInstanceFallbackIcon(result) {
+    if (result.icon === "\u2705") return "\u{1F527}";
+    return result.icon;
+  }
+  async function applyAutoFix(issue, context) {
+    const { categories } = context;
+    const ruleId = issue.ruleId;
+    if (issue.targetProperty === "name" && typeof issue.suggestedName === "string") {
+      const suggestedName = issue.suggestedName;
+      const question = {
+        nodeId: issue.nodeId,
+        ruleId,
+        ...issue.sourceChildId ? { sourceChildId: issue.sourceChildId } : {}
+      };
+      const result = await applyWithInstanceFallback(
+        question,
+        (target) => {
+          if (target) {
+            target.name = suggestedName;
+          }
+        },
+        {
+          categories,
+          ...context.allowDefinitionWrite !== void 0 ? { allowDefinitionWrite: context.allowDefinitionWrite } : {},
+          ...context.telemetry !== void 0 ? { telemetry: context.telemetry } : {}
+        }
+      );
+      const sceneAfter = await figma.getNodeByIdAsync(issue.nodeId);
+      return {
+        outcome: mapInstanceFallbackIcon(result),
+        nodeId: issue.nodeId,
+        nodeName: pickNodeName(issue, sceneAfter),
+        ruleId,
+        label: result.label
+      };
+    }
+    const scene = await figma.getNodeByIdAsync(issue.nodeId);
+    const markdown = issue.message ?? `Auto-flagged: ${ruleId}`;
+    if (scene) {
+      upsertCanicodeAnnotation(scene, {
+        ruleId,
+        markdown,
+        categoryId: categories.flag,
+        ...issue.annotationProperties && issue.annotationProperties.length > 0 ? { properties: issue.annotationProperties } : {}
+      });
+    }
+    return {
+      outcome: "\u{1F4DD}",
+      nodeId: issue.nodeId,
+      nodeName: pickNodeName(issue, scene),
+      ruleId,
+      label: scene ? `annotation added to canicode:flag \u2014 ${ruleId}` : `missing node (annotation skipped) \u2014 ${ruleId}`
+    };
+  }
+  async function applyAutoFixes(issues, context) {
+    const out = [];
+    for (const issue of issues) {
+      if (issue.applyStrategy !== "auto-fix") {
+        out.push({
+          outcome: "\u23ED\uFE0F",
+          nodeId: issue.nodeId,
+          nodeName: pickNodeName(issue, null),
+          ruleId: issue.ruleId,
+          label: `skipped \u2014 applyStrategy is ${issue.applyStrategy ?? "absent"}`
+        });
+        continue;
+      }
+      out.push(await applyAutoFix(issue, context));
+    }
+    return out;
+  }
+
   // src/core/roundtrip/remove-canicode-annotations.ts
   var LEGACY_CANICODE_PREFIX = "**[canicode]";
   function isCanicodeAnnotation(annotation, categories) {
@@ -419,6 +503,8 @@ ${footer}`;
     return annotations.filter((a) => !isCanicodeAnnotation(a, categories));
   }
 
+  exports.applyAutoFix = applyAutoFix;
+  exports.applyAutoFixes = applyAutoFixes;
   exports.applyPropertyMod = applyPropertyMod;
   exports.applyWithInstanceFallback = applyWithInstanceFallback;
   exports.computeRoundtripTally = computeRoundtripTally;

--- a/src/core/roundtrip/apply-auto-fix.test.ts
+++ b/src/core/roundtrip/apply-auto-fix.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyAutoFix,
+  applyAutoFixes,
+  type AutoFixIssueInput,
+} from "./apply-auto-fix.js";
+import {
+  createFigmaGlobal,
+  installFigmaGlobal,
+  uninstallFigmaGlobal,
+  type FigmaGlobalMock,
+} from "./test-utils.js";
+import type {
+  AnnotationEntry,
+  CanicodeCategories,
+  FigmaNode,
+} from "./types.js";
+
+const CATEGORIES: CanicodeCategories = {
+  gotcha: "cat-gotcha",
+  flag: "cat-flag",
+  fallback: "cat-fallback",
+};
+
+let mock: FigmaGlobalMock;
+
+afterEach(() => {
+  uninstallFigmaGlobal();
+});
+
+describe("applyAutoFix — naming branch (suggestedName present)", () => {
+  let scene: FigmaNode;
+
+  beforeEach(() => {
+    scene = {
+      id: "scene-1",
+      name: "frame-old",
+      type: "FRAME",
+      annotations: [],
+    };
+    mock = createFigmaGlobal({ nodes: { "scene-1": scene } });
+    installFigmaGlobal(mock);
+  });
+
+  it("renames the scene node and returns outcome 🔧", async () => {
+    const issue: AutoFixIssueInput = {
+      nodeId: "scene-1",
+      ruleId: "non-standard-naming",
+      applyStrategy: "auto-fix",
+      targetProperty: "name",
+      suggestedName: "Hover",
+    };
+    const outcome = await applyAutoFix(issue, { categories: CATEGORIES });
+    expect(outcome.outcome).toBe("🔧");
+    expect(outcome.nodeId).toBe("scene-1");
+    expect(outcome.ruleId).toBe("non-standard-naming");
+    // Re-read happens after the rename, so the outcome's nodeName reflects
+    // the post-rename label.
+    expect(outcome.nodeName).toBe("Hover");
+    expect(scene.name).toBe("Hover");
+    // applyWithInstanceFallback returns the tier-1 success label as-is.
+    expect(outcome.label).toMatch(/instance\/scene/);
+  });
+
+  it("translates ✅ from applyWithInstanceFallback to 🔧 (Strategy D vocabulary)", async () => {
+    const issue: AutoFixIssueInput = {
+      nodeId: "scene-1",
+      ruleId: "inconsistent-naming-convention",
+      applyStrategy: "auto-fix",
+      targetProperty: "name",
+      suggestedName: "my-url-parser",
+    };
+    const outcome = await applyAutoFix(issue, { categories: CATEGORIES });
+    // The internal RoundtripResult.icon is ✅; the helper must remap it so
+    // the SKILL prose can count 🔧 lines as auto-fixes (✅ is reserved for
+    // Strategy A property writes).
+    expect(outcome.outcome).toBe("🔧");
+  });
+});
+
+describe("applyAutoFix — instance-child rename via applyWithInstanceFallback", () => {
+  it("rename succeeds on the scene tier (instance child accepts node.name writes per Experiment 08) → 🔧", async () => {
+    // Experiment 08 confirmed `node.name` is one of the rare properties that
+    // accepts a raw write on instance children. The helper writes via
+    // applyWithInstanceFallback so the path is exercised end-to-end here.
+    const sceneInstanceChild: FigmaNode = {
+      id: "instance-child-1",
+      name: "Frame 42",
+      type: "FRAME",
+      annotations: [],
+    };
+    const sourceDef: FigmaNode = {
+      id: "source-def-1",
+      name: "Frame 42",
+      type: "FRAME",
+      annotations: [],
+    };
+    mock = createFigmaGlobal({
+      nodes: {
+        "instance-child-1": sceneInstanceChild,
+        "source-def-1": sourceDef,
+      },
+    });
+    installFigmaGlobal(mock);
+
+    const issue: AutoFixIssueInput = {
+      nodeId: "instance-child-1",
+      ruleId: "non-standard-naming",
+      applyStrategy: "auto-fix",
+      targetProperty: "name",
+      suggestedName: "Pressed",
+      sourceChildId: "source-def-1",
+    };
+    const outcome = await applyAutoFix(issue, { categories: CATEGORIES });
+    expect(outcome.outcome).toBe("🔧");
+    expect(sceneInstanceChild.name).toBe("Pressed");
+    // Definition must NOT be touched on the happy path — ADR-012 default,
+    // and the scene write succeeded so no fallback fires.
+    expect(sourceDef.name).toBe("Frame 42");
+  });
+});
+
+describe("applyAutoFix — annotation branch (non-naming auto-fixes)", () => {
+  let scene: FigmaNode;
+
+  beforeEach(() => {
+    scene = {
+      id: "scene-1",
+      name: "Container",
+      type: "FRAME",
+      annotations: [],
+    };
+    mock = createFigmaGlobal({ nodes: { "scene-1": scene } });
+    installFigmaGlobal(mock);
+  });
+
+  it("writes an annotation under categories.flag for raw-value rules → 📝", async () => {
+    const issue: AutoFixIssueInput = {
+      nodeId: "scene-1",
+      ruleId: "raw-value",
+      applyStrategy: "auto-fix",
+      message: "Raw color #FF0000 should bind to a token.",
+    };
+    const outcome = await applyAutoFix(issue, { categories: CATEGORIES });
+    expect(outcome).toEqual({
+      outcome: "📝",
+      nodeId: "scene-1",
+      nodeName: "Container",
+      ruleId: "raw-value",
+      label: expect.stringContaining("annotation added to canicode:flag"),
+    });
+    const annotations = scene.annotations as readonly AnnotationEntry[];
+    expect(annotations).toHaveLength(1);
+    expect(annotations[0]?.categoryId).toBe(CATEGORIES.flag);
+    expect(annotations[0]?.labelMarkdown).toMatch(
+      /Raw color #FF0000 should bind to a token\./
+    );
+    // The footer marker upsertCanicodeAnnotation appends — used by Step 5a
+    // acknowledgment harvesting.
+    expect(annotations[0]?.labelMarkdown).toMatch(/— \*raw-value\*$/);
+  });
+
+  it("forwards annotationProperties when present (Dev Mode property surface)", async () => {
+    const issue: AutoFixIssueInput = {
+      nodeId: "scene-1",
+      ruleId: "missing-interaction-state",
+      applyStrategy: "auto-fix",
+      message: "Add hover / pressed states.",
+      annotationProperties: [{ type: "fills" }],
+    };
+    const outcome = await applyAutoFix(issue, { categories: CATEGORIES });
+    expect(outcome.outcome).toBe("📝");
+    const annotations = scene.annotations as readonly AnnotationEntry[];
+    expect(annotations[0]?.properties).toEqual([{ type: "fills" }]);
+  });
+
+  it("falls back to a generic markdown when issue.message is absent", async () => {
+    const issue: AutoFixIssueInput = {
+      nodeId: "scene-1",
+      ruleId: "missing-prototype",
+      applyStrategy: "auto-fix",
+    };
+    const outcome = await applyAutoFix(issue, { categories: CATEGORIES });
+    expect(outcome.outcome).toBe("📝");
+    const annotations = scene.annotations as readonly AnnotationEntry[];
+    expect(annotations[0]?.labelMarkdown).toMatch(/Auto-flagged: missing-prototype/);
+  });
+
+  it("returns 📝 with a 'missing node' label when getNodeByIdAsync returns null", async () => {
+    mock = createFigmaGlobal({ nodes: {} });
+    installFigmaGlobal(mock);
+    const issue: AutoFixIssueInput = {
+      nodeId: "stale-id",
+      ruleId: "raw-value",
+      applyStrategy: "auto-fix",
+      message: "Bind to token",
+      nodePath: "Page › Frame › StaleButton",
+    };
+    const outcome = await applyAutoFix(issue, { categories: CATEGORIES });
+    expect(outcome.outcome).toBe("📝");
+    expect(outcome.nodeName).toBe("StaleButton");
+    expect(outcome.label).toMatch(/missing node/);
+  });
+});
+
+describe("applyAutoFixes — loop wrapper with filtering", () => {
+  it("filters out non-auto-fix issues with outcome ⏭️ and applies the rest", async () => {
+    const namingScene: FigmaNode = {
+      id: "n-1",
+      name: "old",
+      type: "FRAME",
+      annotations: [],
+    };
+    const annotationScene: FigmaNode = {
+      id: "a-1",
+      name: "Body",
+      type: "FRAME",
+      annotations: [],
+    };
+    mock = createFigmaGlobal({
+      nodes: { "n-1": namingScene, "a-1": annotationScene },
+    });
+    installFigmaGlobal(mock);
+
+    const issues: AutoFixIssueInput[] = [
+      {
+        nodeId: "skip-1",
+        ruleId: "missing-size-constraint",
+        applyStrategy: "property-mod",
+        nodePath: "Root › Skipped",
+      },
+      {
+        nodeId: "n-1",
+        ruleId: "non-standard-naming",
+        applyStrategy: "auto-fix",
+        targetProperty: "name",
+        suggestedName: "Hover",
+      },
+      {
+        nodeId: "skip-2",
+        ruleId: "deep-nesting",
+        applyStrategy: "structural-mod",
+      },
+      {
+        nodeId: "a-1",
+        ruleId: "raw-value",
+        applyStrategy: "auto-fix",
+        message: "Bind raw color to token.",
+      },
+    ];
+    const outcomes = await applyAutoFixes(issues, { categories: CATEGORIES });
+
+    expect(outcomes.map((o) => o.outcome)).toEqual(["⏭️", "🔧", "⏭️", "📝"]);
+    // Skipped entries carry a useful label so the SKILL prose can surface
+    // why each was passed over.
+    expect(outcomes[0]?.label).toMatch(/applyStrategy is property-mod/);
+    expect(outcomes[2]?.label).toMatch(/applyStrategy is structural-mod/);
+    // The naming + annotation actions actually fired.
+    expect(namingScene.name).toBe("Hover");
+    expect(
+      (annotationScene.annotations as readonly AnnotationEntry[])[0]?.categoryId
+    ).toBe(CATEGORIES.flag);
+  });
+
+  it("returns an empty array for empty input", async () => {
+    mock = createFigmaGlobal({ nodes: {} });
+    installFigmaGlobal(mock);
+    expect(await applyAutoFixes([], { categories: CATEGORIES })).toEqual([]);
+  });
+
+  it("handles outcome shape consistently — every entry has nodeId/nodeName/ruleId/label", async () => {
+    mock = createFigmaGlobal({ nodes: {} });
+    installFigmaGlobal(mock);
+    const issues: AutoFixIssueInput[] = [
+      {
+        nodeId: "x",
+        ruleId: "irregular-spacing",
+        applyStrategy: "property-mod",
+        nodePath: "Page › Card",
+      },
+    ];
+    const outcomes = await applyAutoFixes(issues, { categories: CATEGORIES });
+    expect(outcomes[0]).toEqual({
+      outcome: "⏭️",
+      nodeId: "x",
+      nodeName: "Card",
+      ruleId: "irregular-spacing",
+      label: expect.stringContaining("skipped"),
+    });
+  });
+});

--- a/src/core/roundtrip/apply-auto-fix.ts
+++ b/src/core/roundtrip/apply-auto-fix.ts
@@ -1,0 +1,230 @@
+import { upsertCanicodeAnnotation } from "./annotations.js";
+import { applyWithInstanceFallback } from "./apply-with-instance-fallback.js";
+import type {
+  AnnotationProperty,
+  CanicodeCategories,
+  FigmaGlobal,
+  RoundtripQuestion,
+  RoundtripResult,
+} from "./types.js";
+
+declare const figma: FigmaGlobal;
+
+/**
+ * Subset of the analyze-response `issues[]` shape this helper consumes.
+ * Mirrors the fields surfaced by `buildResultJson` in `core/engine/scoring.ts`
+ * — kept narrow on purpose so a partial / synthesized issue (e.g. a fixture
+ * test) can still drive the helper without filling unrelated metadata.
+ */
+export interface AutoFixIssueInput {
+  nodeId: string;
+  ruleId: string;
+  applyStrategy?: string;
+  targetProperty?: string | string[];
+  suggestedName?: string;
+  sourceChildId?: string;
+  annotationProperties?: AnnotationProperty[];
+  message?: string;
+  nodePath?: string;
+  // Allow upstream callers to pass the full McpIssue without a structural
+  // mismatch — the helper only reads the named fields.
+  [key: string]: unknown;
+}
+
+/**
+ * Per-issue outcome accumulator (audit scope D follow-up).
+ *
+ * `outcome` mirrors the emoji vocabulary in `canicode-roundtrip/SKILL.md`
+ * Step 4 so the SKILL prose can read structured data instead of asking the
+ * LLM to format / re-count emoji bullets:
+ *
+ * - `🔧` — naming auto-fix succeeded (rename via `applyWithInstanceFallback`,
+ *   tier 1 scene write).
+ * - `🌐` — `applyWithInstanceFallback` escalated to a definition write
+ *   (only possible when the orchestrator passes `allowDefinitionWrite: true`).
+ * - `📝` — wrote a Figma annotation (default branch for non-naming rules,
+ *   plus the fallback path when `applyWithInstanceFallback` annotates instead
+ *   of writing).
+ * - `⏭️` — the issue was filtered out (currently only used by `applyAutoFixes`
+ *   when an issue's `applyStrategy !== "auto-fix"`; included for shape
+ *   symmetry with the other strategies that may emit it).
+ *
+ * The `nodeName` is the live name of the resolved scene node when available,
+ * falling back to the issue's `nodePath` and finally its `nodeId`. `label` is
+ * a short human description for surface logging and mirrors
+ * `RoundtripResult.label` from Strategies A/B/C.
+ */
+export type AutoFixOutcomeIcon = "🔧" | "🌐" | "📝" | "⏭️";
+
+export interface AutoFixOutcome {
+  outcome: AutoFixOutcomeIcon;
+  nodeId: string;
+  nodeName: string;
+  ruleId: string;
+  label: string;
+}
+
+export interface ApplyAutoFixContext {
+  categories: CanicodeCategories;
+  // Forwarded to `applyWithInstanceFallback` for the naming-rule branch so the
+  // orchestrator's ADR-012 opt-in flag controls the same tier-2 / tier-3
+  // policy as Strategies A and C.
+  allowDefinitionWrite?: boolean;
+  telemetry?: (event: string, props?: Record<string, unknown>) => void;
+}
+
+function pickNodeName(
+  issue: AutoFixIssueInput,
+  resolved: { name?: string } | null | undefined
+): string {
+  if (resolved && typeof resolved.name === "string" && resolved.name.length > 0) {
+    return resolved.name;
+  }
+  if (typeof issue.nodePath === "string" && issue.nodePath.length > 0) {
+    // `nodePath` is the breadcrumb (e.g. "Page › Frame › Button") — the last
+    // segment is the closest thing to the node's display name we have without
+    // a live Figma read.
+    const segments = issue.nodePath.split(/\s*[›>/]\s*/);
+    const tail = segments[segments.length - 1];
+    if (tail && tail.length > 0) return tail;
+  }
+  return issue.nodeId;
+}
+
+function mapInstanceFallbackIcon(
+  result: RoundtripResult
+): "🔧" | "🌐" | "📝" {
+  // Strategy D's naming branch reuses applyWithInstanceFallback's three-tier
+  // policy, which returns ✅ / 🌐 / 📝. Translate ✅ to 🔧 because the auto-fix
+  // wrap-up template (SKILL Step 4) reserves 🔧 for "auto-fix renamed" — ✅
+  // is owned by Strategy A property writes. 🌐 / 📝 pass through unchanged.
+  if (result.icon === "✅") return "🔧";
+  return result.icon;
+}
+
+/**
+ * Apply one Strategy D auto-fix issue. Branches on the same
+ * `targetProperty === "name" && suggestedName` test the SKILL.md prose used
+ * to carry inline:
+ *
+ * 1. **Naming branch** — rename via `applyWithInstanceFallback` so instance
+ *    children share the same tier-1/2/3 policy (and ADR-012 opt-in default)
+ *    as Strategy A. A successful scene rename surfaces as 🔧; a
+ *    propagated definition write surfaces as 🌐; a fallback annotation surfaces
+ *    as 📝.
+ * 2. **Annotation branch** — non-naming auto-fixes (`raw-value`,
+ *    `missing-interaction-state`, `missing-prototype`, …) record the issue's
+ *    `message` directly on the scene node under `categories.flag` so the
+ *    designer sees the flag in Dev Mode.
+ *
+ * The returned `AutoFixOutcome` is the per-issue input the SKILL Step 5
+ * tally consumes via `computeRoundtripTally` — `outcome === "🔧" | "🌐"` bumps
+ * `stepFourReport.resolved` (or `definitionWritten` for 🌐), `outcome === "📝"`
+ * bumps `annotated`, and `outcome === "⏭️"` (only emitted by `applyAutoFixes`
+ * for non-auto-fix issues) bumps `skipped`.
+ */
+export async function applyAutoFix(
+  issue: AutoFixIssueInput,
+  context: ApplyAutoFixContext
+): Promise<AutoFixOutcome> {
+  const { categories } = context;
+  const ruleId = issue.ruleId;
+
+  // Naming branch — `targetProperty === "name"` plus a pre-computed
+  // `suggestedName`. Routes through `applyWithInstanceFallback` so locked /
+  // instance-override / external-library nodes annotate cleanly instead of
+  // throwing the whole batch.
+  if (issue.targetProperty === "name" && typeof issue.suggestedName === "string") {
+    const suggestedName = issue.suggestedName;
+    const question: RoundtripQuestion = {
+      nodeId: issue.nodeId,
+      ruleId,
+      ...(issue.sourceChildId ? { sourceChildId: issue.sourceChildId } : {}),
+    };
+    const result = await applyWithInstanceFallback(
+      question,
+      (target) => {
+        if (target) {
+          (target as { name: string }).name = suggestedName;
+        }
+      },
+      {
+        categories,
+        ...(context.allowDefinitionWrite !== undefined
+          ? { allowDefinitionWrite: context.allowDefinitionWrite }
+          : {}),
+        ...(context.telemetry !== undefined
+          ? { telemetry: context.telemetry }
+          : {}),
+      }
+    );
+    // Re-read the scene name AFTER the write so the outcome reports the
+    // post-rename label rather than the pre-rename one. The helper already
+    // resolved this node once, but it's an in-memory map lookup in the mock
+    // and a cached lookup live (Figma deduplicates `getNodeByIdAsync` calls
+    // inside the same batch), so the cost is negligible.
+    const sceneAfter = await figma.getNodeByIdAsync(issue.nodeId);
+    return {
+      outcome: mapInstanceFallbackIcon(result),
+      nodeId: issue.nodeId,
+      nodeName: pickNodeName(issue, sceneAfter),
+      ruleId,
+      label: result.label,
+    };
+  }
+
+  // Annotation branch — record the issue message on the scene node so the
+  // designer sees it in Dev Mode under the canicode:flag category.
+  const scene = await figma.getNodeByIdAsync(issue.nodeId);
+  const markdown = issue.message ?? `Auto-flagged: ${ruleId}`;
+  if (scene) {
+    upsertCanicodeAnnotation(scene, {
+      ruleId,
+      markdown,
+      categoryId: categories.flag,
+      ...(issue.annotationProperties && issue.annotationProperties.length > 0
+        ? { properties: issue.annotationProperties }
+        : {}),
+    });
+  }
+  return {
+    outcome: "📝",
+    nodeId: issue.nodeId,
+    nodeName: pickNodeName(issue, scene),
+    ruleId,
+    label: scene
+      ? `annotation added to canicode:flag — ${ruleId}`
+      : `missing node (annotation skipped) — ${ruleId}`,
+  };
+}
+
+/**
+ * Loop wrapper — filters `issues` to `applyStrategy === "auto-fix"` and
+ * applies each one in sequence. Non-auto-fix entries are returned with
+ * `outcome === "⏭️"` so the caller can include them in a structured
+ * Step 4 report alongside Strategies A/B/C without a separate accumulator.
+ *
+ * The SKILL Step 4 prose used to inline the filter + branch + ad-hoc
+ * question shaping. Per ADR-303 / PR #303 that arithmetic now lives here
+ * with vitest coverage.
+ */
+export async function applyAutoFixes(
+  issues: readonly AutoFixIssueInput[],
+  context: ApplyAutoFixContext
+): Promise<AutoFixOutcome[]> {
+  const out: AutoFixOutcome[] = [];
+  for (const issue of issues) {
+    if (issue.applyStrategy !== "auto-fix") {
+      out.push({
+        outcome: "⏭️",
+        nodeId: issue.nodeId,
+        nodeName: pickNodeName(issue, null),
+        ruleId: issue.ruleId,
+        label: `skipped — applyStrategy is ${issue.applyStrategy ?? "absent"}`,
+      });
+      continue;
+    }
+    out.push(await applyAutoFix(issue, context));
+  }
+  return out;
+}

--- a/src/core/roundtrip/index.ts
+++ b/src/core/roundtrip/index.ts
@@ -15,6 +15,13 @@ export {
   readCanicodeAcknowledgments,
 } from "./read-acknowledgments.js";
 export { computeRoundtripTally } from "./compute-roundtrip-tally.js";
+export { applyAutoFix, applyAutoFixes } from "./apply-auto-fix.js";
+export type {
+  ApplyAutoFixContext,
+  AutoFixIssueInput,
+  AutoFixOutcome,
+  AutoFixOutcomeIcon,
+} from "./apply-auto-fix.js";
 export {
   isCanicodeAnnotation,
   removeCanicodeAnnotations,


### PR DESCRIPTION
## Summary

Closes #386. Bundles the audit add-on for the per-question outcome accumulator (audit scope D).

- New `applyAutoFix(issue, ctx)` + `applyAutoFixes(issues, ctx)` in `src/core/roundtrip/apply-auto-fix.ts` with vitest coverage. The loop body moves out of the canicode-roundtrip `SKILL.md` Strategy D prose (per ADR-303 / PR #303) and into TypeScript so the filter / branch / rename-vs-annotate split can no longer drift in the LLM transcript.
- The naming branch reuses `applyWithInstanceFallback`, so locked / read-only / instance-override nodes annotate cleanly instead of aborting the batch — same posture as Strategy A. The annotation branch routes through `upsertCanicodeAnnotation` under `categories.flag` and forwards `issue.message` + `issue.annotationProperties`.
- Helpers re-exported from `src/core/roundtrip/index.ts` and bundled into `.claude/skills/canicode-roundtrip/helpers.js` via `pnpm build:roundtrip` (+ `bundle:skills`). The SKILL.md Strategy D section is now a one-liner `await CanICodeRoundtrip.applyAutoFixes(...)` plus a brief note on the outcome shape; the helpers-bundled list also documents the new exports.

### Audit scope D — per-question outcome accumulator

Each call returns one `AutoFixOutcome` shaped as `{ outcome, nodeId, nodeName, ruleId, label }`. `outcome` is `"🔧" | "🌐" | "📝" | "⏭️"`, mirroring the SKILL Step 4 emoji vocabulary so the `stepFourReport` counters bump 1:1:

| outcome | bumps |
|---------|-------|
| `🔧` | `resolved` (rename succeeded; remaps `applyWithInstanceFallback`'s `✅` to keep `✅` reserved for Strategy A) |
| `🌐` | `definitionWritten` (only when `allowDefinitionWrite: true`) |
| `📝` | `annotated` (annotation branch + fallback path) |
| `⏭️` | `skipped` (only emitted by `applyAutoFixes` for non-auto-fix issues) |

`computeRoundtripTally`'s public shape is **unchanged** — the per-issue → counter rollup happens at the SKILL call site. No silent contract drift.

### Out of scope

Strategies A / B / C still return `RoundtripResult` (`{ icon, label }`). The shape is compatible enough that the SKILL can continue accumulating their counters into the same `stepFourReport`, but a follow-up could harmonize them to the same `AutoFixOutcome` shape so the SKILL prose drops the per-strategy mapping prose entirely. Did NOT expand here to keep the PR scoped to #386 — would file a follow-up issue if reviewers want it.

## Test plan

- [x] `pnpm lint` (tsc --noEmit) — clean
- [x] `pnpm test:run` — 965 / 965 (delta +10 for `apply-auto-fix.test.ts`)
- [x] `pnpm build` — including `build:roundtrip` regeneration + `bundle:skills` copy. Verified `helpers.js` exports `applyAutoFix` and `applyAutoFixes`.
- [x] New test cases: naming happy-path → 🔧, ✅→🔧 remap, instance-child rename via `applyWithInstanceFallback`, raw-value annotation → 📝, `annotationProperties` forwarded, generic markdown when `issue.message` absent, missing-node 📝 with `nodePath` derived nodeName, full filter loop (mix of property-mod / structural-mod / auto-fix), empty input.

## Files changed

- `src/core/roundtrip/apply-auto-fix.ts` (new)
- `src/core/roundtrip/apply-auto-fix.test.ts` (new)
- `src/core/roundtrip/index.ts` (re-export)
- `.claude/skills/canicode-roundtrip/SKILL.md` (Strategy D prose + helpers list)
- `.claude/skills/canicode-roundtrip/helpers.js` (regenerated via `pnpm build:roundtrip`)