### PR TITLE
chore(release): v0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
   "type": "module",


### PR DESCRIPTION
14 commits since v0.10.3 — bug fixes from the live walkthrough on Simple Design System (Community), gotcha-survey UX features, and ADR-016 codification of the SKILL.md determinism rule.

## Bug fixes — discovered in v0.10.3 walkthrough on 2026-04-20

| PR | Issue | Change |
|---|---|---|
| #375 | #363 | `probeDefinitionWritability` walks up parent chain to containing COMPONENT/COMPONENT_SET to read `.remote` (was always `undefined` on TEXT/FRAME children → false-negative on every external library) |
| #376 | #374 | `missing-size-constraint` `targetProperty` returns both `[minWidth, maxWidth]` so the `{minWidth, maxWidth}` answer shape lands fully |
| #377 | #373 | Sibling dedupe skips instance-child issues so the `#356` source-component dedupe owns them with `replicaNodeIds` fan-out |
| #378 | #372 | `inconsistent-naming-convention` suppressed when the case-conversion produces the same name (no-op rename) |
| #379 | #365 | MCP `analyze` tool's `openReport` is opt-in (default `false`) — no more browser pop-up mid-roundtrip |
| #380 | #364, #366, #367 | README install: long-form `--yes --package=` (short `-y -p` collides with `claude mcp add` parser), drop broken `-e FIGMA_TOKEN`, "pick one" matrix |

## Features

| PR | Issue | Change |
|---|---|---|
| #381 | #368, #369, #370 | `gotcha-survey` response carries `groupedQuestions` (source-component group + batchable rule batch); Strategy B instance-child guard with a/b confirmation |
| #382 | #371 | Re-analyze recognises canicode-authored Figma annotations as **acknowledgments** (half-weight density) so the `32 → 32` "nothing happened" wrap-up reads `V_ack acknowledged / V_open unaddressed` instead |

## ADR-016 codification — deterministic logic in SKILL.md must live in TS

| PR | Issue | Change |
|---|---|---|
| #387 | #383, #384 | `computeRoundtripTally` + canonical `computeDesignKey` + `removeCanicodeAnnotations` filter extracted to TS (Step 5 emoji counting + URL parsing dupe fix) |
| #391 | #385 | `upsert-gotcha-section` helper + `canicode gotcha-upsert` CLI subcommand (4-state file detect + section walking + monotonic NNN) |
| #392 | #386 | `applyAutoFix` Strategy D loop extracted to plugin-sandbox helper |
| #393 | #388 | ADR-016 codified in `.claude/docs/ADR.md` (deterministic logic in SKILL.md must live in TS — the rule that the rest of this section enforces) |
| #394 | #389 | `scripts/check-skill-determinism.ts` grep CI gate — flags new pseudocode/algorithm-in-prose without an `<!-- adr-016-ack: ... -->` marker |
| #395 | #390 | `.github/PULL_REQUEST_TEMPLATE.md` ADR-016 checklist + monthly SKILL.md audit reminder workflow |

## Verification

- 1003/1003 vitest tests pass
- `pnpm lint` clean
- `pnpm build` clean (CLI + roundtrip + skills bundle)

## Methodology note — Dual-agent UAT continues

v0.10.3's [Experiment 09](https://github.com/let-sunny/canicode/wiki/Experiment-09-onboarding-execution-2026-04-19) walkthrough surfaced 6 bugs + 3 features in this release. v0.10.4 should run the same walkthrough on the same fixture (or a fresh community design) before tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)