### PR TITLE
docs(adr): rule-based best-practice detection and annotation output

### DIFF
--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -24,7 +24,7 @@ Core decisions that shape every session. ADRs are listed by ADR number; chronolo
 
 **Decision**: Analysis score predicts how many gotchas (manual annotations) a design needs for correct implementation.
 **Why**: Roundtrip pivot — canicode diagnoses, then elicits gotchas from users. S-grade = no gotchas needed, D-grade = many needed.
-**Impact**: Score/lint framing should always connect to gotcha burden. See [Round-Trip Integration wiki](https://github.com/let-sunny/canicode/wiki/Round-Trip-Integration).
+**Impact**: Score/lint framing should always connect to gotcha burden. Rule results and gotcha annotations are parallel outputs from the same detection pass (formalized in ADR-017): score captures best-practice risk, gotcha captures missing implementation context. See [Round-Trip Integration wiki](https://github.com/let-sunny/canicode/wiki/Round-Trip-Integration).
 
 ## ADR-005: Platform standards cover web + app
 
@@ -197,3 +197,25 @@ This rule was originally established in [PR #303](https://github.com/let-sunny/c
 **Verification**: This is a process / coding-standard ADR, not an empirical one — there is no experiment to cite. The supporting evidence is the regression record cited under **Why** above (six known violations across two SKILL files, all caught only by manual audit, all with the same root cause). The rule's automated enforcement is split across two follow-ups (#389 grep CI, #390 PR template / audit cadence), each with its own test plan.
 
 **References**: PR #303 (origin of the rule), PR #381 (response-field channel pattern: `groupedQuestions`), PR #387 (helpers.js channel + half-extraction lesson: `computeRoundtripTally`, `removeCanicodeAnnotations`), PR #391 (`upsertGotchaSection` extraction, closes [#385](https://github.com/let-sunny/canicode/issues/385)), PR #392 (`applyAutoFix` Strategy D extraction, closes [#386](https://github.com/let-sunny/canicode/issues/386)), [#388](https://github.com/let-sunny/canicode/issues/388) (this ADR), [#389](https://github.com/let-sunny/canicode/issues/389) (grep CI), [#390](https://github.com/let-sunny/canicode/issues/390) (PR template + audit cadence).
+
+## ADR-017: Rule/Gotcha output channels — rule-first trigger, score-second signal
+
+**Decision**: Define rules first as the trigger layer for gotcha collection, and second as the score-signal layer. Keep gotchas rule-triggered, and make output channels explicit. A rule firing on a node emits two independent outputs:
+- **Rule output (score channel)**: best-practice signal for readiness scoring
+- **Gotcha output (annotation channel)**: missing context that Figma cannot encode natively, written for downstream implementation
+
+Rules split into two subtypes by primary purpose:
+- **Violation rule**: gotcha-trigger + score-primary. Node is violating a best-practice expectation (typical score range: -3 to -10).
+- **Info-collection rule**: annotation-primary. Node is not necessarily "wrong," but implementation-critical context is absent from Figma (typical score: -1 or 0).
+
+Gotcha answers do not retroactively erase the rule score. Scores represent design best-practice state; gotcha answers represent annotation completeness. They are correlated but not the same mechanism.
+
+**Why**: Prior docs used "rules trigger gotchas" correctly but blurred the purpose boundary, making low-severity information-collection behavior look like weak violation detection. The explicit two-channel model keeps rule evaluation coherent while acknowledging that some checks exist mainly to collect annotation context (for example interaction intent/state) rather than to penalize design quality.
+
+**Impact**:
+- Rule authors can classify intent explicitly (violation vs info-collection) without changing the core "rules trigger gotchas" invariant.
+- Scoring remains meaningful: severe violations still dominate readiness penalties; info-collection checks stay low-penalty while still producing required gotcha prompts.
+- Gotcha persistence/dedupe policy can vary by subtype in follow-up architecture work (annotation continuity matters more for info-collection checks).
+- Documentation and skills should frame gotchas as annotation completion for `figma-implement-design`, not only as violation remediation prompts.
+
+**References**: ADR-004 (score framing), ADR-013 (scope boundary), [Round-Trip Integration wiki](https://github.com/let-sunny/canicode/wiki/Round-Trip-Integration), #402, #405, #406.

--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -198,9 +198,9 @@ This rule was originally established in [PR #303](https://github.com/let-sunny/c
 
 **References**: PR #303 (origin of the rule), PR #381 (response-field channel pattern: `groupedQuestions`), PR #387 (helpers.js channel + half-extraction lesson: `computeRoundtripTally`, `removeCanicodeAnnotations`), PR #391 (`upsertGotchaSection` extraction, closes [#385](https://github.com/let-sunny/canicode/issues/385)), PR #392 (`applyAutoFix` Strategy D extraction, closes [#386](https://github.com/let-sunny/canicode/issues/386)), [#388](https://github.com/let-sunny/canicode/issues/388) (this ADR), [#389](https://github.com/let-sunny/canicode/issues/389) (grep CI), [#390](https://github.com/let-sunny/canicode/issues/390) (PR template + audit cadence).
 
-## ADR-017: Rule/Gotcha output channels — rule-first trigger, score-second signal
+## ADR-017: Rule/Gotcha output channels — rule-based best-practice detection; gotcha as annotation output
 
-**Decision**: Define rules first as the trigger layer for gotcha collection, and second as the score-signal layer. Keep gotchas rule-triggered, and make output channels explicit. A rule firing on a node emits two independent outputs:
+**Decision**: Define rules as a rule-based best-practice detection layer, with gotcha as annotation output from the same detection pass. Keep gotchas rule-triggered, and make output channels explicit. A rule firing on a node emits two independent outputs:
 - **Rule output (score channel)**: best-practice signal for readiness scoring
 - **Gotcha output (annotation channel)**: missing context that Figma cannot encode natively, written for downstream implementation
 

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -24,12 +24,15 @@
 - Data source: `gotcha-survey` MCP tool OR `npx canicode gotcha-survey --json` CLI fallback (canicode MCP server is optional)
 - Workflow: calls gotcha-survey → presents questions to user → collects answers → writes `.claude/skills/canicode-gotchas/SKILL.md` in the user's project
 - Output: skill file with design gotcha Q&A pairs (nodeId, ruleId, severity, question, answer)
+- Purpose: collect implementation context that Figma cannot encode natively and persist it as annotation-ready gotcha answers for downstream `figma-implement-design`
+- Trigger model: rules are the primary gotcha trigger layer; scoring is a secondary signal from the same detection pass. Triggering rules may be violation rules (score-primary) or info-collection rules (annotation-primary), per ADR-017
 - **Augmentation handoff**: Auto-discovery of a separate skill file cannot reach `figma-implement-design` (Figma skills only support explicit cross-references). The `canicode-roundtrip` orchestration skill (#277) connects analyze → gotcha survey → apply to Figma in a single flow; the user then invokes `figma-implement-design` for code generation (ADR-009, ADR-013).
 
 **3b. Claude Code Skill (`/canicode-roundtrip`)**
 - Location: `.claude/skills/canicode-roundtrip/SKILL.md` (copy to any project)
 - Data source: `analyze` + `gotcha-survey` MCP tools OR `npx canicode analyze/gotcha-survey --json` CLI fallback (canicode MCP server is optional). Figma MCP (`get_design_context`, `get_screenshot`, `use_figma`) is still REQUIRED — there is no CLI fallback for `use_figma`.
 - Workflow: analyze → gate on `isReadyForCodeGen` → gotcha survey (if needed) → **apply fixes to Figma via `use_figma`** → re-analyze → ready for `figma-implement-design`
+- Scope note: analysis scope (page/screen vs standalone component) directly changes rule evaluation intent and therefore which gotcha prompts appear; scope-sensitive behavior is architecture-owned (see #404)
 - True roundtrip: gotcha answers are applied back to the Figma design (property modification, structural modification with confirmation, or annotations for unfixable issues) so the design itself improves. Code generation is the user-driven downstream step (ADR-013) — canicode hands off once the re-analyze passes.
 - Requires Figma Full seat + file edit permission for `use_figma`; falls back to one-way flow (gotcha answers stay as a separate skill file the user can reference) if no edit permission
 - See #281, ADR-010

--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -25,7 +25,7 @@
 - Workflow: calls gotcha-survey → presents questions to user → collects answers → writes `.claude/skills/canicode-gotchas/SKILL.md` in the user's project
 - Output: skill file with design gotcha Q&A pairs (nodeId, ruleId, severity, question, answer)
 - Purpose: collect implementation context that Figma cannot encode natively and persist it as annotation-ready gotcha answers for downstream `figma-implement-design`
-- Trigger model: rules are the primary gotcha trigger layer; scoring is a secondary signal from the same detection pass. Triggering rules may be violation rules (score-primary) or info-collection rules (annotation-primary), per ADR-017
+- Trigger model: rules run as rule-based best-practice detection, and gotcha is emitted as annotation output from the same detection pass. Triggering rules may be violation rules (score-primary) or info-collection rules (annotation-primary), per ADR-017
 - **Augmentation handoff**: Auto-discovery of a separate skill file cannot reach `figma-implement-design` (Figma skills only support explicit cross-references). The `canicode-roundtrip` orchestration skill (#277) connects analyze → gotcha survey → apply to Figma in a single flow; the user then invokes `figma-implement-design` for code generation (ADR-009, ADR-013).
 
 **3b. Claude Code Skill (`/canicode-roundtrip`)**

--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -5,7 +5,7 @@ description: Gotcha survey workflow plus accumulating per-design answers — one
 
 # CanICode Gotchas -- Design Gotcha Survey & Skill Writer
 
-Run a gotcha survey on a Figma design to identify implementation pitfalls, collect developer answers, and upsert them into this skill file so code generation agents can reference them automatically. The file has two regions: the **Workflow** below (installed by `canicode init`, never overwritten) and the **Collected Gotchas** region at the bottom (one numbered section per design, replaced in place on re-runs).
+Run a gotcha survey on a Figma design to collect implementation context that Figma cannot encode natively, capture developer/designer answers, and upsert them into this skill file so downstream `figma-implement-design` runs have annotation-ready context. In this model, rules are primarily gotcha triggers; score is a secondary readiness signal. Some gotchas come from violation rules (what is wrong and how to resolve it); others come from info-collection rules (neutral context Figma cannot represent, like interaction intent/state). The file has two regions: the **Workflow** below (installed by `canicode init`, never overwritten) and the **Collected Gotchas** region at the bottom (one numbered section per design, replaced in place on re-runs).
 
 ## Prerequisites
 

--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -5,7 +5,7 @@ description: Gotcha survey workflow plus accumulating per-design answers — one
 
 # CanICode Gotchas -- Design Gotcha Survey & Skill Writer
 
-Run a gotcha survey on a Figma design to collect implementation context that Figma cannot encode natively, capture developer/designer answers, and upsert them into this skill file so downstream `figma-implement-design` runs have annotation-ready context. In this model, rules are primarily gotcha triggers; score is a secondary readiness signal. Some gotchas come from violation rules (what is wrong and how to resolve it); others come from info-collection rules (neutral context Figma cannot represent, like interaction intent/state). The file has two regions: the **Workflow** below (installed by `canicode init`, never overwritten) and the **Collected Gotchas** region at the bottom (one numbered section per design, replaced in place on re-runs).
+Run a gotcha survey on a Figma design to collect implementation context that Figma cannot encode natively, capture developer/designer answers, and upsert them into this skill file so downstream `figma-implement-design` runs have annotation-ready context. In this model, rules do rule-based best-practice detection, and gotcha is the annotation output from that detection. Some gotchas come from violation rules (what is wrong and how to resolve it); others come from info-collection rules (neutral context Figma cannot represent, like interaction intent/state). The file has two regions: the **Workflow** below (installed by `canicode init`, never overwritten) and the **Collected Gotchas** region at the bottom (one numbered section per design, replaced in place on re-runs).
 
 ## Prerequisites
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,8 @@ Rules are classified into 4 severity levels:
 - **missing-info**: Information is absent, forcing developers to guess.
 - **suggestion**: Not immediately problematic, but improves systemization.
 
+Severity labels describe user impact, while rule purpose may differ (ADR-017): rules are first-class gotcha triggers, and score is a secondary readiness signal. Violation rules remain score-primary best-practice checks; info-collection rules are annotation-primary checks for context Figma cannot encode. In practice, info-collection rules should usually stay in low-penalty ranges (commonly `missing-info` or `suggestion` severity, depending on implementation risk).
+
 ## Adjustable Rule Config
 
 All rule scores, severity, and thresholds are managed in `rules/rule-config.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ Rules are classified into 4 severity levels:
 - **missing-info**: Information is absent, forcing developers to guess.
 - **suggestion**: Not immediately problematic, but improves systemization.
 
-Severity labels describe user impact, while rule purpose may differ (ADR-017): rules are first-class gotcha triggers, and score is a secondary readiness signal. Violation rules remain score-primary best-practice checks; info-collection rules are annotation-primary checks for context Figma cannot encode. In practice, info-collection rules should usually stay in low-penalty ranges (commonly `missing-info` or `suggestion` severity, depending on implementation risk).
+Severity labels describe user impact, while rule purpose may differ (ADR-017): rules perform rule-based best-practice detection, and gotcha is annotation output from that detection pass. Violation rules remain score-primary best-practice checks; info-collection rules are annotation-primary checks for context Figma cannot encode. In practice, info-collection rules should usually stay in low-penalty ranges (commonly `missing-info` or `suggestion` severity, depending on implementation risk).
 
 ## Adjustable Rule Config
 


### PR DESCRIPTION
## Summary
- add ADR-017 to formalize rule/gotcha output channels with rule-first trigger positioning
- align ADR-004 and ARCHITECTURE docs to frame scoring as secondary to gotcha triggering
- update canicode-gotchas SKILL and CLAUDE guidance for consistent wording across docs

## Test plan
- [x] Verified modified markdown files render as plain text without formatting breakage
- [x] Checked lint diagnostics for edited files (`ADR.md`, `ARCHITECTURE.md`, `SKILL.md`, `CLAUDE.md`)
- [ ] Optional: reviewer wording pass for ADR terminology consistency with #402/#406 follow-ups


Made with [Cursor](https://cursor.com)