### PR TITLE
feat(rules): info-collection rule subtype — annotation-primary rules (#406)

### DIFF
--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -168,7 +168,7 @@ Each per-design section in the `# Collected Gotchas` region has this exact shape
 | `analyzedAt` | Current timestamp (ISO 8601) |
 | `ruleId` | `ruleId` from each question |
 | `nodeName` | `nodeName` from each question |
-| `severity` | `severity` from each question (blocking / risk) |
+| `severity` | `severity` from each question (blocking / risk / missing-info — the last surfaces only for info-collection rules per #406) |
 | `nodeId` | `nodeId` from each question |
 | `instanceContext` | When present on the question, copy `parentInstanceNodeId`, `sourceNodeId`, `sourceComponentId`, `sourceComponentName` into the bullet above (roundtrip / Plugin apply) |
 | `question` | `question` from each question |

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -402,7 +402,7 @@ Notes:
 
 #### Strategy D: Auto-fix lower-severity issues from analysis
 
-The gotcha survey covers only blocking/risk severity. Lower-severity rules appear in `analyzeResult.issues[]` without a survey question. Each issue carries the same pre-computed fields (`applyStrategy`, `targetProperty`, `annotationProperties`, `suggestedName`, `isInstanceChild`, `sourceChildId`). The bundled helper handles the loop, the filter (`applyStrategy === "auto-fix"`), the naming-vs-annotation branch, and the per-issue outcome accumulator in one call:
+The gotcha survey covers blocking/risk severity plus `missing-info` severity from info-collection rules (#406 — currently `missing-prototype`, `missing-interaction-state`). All other lower-severity rules appear in `analyzeResult.issues[]` without a survey question. Each issue carries the same pre-computed fields (`applyStrategy`, `targetProperty`, `annotationProperties`, `suggestedName`, `isInstanceChild`, `sourceChildId`). The bundled helper handles the loop, the filter (`applyStrategy === "auto-fix"`), the naming-vs-annotation branch, and the per-issue outcome accumulator in one call:
 
 ```javascript
 const outcomes = await CanICodeRoundtrip.applyAutoFixes(analyzeResult.issues, { categories });
@@ -577,6 +577,7 @@ Follow the **figma-implement-design** skill workflow to generate code from the F
 
 - Gotchas with severity **blocking** MUST be addressed — the design cannot be implemented correctly without this information
 - Gotchas with severity **risk** SHOULD be addressed — they indicate potential issues that will surface later
+- Gotchas with severity **missing-info** from info-collection rules (`purpose === "info-collection"`, e.g. `missing-prototype`, `missing-interaction-state`) are annotation-primary (#406): the answer describes implementation context Figma cannot encode (click target, state variants). Treat them as code-generation context rather than violations to fix — the rule's score impact is minimal by design
 - Reference the specific node IDs from gotcha answers to locate the affected elements in the design
 - Pass the Figma URL or `survey.designKey` to `figma-implement-design` so it can grep the matching `## #NNN — …` section in `.claude/skills/canicode-gotchas/SKILL.md` instead of reading the whole accumulated file
 
@@ -613,5 +614,5 @@ Code: <files generated / next-step pointer from figma-implement-design>
 - **Partial gotcha answers**: Apply only the answered questions. Skipped/n/a questions are neither applied nor annotated.
 - **use_figma call fails for a node**: Report the error for that specific node, continue with other nodes. Failed property modifications become annotations so the context is not lost.
 - **Re-analyze shows new issues**: Only address issues from the original gotcha survey. New issues may appear due to structural changes — report them but do not re-enter the gotcha loop.
-- **Very large design (many gotchas)**: The gotcha survey already deduplicates sibling nodes and filters to blocking/risk severity only. If there are still many questions, ask the user if they want to focus on blocking issues only.
+- **Very large design (many gotchas)**: The gotcha survey already deduplicates sibling nodes and filters to blocking/risk plus `missing-info` from info-collection rules (#406). If there are still many questions, ask the user if they want to focus on blocking issues only.
 - **External library components**: Applies only when the orchestrator has set `allowDefinitionWrite: true`. Experiment 10's observed case is `getMainComponentAsync()` resolving with `mainComponent.remote === true` — writes then throw *"Cannot write to internal and read-only node"*. The `mainComponent === null` case is documented in the Plugin API but was not reproduced live in Experiment 10; Experiment 11 (#309) unit-test-covers the helper's routing for that branch (override-error + no `sourceChildId` → annotate with `could not apply automatically:` markdown — see ADR-011 Verification), so the code path is regression-locked while live Figma reproduction remains a manual fixture-seeding follow-up. Under the default (`allowDefinitionWrite: false`), the definition write never fires and this throw cannot surface. **The pre-flight `probeDefinitionWritability` (#357) detects both branches up-front** so the Definition write picker can drop the opt-in option entirely when every candidate is unwritable, saving the user a wasted decision before the runtime fallback kicks in.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -134,8 +134,8 @@ Override score, severity, or enable/disable individual rules:
 
 | Rule ID | Default Score | Default Severity |
 |---------|--------------|-----------------|
-| `missing-interaction-state` | -1 | suggestion |
-| `missing-prototype` *(disabled)* | -3 | missing-info |
+| `missing-interaction-state` | -1 | missing-info |
+| `missing-prototype` | -1 | missing-info |
 <!-- RULE_TABLE_END -->
 
 ### Example Configs

--- a/src/core/contracts/channels.ts
+++ b/src/core/contracts/channels.ts
@@ -12,3 +12,18 @@ export const PersistenceIntentSchema = z.enum(["transient", "durable"]);
 export type Detection = z.infer<typeof DetectionSchema>;
 export type OutputChannel = z.infer<typeof OutputChannelSchema>;
 export type PersistenceIntent = z.infer<typeof PersistenceIntentSchema>;
+
+/**
+ * #406 rule purpose classification.
+ * - `violation`: score-primary. Node is violating a best-practice expectation;
+ *   fixing the violation removes the rule fire. Gotcha question is secondary
+ *   context about how to resolve the violation.
+ * - `info-collection`: annotation-primary. Node is not necessarily "wrong,"
+ *   but implementation-critical context is absent from Figma (e.g. click
+ *   target, interaction states). Gotcha question is the primary output;
+ *   score impact is intentionally minimal (typically -1 or 0).
+ *
+ * Detection stays `rule-based` in both cases — see ADR-017.
+ */
+export const RulePurposeSchema = z.enum(["violation", "info-collection"]);
+export type RulePurpose = z.infer<typeof RulePurposeSchema>;

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -4,6 +4,7 @@ import {
   DetectionSchema,
   OutputChannelSchema,
   PersistenceIntentSchema,
+  RulePurposeSchema,
 } from "./channels.js";
 
 const GradeSchema = z.enum(["S", "A+", "A", "B+", "B", "C+", "C", "D", "F"]);
@@ -60,6 +61,14 @@ export const GotchaSurveyQuestionSchema = z.object({
   detection: GotchaDetectionSchema,
   outputChannel: GotchaOutputChannelSchema,
   persistenceIntent: GotchaPersistenceIntentSchema,
+  /**
+   * #406: Classifies the triggering rule as `violation` (score-primary,
+   * gotcha secondary) or `info-collection` (annotation-primary, score
+   * minimal). Consumers use this to prioritize answers that collect durable
+   * implementation context over answers that merely describe how to fix a
+   * violation the rule will stop firing for.
+   */
+  purpose: RulePurposeSchema,
   severity: SeveritySchema,
   question: z.string(),
   hint: z.string(),

--- a/src/core/contracts/mcp-response.ts
+++ b/src/core/contracts/mcp-response.ts
@@ -5,6 +5,7 @@ import {
   DetectionSchema,
   OutputChannelSchema,
   PersistenceIntentSchema,
+  RulePurposeSchema,
 } from "./channels.js";
 
 const GradeSchema = z.enum(["S", "A+", "A", "B+", "B", "C+", "C", "D", "F"]);
@@ -32,6 +33,13 @@ const McpIssueSchema = z.object({
   detection: DetectionSchema,
   outputChannel: OutputChannelSchema.extract(["score"]),
   persistenceIntent: PersistenceIntentSchema.extract(["transient"]),
+  /**
+   * #406: Whether the triggering rule's primary output is a score penalty
+   * (`violation`) or a gotcha annotation (`info-collection`). MCP consumers
+   * use this to decide whether the issue is actionable ("fix this") or
+   * annotation-seeking ("tell us what you meant here").
+   */
+  purpose: RulePurposeSchema,
   subType: z.string().optional(),
   severity: SeveritySchema,
   nodeId: z.string(),

--- a/src/core/engine/scoring.test.ts
+++ b/src/core/engine/scoring.test.ts
@@ -497,6 +497,7 @@ describe("buildResultJson", () => {
       detection: "rule-based",
       outputChannel: "score",
       persistenceIntent: "transient",
+      purpose: "violation",
       severity: "blocking",
       nodeId: expect.any(String),
       nodePath: expect.any(String),
@@ -507,6 +508,26 @@ describe("buildResultJson", () => {
       ruleId: "raw-value",
       subType: "color",
       severity: "missing-info",
+      purpose: "violation",
+    });
+  });
+
+  it("tags info-collection rules with purpose 'info-collection' (#406)", () => {
+    const result = makeResult([
+      makeIssue({
+        ruleId: "missing-prototype",
+        category: "interaction",
+        severity: "missing-info",
+      }),
+    ]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+    const issues = json.issues as Array<Record<string, unknown>>;
+
+    expect(issues[0]).toMatchObject({
+      ruleId: "missing-prototype",
+      purpose: "info-collection",
+      outputChannel: "score",
     });
   });
 

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -3,7 +3,7 @@ import { CATEGORIES, CATEGORY_LABELS } from "../contracts/category.js";
 import type { RuleId, RuleConfig } from "../contracts/rule.js";
 import type { Severity } from "../contracts/severity.js";
 import type { AnalysisResult } from "./rule-engine.js";
-import { RULE_CONFIGS, RULE_ID_CATEGORY } from "../rules/rule-config.js";
+import { RULE_CONFIGS, RULE_ID_CATEGORY, getRulePurpose } from "../rules/rule-config.js";
 import { computeApplyContext } from "../gotcha/apply-context.js";
 import { version as VERSION } from "../../../package.json";
 
@@ -441,6 +441,7 @@ export function buildResultJson(
       detection: "rule-based" as const,
       outputChannel: "score" as const,
       persistenceIntent: "transient" as const,
+      purpose: getRulePurpose(issue.violation.ruleId as RuleId),
       ...(issue.violation.subType && { subType: issue.violation.subType }),
       severity: issue.config.severity,
       nodeId: issue.violation.nodeId,

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -441,7 +441,7 @@ export function buildResultJson(
       detection: "rule-based" as const,
       outputChannel: "score" as const,
       persistenceIntent: "transient" as const,
-      purpose: getRulePurpose(issue.violation.ruleId as RuleId),
+      purpose: getRulePurpose(issue.violation.ruleId),
       ...(issue.violation.subType && { subType: issue.violation.subType }),
       severity: issue.config.severity,
       nodeId: issue.violation.nodeId,

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -156,7 +156,7 @@ describe("generateGotchaSurvey", () => {
     expect(survey.designKey).toBe("");
   });
 
-  it("includes only blocking and risk severity issues", () => {
+  it("includes only blocking and risk severity issues for violation rules", () => {
     const issues = [
       makeIssue({
         ruleId: "no-auto-layout",
@@ -197,6 +197,102 @@ describe("generateGotchaSurvey", () => {
     expect(survey.questions.map((q) => q.ruleId)).toEqual([
       "no-auto-layout",
       "fixed-size-in-auto-layout",
+    ]);
+  });
+
+  it("includes missing-info severity issues from info-collection rules (#406)", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "missing-prototype",
+        category: "interaction",
+        severity: "missing-info",
+        nodeId: "10:1",
+        nodePath: "Root > Button",
+      }),
+      makeIssue({
+        ruleId: "missing-interaction-state",
+        category: "interaction",
+        severity: "missing-info",
+        nodeId: "10:2",
+        nodePath: "Root > IconButton",
+      }),
+      makeIssue({
+        ruleId: "raw-value",
+        category: "token-management",
+        severity: "missing-info",
+        nodeId: "10:3",
+        nodePath: "Root > Label",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("C"),
+    );
+
+    const ruleIds = survey.questions.map((q) => q.ruleId);
+    expect(ruleIds).toContain("missing-prototype");
+    expect(ruleIds).toContain("missing-interaction-state");
+    // raw-value is a violation rule — missing-info severity still filtered out.
+    expect(ruleIds).not.toContain("raw-value");
+  });
+
+  it("tags each question with its rule purpose (#406)", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "no-auto-layout",
+        category: "pixel-critical",
+        severity: "blocking",
+        nodeId: "11:1",
+        nodePath: "Root > Hero",
+      }),
+      makeIssue({
+        ruleId: "missing-prototype",
+        category: "interaction",
+        severity: "missing-info",
+        nodeId: "11:2",
+        nodePath: "Root > Hero > CTA",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("D"),
+    );
+
+    const byRule = Object.fromEntries(
+      survey.questions.map((q) => [q.ruleId, q.purpose]),
+    );
+    expect(byRule["no-auto-layout"]).toBe("violation");
+    expect(byRule["missing-prototype"]).toBe("info-collection");
+  });
+
+  it("places missing-info info-collection questions after risk questions (#406)", () => {
+    const issues = [
+      makeIssue({
+        ruleId: "missing-prototype",
+        category: "interaction",
+        severity: "missing-info",
+        nodeId: "12:1",
+        nodePath: "Root > Button",
+      }),
+      makeIssue({
+        ruleId: "fixed-size-in-auto-layout",
+        category: "responsive-critical",
+        severity: "risk",
+        nodeId: "12:2",
+        nodePath: "Root > Card",
+      }),
+    ];
+
+    const survey = generateGotchaSurvey(
+      makeResult(issues),
+      makeScoreReport("D"),
+    );
+
+    expect(survey.questions.map((q) => q.severity)).toEqual([
+      "risk",
+      "missing-info",
     ]);
   });
 

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -9,6 +9,7 @@ import type {
 import type { AnalysisFile, AnalysisNode } from "../contracts/figma-node.js";
 import type { RuleId } from "../contracts/rule.js";
 import { GOTCHA_QUESTIONS } from "../rules/gotcha-questions.js";
+import { getRulePurpose } from "../rules/rule-config.js";
 import {
   isInstanceChildNodeId,
   parseInstanceChildNodeId,
@@ -33,10 +34,23 @@ export function generateGotchaSurvey(
 ): GotchaSurvey {
   const grade = scores.overall.grade;
 
-  // Step 1: Filter to blocking and risk severity only
-  const relevantIssues = result.issues.filter(
-    (issue) => issue.config.severity === "blocking" || issue.config.severity === "risk",
-  );
+  // Step 1: Filter to gotcha-relevant issues.
+  // - `blocking` + `risk`: violation rules where the user needs to describe
+  //   how to resolve the violation (existing behavior).
+  // - `missing-info` + purpose `info-collection` (#406): annotation-primary
+  //   rules like `missing-prototype` / `missing-interaction-state` where the
+  //   gotcha IS the output. Without this, info-collection rules would never
+  //   reach the survey because their penalty is intentionally minimal.
+  // `suggestion` severity still stays out — it's prose-level advice, not an
+  // implementation gap Figma can't encode.
+  const relevantIssues = result.issues.filter((issue) => {
+    const severity = issue.config.severity;
+    if (severity === "blocking" || severity === "risk") return true;
+    if (severity === "missing-info") {
+      return getRulePurpose(issue.violation.ruleId as RuleId) === "info-collection";
+    }
+    return false;
+  });
 
   // Step 2: Deduplicate — same ruleId on siblings (same parent path) → keep first
   const deduped = deduplicateSiblingIssues(relevantIssues);
@@ -131,22 +145,27 @@ function getNodeName(nodePath: string): string {
 }
 
 /**
- * Stable sort: blocking before risk, preserving original array order within
- * each severity group.
+ * Stable sort: blocking → risk → missing-info, preserving original array
+ * order within each group. `missing-info` is surfaced only for
+ * info-collection rules (#406), placed last because their penalty is
+ * minimal; fix-describe questions for actual violations take priority.
  */
 function stableSortBySeverity(issues: AnalysisIssue[]): AnalysisIssue[] {
   const blocking: AnalysisIssue[] = [];
   const risk: AnalysisIssue[] = [];
+  const missingInfo: AnalysisIssue[] = [];
 
   for (const issue of issues) {
     if (issue.config.severity === "blocking") {
       blocking.push(issue);
+    } else if (issue.config.severity === "missing-info") {
+      missingInfo.push(issue);
     } else {
       risk.push(issue);
     }
   }
 
-  return [...blocking, ...risk];
+  return [...blocking, ...risk, ...missingInfo];
 }
 
 /**
@@ -176,6 +195,7 @@ function mapToQuestion(
     detection: template.detection,
     outputChannel: template.outputChannel,
     persistenceIntent: template.persistenceIntent,
+    purpose: getRulePurpose(ruleId),
     severity: issue.config.severity,
     question: template.question.replace("{nodeName}", nodeName),
     hint: template.hint,

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -47,7 +47,7 @@ export function generateGotchaSurvey(
     const severity = issue.config.severity;
     if (severity === "blocking" || severity === "risk") return true;
     if (severity === "missing-info") {
-      return getRulePurpose(issue.violation.ruleId as RuleId) === "info-collection";
+      return getRulePurpose(issue.violation.ruleId) === "info-collection";
     }
     return false;
   });
@@ -195,7 +195,7 @@ function mapToQuestion(
     detection: template.detection,
     outputChannel: template.outputChannel,
     persistenceIntent: template.persistenceIntent,
-    purpose: getRulePurpose(ruleId),
+    purpose: getRulePurpose(issue.violation.ruleId),
     severity: issue.config.severity,
     question: template.question.replace("{nodeName}", nodeName),
     hint: template.hint,

--- a/src/core/rules/rule-config.test.ts
+++ b/src/core/rules/rule-config.test.ts
@@ -1,7 +1,12 @@
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { RULE_CONFIGS, getAnnotationProperties } from "./rule-config.js";
+import {
+  RULE_CONFIGS,
+  RULE_PURPOSE,
+  getAnnotationProperties,
+  getRulePurpose,
+} from "./rule-config.js";
 import { ruleRegistry } from "./rule-registry.js";
 import type { RuleId } from "../contracts/rule.js";
 
@@ -130,6 +135,46 @@ describe("rule-config sync", () => {
       expect(
         getAnnotationProperties("fixed-size-in-auto-layout", "horizontal")
       ).toEqual([{ type: "width" }, { type: "height" }, { type: "layoutMode" }]);
+    });
+  });
+
+  describe("RULE_PURPOSE (#406)", () => {
+    it("covers every RULE_CONFIGS entry", () => {
+      for (const id of Object.keys(RULE_CONFIGS)) {
+        expect(RULE_PURPOSE[id as RuleId]).toBeDefined();
+      }
+    });
+
+    it("marks both interaction rules as info-collection", () => {
+      expect(RULE_PURPOSE["missing-prototype"]).toBe("info-collection");
+      expect(RULE_PURPOSE["missing-interaction-state"]).toBe("info-collection");
+    });
+
+    it("keeps all non-interaction rules as violation", () => {
+      for (const [id, purpose] of Object.entries(RULE_PURPOSE)) {
+        if (
+          id === "missing-prototype" ||
+          id === "missing-interaction-state"
+        ) {
+          continue;
+        }
+        expect(purpose).toBe("violation");
+      }
+    });
+
+    it("info-collection rules are enabled and use missing-info severity", () => {
+      for (const [id, purpose] of Object.entries(RULE_PURPOSE)) {
+        if (purpose !== "info-collection") continue;
+        const config = RULE_CONFIGS[id as RuleId];
+        expect(config.enabled).toBe(true);
+        expect(config.severity).toBe("missing-info");
+        // Score kept minimal — annotation is primary output, not score penalty.
+        expect(config.score).toBeGreaterThanOrEqual(-1);
+      }
+    });
+
+    it("getRulePurpose falls back to 'violation' for unknown rule ids", () => {
+      expect(getRulePurpose("made-up-rule" as RuleId)).toBe("violation");
     });
   });
 

--- a/src/core/rules/rule-config.test.ts
+++ b/src/core/rules/rule-config.test.ts
@@ -174,7 +174,9 @@ describe("rule-config sync", () => {
     });
 
     it("getRulePurpose falls back to 'violation' for unknown rule ids", () => {
-      expect(getRulePurpose("made-up-rule" as RuleId)).toBe("violation");
+      // Signature intentionally accepts `string` so custom-rule ids from the
+      // config loader don't need a caller-side `as RuleId` cast.
+      expect(getRulePurpose("made-up-rule")).toBe("violation");
     });
   });
 

--- a/src/core/rules/rule-config.ts
+++ b/src/core/rules/rule-config.ts
@@ -1,4 +1,5 @@
 import type { Category } from "../contracts/category.js";
+import type { RulePurpose } from "../contracts/channels.js";
 import type { RuleConfig, RuleId } from "../contracts/rule.js";
 import type { AnnotationProperty } from "../roundtrip/types.js";
 
@@ -35,6 +36,56 @@ export const RULE_ID_CATEGORY: Record<RuleId, Category> = {
   "non-semantic-name": "semantic",
   "inconsistent-naming-convention": "semantic",
 };
+
+/**
+ * #406: Classifies each rule by primary output channel.
+ *
+ * - `violation` (default): score-primary. Rule fires when a best-practice
+ *   expectation is broken; the score penalty is the main signal, gotcha
+ *   questions are secondary context on how to resolve the violation.
+ * - `info-collection`: annotation-primary. Rule fires on nodes that need
+ *   implementation context Figma cannot encode natively (click target,
+ *   state variants). The gotcha annotation IS the output; score impact is
+ *   kept minimal (-1 range) so presence/absence of the annotation — not
+ *   the penalty — differentiates designs.
+ *
+ * Sibling map (mirrors `RULE_ID_CATEGORY`) so existing `RuleDefinition`
+ * call sites don't need to be touched. Look up via `getRulePurpose`.
+ */
+export const RULE_PURPOSE: Record<RuleId, RulePurpose> = {
+  // Pixel Critical
+  "no-auto-layout": "violation",
+  "absolute-position-in-auto-layout": "violation",
+  "non-layout-container": "violation",
+  // Responsive Critical
+  "fixed-size-in-auto-layout": "violation",
+  "missing-size-constraint": "violation",
+  // Code Quality
+  "missing-component": "violation",
+  "detached-instance": "violation",
+  "variant-structure-mismatch": "violation",
+  "deep-nesting": "violation",
+  // Token Management
+  "raw-value": "violation",
+  "irregular-spacing": "violation",
+  // Interaction — gotcha-primary: Figma cannot encode "what happens on
+  // click" or "which states exist" in a way downstream code generation can
+  // consume. Rules fire to trigger the annotation, not to flag a violation.
+  "missing-interaction-state": "info-collection",
+  "missing-prototype": "info-collection",
+  // Semantic
+  "non-standard-naming": "violation",
+  "non-semantic-name": "violation",
+  "inconsistent-naming-convention": "violation",
+};
+
+/**
+ * Resolve a rule's purpose. Defaults to `"violation"` for unknown ids so
+ * this stays safe for out-of-tree custom rules added via config loader.
+ */
+export function getRulePurpose(ruleId: RuleId): RulePurpose {
+  return RULE_PURPOSE[ruleId] ?? "violation";
+}
 
 /**
  * Central configuration for all rules.
@@ -127,15 +178,20 @@ export const RULE_CONFIGS: Record<RuleId, RuleConfig> = {
   },
 
   // ── Interaction ──
+  // #406: both rules are `info-collection` — primary output is the gotcha
+  // annotation, not the score. Severity is `missing-info` so they surface in
+  // the gotcha survey (see `generateGotchaSurvey`) even though the penalty
+  // is minimal. Score stays at -1 so re-enabling `missing-prototype` on
+  // fixtures that lack `interactionDestinations` (#139) cannot swing grades.
   "missing-interaction-state": {
-    severity: "suggestion",
+    severity: "missing-info",
     score: -1, // uncalibrated: no metric to validate score (#210), kept at -1 to preserve category visibility
     enabled: true,
   },
   "missing-prototype": {
     severity: "missing-info",
-    score: -3,
-    enabled: false, // disabled: interactionDestinations data missing from fixtures (#139)
+    score: -1, // #406: info-collection — annotation is primary output; score kept minimal so #139 fixtures don't skew calibration
+    enabled: true,
   },
 
   // ── Semantic ──

--- a/src/core/rules/rule-config.ts
+++ b/src/core/rules/rule-config.ts
@@ -80,11 +80,15 @@ export const RULE_PURPOSE: Record<RuleId, RulePurpose> = {
 };
 
 /**
- * Resolve a rule's purpose. Defaults to `"violation"` for unknown ids so
- * this stays safe for out-of-tree custom rules added via config loader.
+ * Resolve a rule's purpose. Accepts `string` (not `RuleId`) because the
+ * purpose concept must work for out-of-tree custom rules added via the
+ * config loader — callers pass `issue.violation.ruleId` which is a plain
+ * string. Defaults to `"violation"` for unknown ids. Keeping the cast
+ * inside this helper (rather than forcing every caller to do `as RuleId`)
+ * makes the fallback semantically honest.
  */
-export function getRulePurpose(ruleId: RuleId): RulePurpose {
-  return RULE_PURPOSE[ruleId] ?? "violation";
+export function getRulePurpose(ruleId: string): RulePurpose {
+  return RULE_PURPOSE[ruleId as RuleId] ?? "violation";
 }
 
 /**


### PR DESCRIPTION
Closes #406. Builds on the channel vocabulary landed in #402 / ADR-017.

## Summary

- Adds a `purpose: "violation" | "info-collection"` classification for rules, surfaced on both MCP issue output (`McpIssueSchema`) and gotcha questions (`GotchaSurveyQuestionSchema`).
- Tags `missing-prototype` and `missing-interaction-state` as `info-collection` — their primary output is a gotcha annotation Figma cannot encode natively, not a best-practice violation score.
- Re-enables `missing-prototype` at score `-1` / severity `missing-info` (was disabled at `-3` per #139). Score kept minimal so the annotation, not the penalty, is the signal.
- Raises `missing-interaction-state` severity from `suggestion` to `missing-info` to keep the interaction pair consistent.
- Survey generator now lets `missing-info` severity through **only** for `info-collection` rules, and places those questions after `risk` so fix-describe prompts for actual violations stay on top. `suggestion` severity and violation-rule `missing-info` (e.g. `raw-value`) are still filtered out.
- `canicode-gotchas` and `canicode-roundtrip` SKILL prose updated so the `missing-info` path is not described as "blocking/risk only." Explicit guidance that info-collection questions are annotation-primary code-gen context, not violations to fix.

## Empirical validation — `missing-prototype` grade impact

Reviewer raised the concern that -1 per-fire × N fires could still swing grades on 300-node fixtures, especially since #139 fixtures still lack `interactionDestinations`. Measured before/after grade on all 24 calibration fixtures (`fixtures/done/*`), default config vs. `{ "missing-prototype": { "enabled": false } }`:

| fixture                 | new | old | mp fires | Δ% |
|-------------------------|-----|-----|----------|----|
| desktop-about           | B   | B   | 14 | +0 |
| desktop-ai-chat         | C+  | C+  | 14 | +0 |
| desktop-article         | C+  | C+  | 11 | +0 |
| desktop-contact-us      | C+  | C+  | 19 | +0 |
| desktop-home-page       | B   | B   | 13 | +0 |
| desktop-landing-page    | B   | B   | 16 | +0 |
| desktop-portfolio       | B   | B   | 13 | +0 |
| desktop-pricing         | B   | B   | 25 | +0 |
| desktop-product-detail  | C+  | C+  | 29 | +0 |
| desktop-shop            | B   | B   | 40 | -1 |
| desktop-slot            | C+  | C+  | 10 | +0 |
| desktop-waitlist        | C+  | C+  | 13 | +0 |
| mobile-about            | B   | B   | 14 | +0 |
| mobile-ai-chat          | B   | B   | 13 | +0 |
| mobile-article          | B+  | B+  | 11 | +0 |
| mobile-contact-us       | C+  | C+  | 19 | +0 |
| mobile-home-page        | B   | B   | 13 | +0 |
| mobile-landing-page     | B   | B   | 16 | +0 |
| mobile-portfolio        | B   | B   | 13 | +0 |
| mobile-pricing          | B   | B   | 24 | +0 |
| mobile-product-detail   | C+  | C+  | 29 | +0 |
| mobile-shop             | B   | B   | 42 | -1 |
| mobile-slot             | B+  | B+  | 10 | -1 |
| mobile-waitlist         | C+  | C+  | 13 | +0 |

**0 / 24 grade shifts.** Max Δ is -1 percentage point (3 fixtures where `missing-prototype` fires 40–42 times). sqrt density damping absorbs even the largest fire counts into sub-1-point swings, well below the 5-point grade boundary spacing. The "cannot swing grades" claim is now empirically grounded; #139 fixture rebuild remains a separate concern for calibration fidelity but is not a prerequisite for this PR.

## Design choices

- **Sibling map over schema field.** Purpose lives in a `RULE_PURPOSE` record in `rule-config.ts` (mirroring `RULE_ID_CATEGORY`) rather than on `RuleDefinition`. Keeps all 16 rule definition call sites untouched and gives custom rules a safe default via `getRulePurpose` (returns `"violation"` for unknown ids).
- **`getRulePurpose` signature accepts `string`.** Cast to `RuleId` stays inside the helper so callers pass `issue.violation.ruleId` (a plain string from the rule engine / custom rules) without a performative `as RuleId` assertion that would contradict the fallback.
- **Shared vocabulary.** `RulePurposeSchema` lives in `contracts/channels.ts` next to `DetectionSchema` / `OutputChannelSchema` / `PersistenceIntentSchema` — same dedupe concern the #409 review flagged. One source of truth for all channel-and-purpose literals.

## Out of scope — tracked as follow-up

The issue also suggests `nodeId + questionType` as the dedupe key for info-collection answers so they survive re-analysis. That change affects `upsertGotchaSection` and the `canicode-gotchas` SKILL workflow, which replaces sections wholesale on re-run. I scoped this PR to classification + score/severity + output plumbing; the cross-run answer persistence change deserves its own PR against the gotcha workflow surface.

## Test plan

- [x] `pnpm vitest run` — 1018 passed (9 new tests)
- [x] `pnpm lint` — clean
- [x] Grade-impact measurement on all 24 `fixtures/done/*` — 0 grade shifts (table above)
- New unit tests:
  - `rule-config.test.ts`: `RULE_PURPOSE` covers every config entry; both interaction rules are `info-collection`; all others stay `violation`; info-collection rules are enabled + `missing-info` severity + score >= -1; `getRulePurpose` accepts `string` and falls back to `"violation"` for unknown ids.
  - `survey-generator.test.ts`: info-collection + `missing-info` makes it into the survey; violation + `missing-info` (`raw-value`) stays filtered; `purpose` field populates from the map; `missing-info` questions sort after `risk`.
  - `scoring.test.ts`: `buildResultJson` emits `purpose` on every issue (violation vs info-collection).

## Cross-refs

- #402 — channel vocabulary (detection / outputChannel / persistenceIntent) this PR extends.
- `.claude/docs/ADR.md` ADR-017 — rule/gotcha output channel decision; `info-collection` is the annotation-primary subtype introduced there. Wiki Decision Log entry pending (will be synced together with the next #402-related sweep per the standing convention).
- #139 — original reason `missing-prototype` was disabled; 0/24 grade shifts at score -1 neutralizes that concern.