### PR TITLE
process: add ADR-016 PR template checklist + monthly SKILL.md audit reminder workflow (#390)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!--
+This template is auto-loaded by GitHub when opening a PR. Delete sections
+that don't apply to your PR — the ADR-016 block at the bottom is the only
+project-specific gate, the rest is conventional.
+-->
+
+## Summary
+
+<!-- 1-3 bullets on what this PR does and why. Link the issue(s) it closes. -->
+
+-
+
+## Test plan
+
+<!-- Checklist of how you / the reviewer can verify this PR works. -->
+
+- [ ]
+
+## ADR-016 checklist (deterministic logic in SKILL.md)
+
+ADR-016 (`.claude/docs/ADR.md`) requires that any deterministic transformation, predicate, accumulator, sort/group/partition, parser, or state-machine asked of the LLM in a `.claude/skills/*/SKILL.md` file lives in TypeScript with vitest coverage — not in SKILL.md prose. CI enforces this via `pnpm check:skill-determinism` (PR #389), but a few patterns the grep gate cannot catch require author judgment.
+
+Tick **one**:
+
+- [ ] This PR does **not** edit any `.claude/skills/*/SKILL.md` file.
+- [ ] This PR edits a SKILL.md file, and every prose change I added is purely workflow orchestration / rendering template / branching on a pre-computed field / LLM judgment. Anything with a deterministic input → output mapping has been extracted to `src/core/` with vitest coverage and is consumed via either `helpers.js` (`canicode-roundtrip`, see PR #303) or a `gotcha-survey` response field (`canicode-gotchas`, see PRs #381 / #387 for the pattern).
+
+If I extracted the **computation** side of a deterministic flow, I also extracted the **input collection** and **output rendering** sides on the same flow (the half-extraction lesson from #383 → #386 — extracting `computeRoundtripTally` while leaving the LLM to count its own emoji bullets did not close the drift surface):
+
+- [ ] N/A — no deterministic extraction in this PR.
+- [ ] Yes — full cycle is in TS.
+
+If I added an `<!-- adr-016-ack: ... -->` or `// adr-016-ack: ...` marker in any SKILL.md, I justified each one in the **Summary** section above (the grep gate accepts the marker but reviewers should still see why):
+
+- [ ] N/A — no new ACK markers.
+- [ ] Yes — each new ACK is explained above.

--- a/.github/workflows/skill-audit-reminder.yml
+++ b/.github/workflows/skill-audit-reminder.yml
@@ -1,0 +1,108 @@
+name: SKILL.md ADR-016 audit reminder
+
+# Opens a periodic audit issue so SKILL.md drift is re-checked on a fixed
+# cadence even when no individual PR adds anything that the grep gate
+# (`pnpm check:skill-determinism`, PR #389) catches. The grep gate covers
+# pattern-level regressions; this workflow covers accumulated drift — small
+# prose adjustments across many PRs that each look harmless individually but
+# together blur the line between LLM judgment and deterministic logic. The
+# post-#387 audit is the precedent: it found two pre-existing violations
+# (dead `fileKey` prose, inline cleanup filter) that had survived several PRs
+# because no individual PR ever changed them and no scheduled re-read was on
+# the calendar.
+#
+# Cadence: 1st of every month at 09:00 UTC. The job is also exposed via
+# `workflow_dispatch` so a maintainer can trigger an off-cycle audit (e.g.
+# right after a large SKILL.md refactor lands) without waiting for the next
+# scheduled run.
+
+on:
+  schedule:
+    # min hour day-of-month month day-of-week
+    - cron: "0 9 1 * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  open-audit-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Open audit issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          CYCLE_TAG="$(date -u +'%Y-%m')"
+          TITLE="SKILL.md ADR-016 audit (cycle ${CYCLE_TAG})"
+
+          # Idempotency: if an issue with this exact title already exists
+          # (open or closed), skip. Prevents duplicate issues if the workflow
+          # gets triggered twice in the same month (e.g. scheduled run +
+          # manual workflow_dispatch).
+          EXISTING="$(gh issue list \
+            --search "in:title \"${TITLE}\"" \
+            --state all \
+            --json number,title \
+            --jq '.[] | select(.title == "'"${TITLE}"'") | .number' \
+            | head -n1)"
+
+          if [ -n "${EXISTING}" ]; then
+            echo "Audit issue for cycle ${CYCLE_TAG} already exists as #${EXISTING}; skipping."
+            exit 0
+          fi
+
+          gh issue create \
+            --title "${TITLE}" \
+            --label "chore" \
+            --body "$(cat <<'BODY'
+          Periodic re-audit of `.claude/skills/canicode-{roundtrip,gotchas,canicode}/SKILL.md` against ADR-016 (`.claude/docs/ADR.md`). Auto-opened by `.github/workflows/skill-audit-reminder.yml` (issue #390).
+
+          ## Why this exists
+
+          The grep gate from PR #389 (`pnpm check:skill-determinism`) catches pattern-level violations the moment they're added to a PR. This audit covers what the grep gate cannot: **accumulated drift** — small prose adjustments across many PRs that each look harmless individually but together blur the line between LLM judgment and deterministic logic. The post-#387 audit is the precedent: it found two pre-existing violations (dead `fileKey` prose, inline cleanup filter) that had survived several PRs because no individual PR ever changed them and no scheduled re-read was on the calendar.
+
+          ## Audit checklist
+
+          For each SKILL.md file in scope:
+
+          - [ ] `.claude/skills/canicode-roundtrip/SKILL.md`
+          - [ ] `.claude/skills/canicode-gotchas/SKILL.md`
+          - [ ] `.claude/skills/canicode/SKILL.md`
+
+          Re-read each one cover-to-cover and check:
+
+          1. **Imperative deterministic prose** — does any line tell the LLM to count, sum, extract, parse, classify, walk, accumulate, or filter something where the inputs and outputs are both deterministic? If yes, file an extraction issue and link it here.
+          2. **Inline JS / TS code blocks** — does any block contain logic beyond a helper / SDK invocation? Loops, filters, accumulators, parsers should all live in `src/core/` with vitest coverage. If yes, file an extraction issue.
+          3. **Stale `<!-- adr-016-ack: ... -->` markers** — for every ACK in the file, is the justification still valid? In particular, ACKs that reference an in-flight extraction issue (e.g. "tracked by #386 — remove when helper lands") should be removed once the referenced PR has merged. List any stale ACKs here.
+          4. **Dead prose** — does any prose section reference a field, helper, or workflow step that no longer exists? The dead `fileKey` extraction prose in `canicode-roundtrip/SKILL.md` survived ~6 months past the last call site that needed it; an audit catches this.
+
+          ## Findings
+
+          File each finding as a separate GitHub issue (don't bundle them into this one) so they can be triaged and assigned independently. List them below as you file them:
+
+          - [ ] *(no findings yet — re-edit this section as you audit)*
+
+          ## Closing this issue
+
+          Close when:
+          - All three SKILL.md files have been re-read.
+          - Every finding has its own tracking issue.
+          - No stale ACK markers remain (or each remaining stale ACK has its own removal issue).
+
+          If the audit found zero issues, close with a comment saying so — the close timestamp itself is the audit record.
+
+          ## References
+
+          - ADR-016 (`.claude/docs/ADR.md`) — the rule this audit enforces.
+          - PR #303 — origin of the rule (`helpers.js` IIFE pattern + bundle drift CI).
+          - PR #387 — the audit precedent that found the two pre-existing violations.
+          - PR #389 — the grep gate this audit complements.
+          - Issue #390 — this audit cadence proposal.
+          BODY
+          )"
+
+          echo "Opened audit issue for cycle ${CYCLE_TAG}."

--- a/.github/workflows/skill-audit-reminder.yml
+++ b/.github/workflows/skill-audit-reminder.yml
@@ -99,6 +99,7 @@ jobs:
 
           - ADR-016 (`.claude/docs/ADR.md`) — the rule this audit enforces.
           - PR #303 — origin of the rule (`helpers.js` IIFE pattern + bundle drift CI).
+          - PRs #381, #387, #391, #392 — extraction precedents (`groupedQuestions` response field, Step 5 tally + cleanup filter, `upsertGotchaSection`, `applyAutoFix`).
           - PR #387 — the audit precedent that found the two pre-existing violations.
           - PR #389 — the grep gate this audit complements.
           - Issue #390 — this audit cadence proposal.


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` (project had no PR template) with an **ADR-016 checklist** at the bottom — three checkbox groups covering the prose-restriction contract, the full-cycle extraction principle (#383 → #386 lesson), and per-ACK justification.
- Adds `.github/workflows/skill-audit-reminder.yml` — monthly cron + manual `workflow_dispatch` that opens an issue titled \`SKILL.md ADR-016 audit (cycle YYYY-MM)\` with a re-audit checklist. Idempotent: skips if an issue with the exact title already exists (open or closed). Uses the existing `chore` label so no label setup needed.
- Both are **human-side process backstops** behind the automated gates from #393 (codification) and #394 (grep gate). Together the four PRs (#393, #394, this one, plus the `closes` linkage from #388) cover the regression surface that the post-#387 audit exposed: rule discoverability, automated detection at PR time, author-side reminder, and periodic re-audit.

## Why both, instead of just one

| Layer | What it catches | Where it fails |
|---|---|---|
| ADR-016 (#393) | Rule is now grep-able | Authors still need to remember to apply it |
| Grep gate (#394) | Pattern-level violations the moment they're added | Cannot catch *accumulated* drift across many small PRs |
| **PR template (this PR)** | Author-side reminder at the moment of authoring | Voluntary checkbox — nothing forces a tick |
| **Audit cadence (this PR)** | Accumulated drift, stale ACKs, dead prose — the post-#387 audit precedent | Once a month is a long time |

The four layers stack: each catches what the prior one cannot, and the cost of the lighter layers (a checkbox in the template, a monthly cron job) is essentially zero.

## What the PR template looks like

The ADR-016 section uses a tick-**one** pattern instead of "check all that apply" so authors who don't touch SKILL.md aren't penalized:

```markdown
## ADR-016 checklist (deterministic logic in SKILL.md)

Tick **one**:
- [ ] This PR does **not** edit any `.claude/skills/*/SKILL.md` file.
- [ ] This PR edits a SKILL.md file, and every prose change I added is
      purely workflow orchestration / rendering template / branching on
      a pre-computed field / LLM judgment. ...
```

Plus two follow-up groups for the full-cycle extraction principle and ACK justification. Total ~30 lines added at the bottom of the template; the rest is conventional `## Summary` / `## Test plan` blocks. Reviewers can adjust copy in this PR.

## What the audit workflow does

- Cron: `0 9 1 * *` — 09:00 UTC on the 1st of each month.
- Manual trigger: `workflow_dispatch` for off-cycle audits (e.g. right after a large SKILL.md refactor lands).
- Permissions: `issues: write` only (least privilege).
- Idempotency: greps existing issues by exact title. If one with the same `cycle YYYY-MM` tag exists (open OR closed), the job exits 0 with a skip message. Prevents duplicate issues from scheduled + manual runs in the same month.
- Issue body carries the re-audit checklist: re-read each of the three SKILL.md files, look for imperative deterministic prose / inline JS-TS code blocks beyond helper invocations / stale ACK markers / dead prose. Each finding gets filed as a separate tracking issue (no bundling).

### Cadence rationale (proposed; reviewer may adjust)

The post-#303 violation rate was four extraction PRs (#383, #384, #385, #386) plus two more pre-existing violations from the post-#387 audit, all over ~1 month. **Monthly** matches that velocity. If the violation rate drops post-#393 / #394 (both close root-cause loops, not just symptoms), the cadence can be relaxed to quarterly via a one-line cron edit.

## Why scheduled cron, not PR-counter-based

The original #390 issue body offered both Part B (line-counter-based, opens audit when SKILL churn > N) and Part C (scheduled cron). I went with Part C because:

- Part B requires a stateful workflow that tracks SKILL.md churn across PRs since the last audit closed, plus reset logic when the audit issue gets filed. For project size (one maintainer, modest PR volume) the simpler approach pays for itself.
- Part C is one cron line, one idempotency check, no state.
- Either approach can be swapped for the other later — the issue body that gets opened is the same.

## Files changed

| File | Change |
|---|---|
| `.github/pull_request_template.md` | NEW — 35 lines |
| `.github/workflows/skill-audit-reminder.yml` | NEW — 109 lines |

2 files changed, +144 / -0.

## Test plan

- [x] \`pnpm lint\` clean (no source touched).
- [x] YAML structurally validated locally (parses, contains `on:` and `jobs:` blocks).
- [ ] Reviewer confirms the PR template copy reads correctly when GitHub auto-loads it on a new draft PR.
- [ ] After merge, manually trigger the audit workflow once via `workflow_dispatch` to verify the `gh issue create` step actually runs end-to-end (the only way to confirm the workflow's runtime behavior — local YAML validation can't catch \`gh\` CLI / permissions issues).
- [ ] Confirm the workflow's idempotency check by triggering it twice in the same month — second run should print the skip message and exit 0.

## Dependency note

This PR's checklist text and audit issue body both reference \"ADR-016\" by name. That entry lands in [#393](https://github.com/let-sunny/canicode/pull/393). For the cleanest PR-template UX, merge #393 → #394 → this one. The workflow itself works regardless of merge order — it just opens an issue, the issue body's references take effect once readers click through.

Closes #390

Made with [Cursor](https://cursor.com)