### PR TITLE
ci(skill): add ADR-016 grep gate (scripts/check-skill-determinism) (#389)

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -404,7 +404,6 @@ Notes:
 
 The gotcha survey covers only blocking/risk severity. Lower-severity rules appear in `analyzeResult.issues[]` without a survey question. Each issue carries the same pre-computed fields (`applyStrategy`, `targetProperty`, `annotationProperties`, `suggestedName`, `isInstanceChild`, `sourceChildId`). The bundled helper handles the loop, the filter (`applyStrategy === "auto-fix"`), the naming-vs-annotation branch, and the per-issue outcome accumulator in one call:
 
-<!-- adr-016-ack: in-flight extraction tracked by #386 (Strategy D auto-fix loop + per-question outcome accumulator). Remove this ACK when the helper lands. -->
 ```javascript
 const outcomes = await CanICodeRoundtrip.applyAutoFixes(analyzeResult.issues, { categories });
 ```

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -311,6 +311,7 @@ await CanICodeRoundtrip.applyPropertyMod(question, answerValue, { categories });
 
 **Replicas (#356)** — when `question.replicaNodeIds` is present, the same answer must land on every replica instance. Iterate the merged set so each scene gets its own per-node failure routing (under the ADR-012 default each replica annotates independently; with `allowDefinitionWrite: true` they share the one definition write because they share the source):
 
+<!-- adr-016-ack: fan-out over an explicit small array of node IDs; the deterministic work lives inside applyPropertyMod -->
 ```javascript
 const targets = [question.nodeId, ...(question.replicaNodeIds ?? [])];
 for (const nodeId of targets) {
@@ -378,6 +379,7 @@ If the user **declines** any structural modification (or the instance-child guar
 
 Rules with `applyStrategy === "annotation"` cannot be auto-fixed via Plugin API. Add the gotcha answer as a Figma annotation so designers see it in Dev Mode. Use the helper — it handles the D1 mutex, D2 in-place upsert, and D4 category assignment. When `question.replicaNodeIds` is present (#356), iterate the merged set so every replica instance gets the annotation:
 
+<!-- adr-016-ack: fan-out over an explicit small array of node IDs; the deterministic work lives inside upsertCanicodeAnnotation -->
 ```javascript
 const targets = [question.nodeId, ...(question.replicaNodeIds ?? [])];
 for (const nodeId of targets) {
@@ -402,6 +404,7 @@ Notes:
 
 The gotcha survey covers only blocking/risk severity. Lower-severity rules appear in `analyzeResult.issues[]` without a survey question. Each issue carries the same pre-computed fields (`applyStrategy`, `targetProperty`, `annotationProperties`, `suggestedName`, `isInstanceChild`, `sourceChildId`). The bundled helper handles the loop, the filter (`applyStrategy === "auto-fix"`), the naming-vs-annotation branch, and the per-issue outcome accumulator in one call:
 
+<!-- adr-016-ack: in-flight extraction tracked by #386 (Strategy D auto-fix loop + per-question outcome accumulator). Remove this ACK when the helper lands. -->
 ```javascript
 const outcomes = await CanICodeRoundtrip.applyAutoFixes(analyzeResult.issues, { categories });
 ```
@@ -511,6 +514,7 @@ If Step 4 produced no `stepFourReport` (e.g. user skipped every question, or no 
   Grade: {oldGrade} → {newGrade}. Ready for code generation.
   ```
 - Clean up canicode annotations on fixed nodes via `use_figma`. Use the bundled `removeCanicodeAnnotations` helper — it gates on **categoryId** (the durable canicode-side identifier — the body no longer carries a `[canicode]` prefix per #353), includes `legacyAutoFix` if `ensureCanicodeCategories` returned it (pre-#355 `canicode:auto-fix` sweep), and also matches the legacy `**[canicode]` body prefix as a secondary marker for entries on files that have not been re-roundtripped yet. The match logic lives in `src/core/roundtrip/remove-canicode-annotations.ts` with vitest coverage so prose stays ADR-016-compliant:
+<!-- adr-016-ack: fan-out over an explicit small array of node IDs; the deterministic work lives inside removeCanicodeAnnotations -->
 ```javascript
 const nodeIds = ["id1", "id2"]; // nodes that now pass
 for (const id of nodeIds) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
+      - run: pnpm check:skill-determinism
       - run: pnpm build
       - run: pnpm test:run
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint": "tsc --noEmit",
     "build:plugin": "bash scripts/build-plugin.sh",
     "sync-docs": "tsx scripts/sync-rule-docs.ts",
+    "check:skill-determinism": "tsx scripts/check-skill-determinism.ts",
     "clean": "rm -rf dist skills"
   },
   "files": [

--- a/scripts/check-skill-determinism.test.ts
+++ b/scripts/check-skill-determinism.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  CODE_BLOCK_PATTERNS,
+  PROSE_PATTERNS,
+  SKILL_FILES,
+  scan,
+} from "./check-skill-determinism.js";
+
+const FILE = "skills/test/SKILL.md";
+
+const wrap = (lines: string[]): string => lines.join("\n");
+
+describe("check-skill-determinism", () => {
+  describe("regression suite — historical violations are caught", () => {
+    it("flags an inline `for` loop in a JS code block (Strategy D auto-fix loop, #386)", () => {
+      const md = wrap([
+        "```javascript",
+        "for (const issue of analyzeResult.issues) {",
+        "  doSomething(issue);",
+        "}",
+        "```",
+      ]);
+      const findings = scan(FILE, md);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.rule).toBe("code:for-loop");
+      expect(findings[0]?.line).toBe(2);
+    });
+
+    it("flags an inline `.filter(` array transform in a JS code block (Step 5 cleanup filter, #387 audit C)", () => {
+      const md = wrap([
+        "```javascript",
+        "const cleaned = annotations.filter(a => !a.categoryId);",
+        "```",
+      ]);
+      const findings = scan(FILE, md);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.rule).toBe("code:array-transform");
+    });
+
+    it("flags an inline `<count of ...>` template (Step 5 tally, #383)", () => {
+      const md = wrap([
+        "Tally inputs:",
+        "- X = <count of ✅ markers>",
+        "- Y = <count of 📝 markers>",
+      ]);
+      const findings = scan(FILE, md);
+      expect(findings.length).toBeGreaterThanOrEqual(2);
+      expect(findings.map((f) => f.rule)).toContain("prose:count-of-template");
+    });
+
+    it("flags imperative URL-parsing prose (designKey, #384, and dead fileKey, #387 audit B)", () => {
+      const md = wrap([
+        "Extract the `fileKey` from the Figma URL (format: `figma.com/design/:fileKey/...`).",
+      ]);
+      const findings = scan(FILE, md);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.rule).toBe("prose:url-parse");
+    });
+
+    it("flags `.split(` and `.match(` parsing in code blocks", () => {
+      const md = wrap([
+        "```javascript",
+        'const fileKey = url.split("/")[3];',
+        "const m = url.match(/node-id=([^&]+)/);",
+        "```",
+      ]);
+      const findings = scan(FILE, md);
+      expect(findings.map((f) => f.rule)).toEqual([
+        "code:string-split",
+        "code:string-match",
+      ]);
+    });
+
+    it("flags `new Set(` and `parseInt(` in code blocks", () => {
+      const md = wrap([
+        "```javascript",
+        "const ids = new Set(items.map(i => i.id));",
+        "const n = parseInt(answer, 10);",
+        "```",
+      ]);
+      const findings = scan(FILE, md);
+      // `.map(` is intentionally NOT flagged — too noisy (every API extraction
+      // pattern uses it). The collection construction and numeric parse are
+      // the actually-distinctive deterministic markers on this input.
+      expect(findings.map((f) => f.rule).sort()).toEqual([
+        "code:collection-construct",
+        "code:numeric-parse",
+      ]);
+    });
+  });
+
+  describe("acceptable patterns — must NOT be flagged", () => {
+    it("does not flag plain helper / SDK invocations", () => {
+      const md = wrap([
+        "```javascript",
+        "await CanICodeRoundtrip.applyPropertyMod(question, value, { categories });",
+        "const node = await figma.getNodeByIdAsync(id);",
+        "node.itemSpacing = 16;",
+        "```",
+      ]);
+      expect(scan(FILE, md)).toEqual([]);
+    });
+
+    it("does not flag prose lines that mention 'count' but not in the imperative-template shape", () => {
+      const md = wrap([
+        "The replicaNodeIds field carries the count of replica instances detected upstream.",
+        "Each scene gets its own per-node failure routing.",
+      ]);
+      expect(scan(FILE, md)).toEqual([]);
+    });
+
+    it("does not flag fenced code blocks in non-JS languages (e.g. shell, json, markdown templates)", () => {
+      const md = wrap([
+        "```bash",
+        "for i in 1 2 3; do echo $i; done",
+        "```",
+        "",
+        "```json",
+        '{ "for": "config" }',
+        "```",
+      ]);
+      expect(scan(FILE, md)).toEqual([]);
+    });
+
+    it("does not flag a code block immediately preceded by an `<!-- adr-016-ack: ... -->` marker", () => {
+      const md = wrap([
+        "<!-- adr-016-ack: fan-out over an explicit small array; deterministic work lives in the helper -->",
+        "```javascript",
+        "for (const nodeId of targets) {",
+        "  await CanICodeRoundtrip.applyPropertyMod({ ...question, nodeId }, answerValue, { categories });",
+        "}",
+        "```",
+      ]);
+      expect(scan(FILE, md)).toEqual([]);
+    });
+
+    it("does not flag prose with an inline `<!-- adr-016-ack: ... -->` marker on the same line", () => {
+      const md = "Extract the `fileKey` from the Figma URL. <!-- adr-016-ack: legacy doc, removal tracked elsewhere -->";
+      expect(scan(FILE, md)).toEqual([]);
+    });
+
+    it("does not flag a single line inside a code block that carries `// adr-016-ack:`", () => {
+      const md = wrap([
+        "```javascript",
+        "for (const id of nodeIds) { // adr-016-ack: fan-out, helper does the work",
+        "  await figma.getNodeByIdAsync(id);",
+        "}",
+        "```",
+      ]);
+      expect(scan(FILE, md)).toEqual([]);
+    });
+  });
+
+  describe("ACK marker grammar", () => {
+    it("does not exempt a code block when the ACK marker is two lines above (only the immediately preceding line counts)", () => {
+      const md = wrap([
+        "<!-- adr-016-ack: too far away -->",
+        "Some intervening prose.",
+        "```javascript",
+        "for (const x of xs) {}",
+        "```",
+      ]);
+      const findings = scan(FILE, md);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.rule).toBe("code:for-loop");
+    });
+
+    it("does not silently accept an ACK marker without a reason payload", () => {
+      const md = wrap([
+        "<!-- adr-016-ack: -->",
+        "```javascript",
+        "for (const x of xs) {}",
+        "```",
+      ]);
+      const findings = scan(FILE, md);
+      // Empty reason means the regex group fails to capture and the marker is
+      // treated as absent — the offending line is still flagged.
+      expect(findings).toHaveLength(1);
+    });
+  });
+
+  describe("module surface", () => {
+    it("exports a stable list of files in scope", () => {
+      expect(SKILL_FILES).toEqual([
+        ".claude/skills/canicode-roundtrip/SKILL.md",
+        ".claude/skills/canicode-gotchas/SKILL.md",
+        ".claude/skills/canicode/SKILL.md",
+      ]);
+    });
+
+    it("exports the pattern arrays for downstream introspection", () => {
+      expect(CODE_BLOCK_PATTERNS.length).toBeGreaterThan(0);
+      expect(PROSE_PATTERNS.length).toBeGreaterThan(0);
+      for (const { re, rule } of [...CODE_BLOCK_PATTERNS, ...PROSE_PATTERNS]) {
+        expect(re).toBeInstanceOf(RegExp);
+        expect(rule).toMatch(/^(code|prose):/);
+      }
+    });
+  });
+});

--- a/scripts/check-skill-determinism.ts
+++ b/scripts/check-skill-determinism.ts
@@ -1,0 +1,190 @@
+#!/usr/bin/env tsx
+/**
+ * ADR-016 enforcement — flags deterministic logic that has crept into
+ * `.claude/skills/*` SKILL.md files (either as imperative prose or as inline
+ * JS/TS code that re-implements something a TypeScript helper should own).
+ *
+ * Companion to the helpers.js bundle drift CI added in PR #303 — that one
+ * catches "helper changed but bundle didn't rebuild"; this one catches the
+ * inverse, "prose got new logic that should have been a helper".
+ *
+ * Findings can be silenced with an inline ACK marker on the line directly
+ * above the offending fenced code block (`<!-- adr-016-ack: reason -->`),
+ * inside the code block (`// adr-016-ack: reason`), or on the same line for
+ * prose findings (`<!-- adr-016-ack: reason -->`). Reviewers are expected to
+ * justify each marker in the PR description.
+ *
+ * Run locally: `pnpm check:skill-determinism` (also runs in CI before tests).
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+interface Finding {
+  file: string;
+  line: number;
+  rule: string;
+  excerpt: string;
+}
+
+interface Pattern {
+  re: RegExp;
+  rule: string;
+}
+
+/**
+ * Files in scope. Each is checked independently. The list is hard-coded
+ * rather than glob-expanded so adding a new SKILL deliberately requires a
+ * one-line edit here, which forces the author to read this file (and the ACK
+ * grammar) before introducing new prose surface.
+ */
+export const SKILL_FILES = [
+  ".claude/skills/canicode-roundtrip/SKILL.md",
+  ".claude/skills/canicode-gotchas/SKILL.md",
+  ".claude/skills/canicode/SKILL.md",
+];
+
+/**
+ * Patterns flagged inside fenced JS / TS code blocks. Each pattern matches a
+ * historical violation shape (see ADR-016 Why for the regression record).
+ * Genuine SDK / helper invocations (`figma.<api>(...)`,
+ * `CanICodeRoundtrip.<helper>(...)`, plain property reads/writes) do not
+ * match any of these.
+ */
+export const CODE_BLOCK_PATTERNS: Pattern[] = [
+  { re: /\.(filter|reduce|flatMap)\(/, rule: "code:array-transform" },
+  { re: /\bfor\s*(\(|await\s*\()/, rule: "code:for-loop" },
+  { re: /\bwhile\s*\(/, rule: "code:while-loop" },
+  { re: /\bnew\s+(Set|Map)\(/, rule: "code:collection-construct" },
+  { re: /\b(parseInt|parseFloat)\b/, rule: "code:numeric-parse" },
+  { re: /\.split\(['"`]/, rule: "code:string-split" },
+  { re: /\.match\(\//, rule: "code:string-match" },
+];
+
+/**
+ * Patterns flagged in prose (anywhere outside a fenced code block).
+ * Targeting the imperative shape "tell the LLM to compute X by doing Y" —
+ * the surface that historically masked dead `fileKey` extraction, the
+ * `<count of ✅>` tally inputs, and the URL parsing `survey.designKey`
+ * replaced.
+ */
+export const PROSE_PATTERNS: Pattern[] = [
+  { re: /<count\s+of\s/i, rule: "prose:count-of-template" },
+  { re: /count of (✅|🔧|🔗|📝|❌)/u, rule: "prose:emoji-counting" },
+  {
+    re: /\b(extract|parse)\b[^.\n]*\bfrom\b[^.\n]*\b(URL|node[- ]id|fileKey|file key)\b/i,
+    rule: "prose:url-parse",
+  },
+];
+
+const ACK_INLINE = /<!--\s*adr-016-ack:\s*([^>]+?)\s*-->/;
+const ACK_CODE_LINE = /\/\/\s*adr-016-ack:\s*(.+?)$/;
+
+const CHECKED_FENCE_LANGS = new Set(["js", "javascript", "ts", "typescript", ""]);
+
+/**
+ * Returns true only when the line carries an ACK marker AND the captured
+ * reason has at least one non-whitespace character. An empty / whitespace-only
+ * reason (e.g. `<!-- adr-016-ack: -->`) is treated as a missing ACK so a
+ * silenced finding still surfaces in CI — reviewer must add a real reason.
+ */
+function hasNonEmptyAck(line: string, re: RegExp): boolean {
+  const match = line.match(re);
+  if (!match) return false;
+  const reason = match[1] ?? "";
+  return reason.trim().length > 0;
+}
+
+export function scan(file: string, content: string): Finding[] {
+  const findings: Finding[] = [];
+  const lines = content.split("\n");
+
+  let inFence = false;
+  let fenceLang = "";
+  let blockAcked = false; // entire current block exempted via ACK on opening fence
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const lineNum = i + 1;
+
+    const fenceOpen = line.match(/^```([\w-]+)?\s*$/);
+    if (fenceOpen) {
+      if (!inFence) {
+        inFence = true;
+        fenceLang = (fenceOpen[1] ?? "").toLowerCase();
+        const prev = lines[i - 1] ?? "";
+        blockAcked = hasNonEmptyAck(prev, ACK_INLINE);
+      } else {
+        inFence = false;
+        fenceLang = "";
+        blockAcked = false;
+      }
+      continue;
+    }
+
+    if (inFence) {
+      if (!CHECKED_FENCE_LANGS.has(fenceLang)) continue;
+      if (blockAcked) continue;
+      if (hasNonEmptyAck(line, ACK_CODE_LINE)) continue;
+      for (const { re, rule } of CODE_BLOCK_PATTERNS) {
+        if (re.test(line)) {
+          findings.push({ file, line: lineNum, rule, excerpt: line.trim() });
+        }
+      }
+    } else {
+      if (hasNonEmptyAck(line, ACK_INLINE)) continue;
+      for (const { re, rule } of PROSE_PATTERNS) {
+        if (re.test(line)) {
+          findings.push({ file, line: lineNum, rule, excerpt: line.trim() });
+        }
+      }
+    }
+  }
+
+  return findings;
+}
+
+function main(): void {
+  const root = process.cwd();
+  const allFindings: Finding[] = [];
+
+  for (const rel of SKILL_FILES) {
+    const path = resolve(root, rel);
+    if (!existsSync(path)) continue;
+    const content = readFileSync(path, "utf-8");
+    allFindings.push(...scan(rel, content));
+  }
+
+  if (allFindings.length === 0) {
+    console.log("✓ check-skill-determinism: no ADR-016 violations found");
+    process.exit(0);
+  }
+
+  console.error("✗ check-skill-determinism: ADR-016 violations found\n");
+  console.error("  Per ADR-016 (.claude/docs/ADR.md), deterministic logic in");
+  console.error("  SKILL.md must be extracted to TypeScript with vitest coverage.");
+  console.error("  Each finding must either be:");
+  console.error("    (a) extracted to a helper in src/core/ + consumed via");
+  console.error("        helpers.js (canicode-roundtrip) or a response field");
+  console.error("        (canicode-gotchas), OR");
+  console.error("    (b) marked with `<!-- adr-016-ack: <reason> -->` on the");
+  console.error("        preceding line (for code blocks), or with");
+  console.error("        `// adr-016-ack: <reason>` inline (for individual code");
+  console.error("        lines), or `<!-- adr-016-ack: <reason> -->` on the");
+  console.error("        same line (for prose). Justify each ACK in the PR");
+  console.error("        description.\n");
+
+  for (const f of allFindings) {
+    console.error(`  ${f.file}:${f.line}  [${f.rule}]`);
+    console.error(`    ${f.excerpt}\n`);
+  }
+  console.error(`  ${allFindings.length} finding(s).`);
+  process.exit(1);
+}
+
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  process.argv[1]?.endsWith("check-skill-determinism.ts");
+if (isMain) {
+  main();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Summary

- Adds `scripts/check-skill-determinism.ts` — a TypeScript module + CLI that scans `.claude/skills/canicode-{roundtrip,gotchas,canicode}/SKILL.md` for deterministic-logic patterns that ADR-016 (#388 / #393) says belong in TypeScript helpers, not in SKILL.md prose.
- 16-test vitest suite (`scripts/check-skill-determinism.test.ts`) — pins each historical violation to a regression case and pins the ACK marker grammar so future tweaks to the patterns can't silently regress.
- Wired into CI as a step in the existing `test` job (`pnpm check:skill-determinism`, runs after `pnpm lint` and before `pnpm build`).
- Baseline pass: surfaced 4 `for` loops in `canicode-roundtrip/SKILL.md` on first run. All four are legitimate fan-out over a small explicit array (the deterministic work lives inside the helper they call); ACK'd inline with reason. After ACKs the check exits 0.

## Why (recap from #388)

PR #303 added a CI check for `helpers.js` bundle drift but there was no inverse check for prose-side deterministic logic creep. Every ADR-016 violation discovered after #303 — six known: #383, #384, #385, #386, plus the post-#387 audit's dead `fileKey` prose and inline cleanup filter — was caught by manual re-read, not by any automated gate. With #393 codifying ADR-016 in `.claude/docs/ADR.md`, this gate makes the rule enforceable instead of memory-dependent.

## What gets flagged

### Inside fenced JS / TS code blocks (`CODE_BLOCK_PATTERNS`)
| Pattern | Rule | Historical violation |
|---|---|---|
| `\.(filter\|reduce\|flatMap)\(` | `code:array-transform` | #387 audit C (`removeCanicodeAnnotations` inline filter) |
| `\bfor\s*(\(\|await\s*\()` | `code:for-loop` | #386 (Strategy D loop) |
| `\bwhile\s*\(` | `code:while-loop` | — |
| `\bnew\s+(Set\|Map)\(` | `code:collection-construct` | — |
| `\b(parseInt\|parseFloat)\b` | `code:numeric-parse` | — |
| `\.split\(['\"\`]` | `code:string-split` | #384 (URL parsing) |
| `\.match\(\/` | `code:string-match` | #384 (node-id regex) |

`.map(` is intentionally **excluded** — it is the canonical API extraction pattern (`items.map(i => i.id)`) and would generate too many false positives. Plain SDK / helper invocations (\`figma.X(...)\`, \`CanICodeRoundtrip.X(...)\`, property reads / writes) match none of the above.

### Outside code blocks (`PROSE_PATTERNS`)
| Pattern | Rule | Historical violation |
|---|---|---|
| `<count\s+of\s` | `prose:count-of-template` | #383 (Step 5 tally inputs) |
| `count of (✅\|🔧\|🔗\|📝\|❌)` | `prose:emoji-counting` | #383 (Step 5 emoji bullets) |
| `\b(extract\|parse).*from.*\b(URL\|node-id\|fileKey)\b` | `prose:url-parse` | #384 + #387 audit B (dead fileKey) |

## ACK marker grammar

Findings can be silenced via three marker positions:

1. **Block-level**: `<!-- adr-016-ack: <reason> -->` on the line **immediately above** a fenced code block exempts the entire block.
2. **Line-level**: `// adr-016-ack: <reason>` inline on a single code line exempts only that line.
3. **Prose**: `<!-- adr-016-ack: <reason> -->` on the **same line** as flagged prose exempts that line.

`hasNonEmptyAck` rejects markers with whitespace-only reasons — empty `<!-- adr-016-ack: -->` is treated as no marker so a silenced finding still surfaces. **Reviewer must justify each ACK in the PR description.**

## Baseline ACKs added in this PR

After the first run, four `for` loops in `canicode-roundtrip/SKILL.md` surfaced. Each is a legitimate fan-out over an explicit small array (the deterministic work lives inside the helper). ACK'd inline:

| Line | Loop | ACK reason |
|---|---|---|
| 314 | `for (const nodeId of targets) { applyPropertyMod }` | fan-out, helper does the work |
| 381 | `for (const nodeId of targets) { upsertCanicodeAnnotation }` | fan-out, helper does the work |
| 404 | `for (const issue of analyzeResult.issues)` | **in-flight extraction tracked by #386 — remove this ACK when the helper lands** |
| 538 | `for (const id of nodeIds) { removeCanicodeAnnotations }` | fan-out, helper does the work |

The line 404 ACK is intentionally written as a debt marker so #386's extraction PR will see it and remove it as part of that change.

## Files changed

| File | Change |
|---|---|
| `scripts/check-skill-determinism.ts` | NEW — 165-line module + CLI |
| `scripts/check-skill-determinism.test.ts` | NEW — 16-test vitest suite |
| `.claude/skills/canicode-roundtrip/SKILL.md` | +4 ACK markers |
| `.github/workflows/ci.yml` | +1 step (\`pnpm check:skill-determinism\`) |
| `package.json` | +1 script (\`check:skill-determinism\`) |
| `vitest.config.ts` | include \`scripts/**/*.test.ts\` |

6 files changed, +397 / -1.

## Test plan

- [x] \`pnpm check:skill-determinism\` exits 0 on the current SKILL state (after the 4 baseline ACKs).
- [x] \`pnpm test:run scripts/check-skill-determinism.test.ts\` — 16 / 16 pass.
- [x] \`pnpm lint\` clean.
- [x] \`pnpm test:run\` (full suite) — 971 / 971 pass.
- [x] \`pnpm build\` clean.
- [ ] Reviewer sanity-checks the four baseline ACKs are genuinely fan-out / in-flight cases and not hidden violations.
- [ ] Reviewer confirms the regression-pinned historical violations match the ones documented in #388 and ADR-016's Why section.

## Dependency on #393

This PR's error messages and code comments reference \"ADR-016\". That entry lands in [#393](https://github.com/let-sunny/canicode/pull/393). Cosmetic only — the gate works either way, but for the cleanest user experience the merge order should be #393 → #389. (#390 is the third companion follow-up, independent of merge order.)

Closes #389

Made with [Cursor](https://cursor.com)