### PR TITLE
feat(analysis): detect analysis scope (page vs component) and inject into RuleContext (#404)

### DIFF
--- a/.claude/docs/ADR.md
+++ b/.claude/docs/ADR.md
@@ -219,3 +219,17 @@ Gotcha answers do not retroactively erase the rule score. Scores represent desig
 - Documentation and skills should frame gotchas as annotation completion for `figma-implement-design`, not only as violation remediation prompts.
 
 **References**: ADR-004 (score framing), ADR-013 (scope boundary), [Round-Trip Integration wiki](https://github.com/let-sunny/canicode/wiki/Round-Trip-Integration), #402, #405, #406.
+
+## ADR-018: Analysis scope selection — `page` vs `component`
+
+**Decision**: Resolve a single `AnalysisScope` (`"page"` or `"component"`) per analysis run and thread it through every `RuleContext`. Detection is deterministic from the analysis root's node type — `COMPONENT`, `COMPONENT_SET`, and `INSTANCE` roots resolve to `component`; everything else (`FRAME`, `SECTION`, `CANVAS`, `DOCUMENT`, `GROUP`, …) resolves to `page`. An explicit `--scope` CLI flag and MCP `scope` parameter let callers override the heuristic when it mis-detects (e.g. a design-system screen packaged as a top-level `COMPONENT` that the user wants audited like a page). Multi-scope analysis is explicitly out of scope — one run, one scope.
+
+**Why**: Responsive-critical rules need to distinguish "this FRAME should define its own bounds because it's a screen container" from "this COMPONENT must stay FILL because it's a reusable unit whose bounds are the parent's responsibility". Without scope context, such rules either over-fire on standalone components (false positives) or under-fire on pages (missed responsive bugs). Option A (interactive prompt) was rejected because CLI/MCP flows are machine-driven; Option B (auto-detection) with an override covers the ambiguous cases without adding friction.
+
+**Impact**:
+- `RuleContext.scope` is now part of the rule contract and is constant for the entire traversal. Whether the *current* node happens to descend from a `COMPONENT` is already signalled by `componentDepth` — rules should not re-derive scope per node.
+- `AnalysisResult.scope`, `buildResultJson(...).scope`, and `McpAnalyzeResponseSchema.scope` surface the resolved value so downstream consumers (report HTML, `figma-implement-design`, gotcha UI) can branch the same way rules do.
+- Rules are intentionally not modified in this step — scope consumption lands in follow-up PRs (first consumer: `missing-size-constraint` redesign, #403). The contract lets those redesigns ship without a second round of plumbing.
+- Calibration fixtures captured from design-system pages frequently have `COMPONENT` roots ("pages packaged as component variants"). Because no rule currently branches on scope, baselines are unchanged; the override (`--scope page`) is the prescribed path if/when #403-style rule redesigns would shift grades on those fixtures.
+
+**References**: ADR-017 (detection-channel split — this ADR extends the rule-context vocabulary), [#404](https://github.com/let-sunny/canicode/issues/404), #403 (first consumer).

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Posts analysis as a PR comment. Fails if score is below threshold. See [**canico
 |------|-----|
 | **Presets** | `--preset relaxed \| dev-friendly \| ai-ready \| strict` |
 | **Config overrides** | `--config ./config.json` — adjust scores, severity, exclude nodes |
+| **Analysis scope** | `--scope page \| component` — override auto-detection when a `COMPONENT`-rooted design should be analyzed as a page (or vice versa) |
 
 See [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md) for the full guide, examples, and all available options.
 

--- a/scripts/calibrate.ts
+++ b/scripts/calibrate.ts
@@ -225,6 +225,39 @@ function estimateTokens(text: string): number {
   return Math.ceil(Buffer.byteLength(text, "utf-8") / 4);
 }
 
+/**
+ * #404: Resolve the analysis scope for a calibration run.
+ *
+ * Policy (single source of truth, intentionally owned by the
+ * orchestrator rather than the rule engine):
+ * 1. If the fixture directory contains a `.scope` file, its trimmed
+ *    content is used (must be `page` or `component`). This is the
+ *    per-fixture escape hatch for the rare case a fixture really is a
+ *    standalone component audit.
+ * 2. Otherwise, default to `page`. All `fixtures/done/*` ship today as
+ *    `COMPONENT` variants ("Platform=Desktop") that represent full
+ *    screens — auto-detection would classify them as component scope
+ *    and once #403 lands (scope-aware `missing-size-constraint`) that
+ *    would flip grades across every baseline. Forcing `page` here keeps
+ *    baselines stable until a fixture is explicitly re-classified.
+ *
+ * This runs in `scripts/calibrate.ts`, not in library code, because
+ * scope-for-calibration is an orchestration policy. The CLI
+ * `calibrate-analyze --scope` flag stays a neutral pass-through so ad-hoc
+ * runs (without the orchestrator) can still opt in to auto-detection.
+ */
+function resolveCalibrationScope(fixturePath: string): "page" | "component" {
+  const scopeFile = join(resolve(fixturePath), ".scope");
+  if (existsSync(scopeFile)) {
+    const raw = readFileSync(scopeFile, "utf-8").trim();
+    if (raw === "page" || raw === "component") return raw;
+    throw new Error(
+      `Invalid .scope file at ${scopeFile}: expected "page" or "component", got ${JSON.stringify(raw)}`,
+    );
+  }
+  return "page";
+}
+
 // ---------------------------------------------------------------------------
 // Strip types
 // ---------------------------------------------------------------------------
@@ -455,8 +488,9 @@ async function runPipeline(index: CalibrationRunIndex): Promise<void> {
   if (shouldRun(STEP_NAMES.ANALYZE)) {
     markRunning(index, STEP_NAMES.ANALYZE);
     try {
+      const scope = resolveCalibrationScope(fixturePath);
       runCli(
-        `${CANICODE_CLI} calibrate-analyze ${shellEscape(fixturePath)} --run-dir ${shellEscape(runDir)}`,
+        `${CANICODE_CLI} calibrate-analyze ${shellEscape(fixturePath)} --run-dir ${shellEscape(runDir)} --scope ${scope}`,
         "calibrate-analyze",
       );
       const analysis = readJson<Record<string, unknown>>(join(runDir, "analysis.json"));

--- a/src/agents/analysis-agent.test.ts
+++ b/src/agents/analysis-agent.test.ts
@@ -62,6 +62,7 @@ function createMockResult(issues: AnalysisIssue[]): AnalysisResult {
     maxDepth: 5,
     nodeCount: 10,
     analyzedAt: "2026-01-01T00:00:00Z",
+    scope: "page",
   };
 }
 

--- a/src/agents/calibration-compute.test.ts
+++ b/src/agents/calibration-compute.test.ts
@@ -1,5 +1,8 @@
 import type { AnalysisFile } from "../core/contracts/figma-node.js";
-import { runCalibrationEvaluate } from "./calibration-compute.js";
+import {
+  runCalibrationAnalyze,
+  runCalibrationEvaluate,
+} from "./calibration-compute.js";
 
 // Register rules so RULE_CONFIGS is populated
 import "../core/rules/index.js";
@@ -233,6 +236,41 @@ describe("runCalibrationEvaluate", () => {
     expect(result.report).toContain("# Calibration Report");
     expect(result.report).toContain("Test File");
     expect(result.report).toContain("test-key");
+  });
+});
+
+// ─── #404 scope plumbing through runCalibrationAnalyze ────────────────────────
+
+describe("runCalibrationAnalyze — scope option (#404)", () => {
+  // These tests drive `loadFile` through a real fixture directory. The
+  // `fixtures/done/*` fixtures all have COMPONENT roots, which means
+  // auto-detect gives `component` — so passing `scope: "page"` is the
+  // exact override path `scripts/calibrate.ts` relies on to keep
+  // calibration baselines stable once #403 lands.
+  const FIXTURE = "./fixtures/done/desktop-home-page";
+
+  it("threads explicit scope: 'page' override into the AnalysisResult", async () => {
+    const { analysisOutput } = await runCalibrationAnalyze({
+      input: FIXTURE,
+      scope: "page",
+    });
+    expect(analysisOutput.analysisResult.scope).toBe("page");
+  });
+
+  it("threads explicit scope: 'component' override into the AnalysisResult", async () => {
+    const { analysisOutput } = await runCalibrationAnalyze({
+      input: FIXTURE,
+      scope: "component",
+    });
+    expect(analysisOutput.analysisResult.scope).toBe("component");
+  });
+
+  it("falls back to auto-detection when scope is omitted — confirms the flag is opt-in, not forced", async () => {
+    const { analysisOutput } = await runCalibrationAnalyze({ input: FIXTURE });
+    // fixtures/done/desktop-home-page has a COMPONENT root → auto →
+    // component. If this ever flips, the orchestrator's `--scope page`
+    // policy becomes the only thing preventing calibration drift.
+    expect(analysisOutput.analysisResult.scope).toBe("component");
   });
 });
 

--- a/src/agents/calibration-compute.ts
+++ b/src/agents/calibration-compute.ts
@@ -222,7 +222,10 @@ export async function runCalibrationAnalyze(
   const parsed = CalibrationConfigSchema.parse(config);
   const { file, fileKey, nodeId } = await loadFile(parsed.input, parsed.token);
 
-  const analyzeOptions = nodeId ? { targetNodeId: nodeId } : {};
+  const analyzeOptions = {
+    ...(nodeId ? { targetNodeId: nodeId } : {}),
+    ...(parsed.scope ? { scope: parsed.scope } : {}),
+  };
   const analysisResult = analyzeFile(file, analyzeOptions);
 
   const analysisOutput = runAnalysisAgent({ analysisResult });

--- a/src/agents/contracts/calibration.ts
+++ b/src/agents/contracts/calibration.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { AnalysisScopeSchema } from "../../core/contracts/analysis-scope.js";
 
 export const SamplingStrategySchema = z.enum(["all", "top-issues", "random"]);
 export type SamplingStrategy = z.infer<typeof SamplingStrategySchema>;
@@ -22,6 +23,15 @@ export const CalibrationConfigSchema = z.object({
   samplingStrategy: SamplingStrategySchema.default("top-issues"),
   outputPath: z.string().default("logs/calibration/calibration-report.md"),
   runDir: z.string().optional(),
+  /**
+   * #404: Explicit analysis scope for the calibration run. When omitted,
+   * the orchestrator (`scripts/calibrate.ts`) injects `"page"` as the
+   * policy default — `fixtures/done/*` are conceptually pages even though
+   * they are stored as `COMPONENT` variants ("Platform=Desktop" etc.) and
+   * would otherwise auto-detect as component scope. A `.scope` file in
+   * the fixture directory overrides the default per-fixture.
+   */
+  scope: AnalysisScopeSchema.optional(),
 });
 
 export type CalibrationConfig = z.infer<typeof CalibrationConfigSchema>;

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -32,6 +32,7 @@ const AnalyzeOptionsSchema = z.object({
   noOpen: z.boolean().optional(),
   json: z.boolean().optional(),
   acknowledgments: z.string().optional(),
+  scope: z.enum(["page", "component"]).optional(),
 });
 
 
@@ -47,6 +48,7 @@ export function registerAnalyze(cli: CAC): void {
     .option("--no-open", "Don't open report in browser after analysis")
     .option("--json", "Output JSON results to stdout (same format as MCP)")
     .option("--acknowledgments <path>", "(#371) Path to a JSON file containing [{ nodeId, ruleId }] pairs harvested from canicode-authored Figma annotations. Matching issues are flagged acknowledged and contribute half weight to density.")
+    .option("--scope <scope>", "(#404) Override analysis scope: `page` (screen/section — container bounds are required) or `component` (standalone reusable unit — root FILL is the design contract). Defaults to auto-detection from the root node type.")
     .example("  canicode analyze https://www.figma.com/design/ABC123/MyDesign")
     .example("  canicode analyze https://www.figma.com/design/ABC123/MyDesign --api --token YOUR_TOKEN")
     .example("  canicode analyze ./fixtures/my-design --output report.html")
@@ -155,6 +157,7 @@ export function registerAnalyze(cli: CAC): void {
           ...(excludeNodeNames && { excludeNodeNames }),
           ...(excludeNodeTypes && { excludeNodeTypes }),
           ...(acknowledgments && { acknowledgments }),
+          ...(options.scope && { scope: options.scope }),
         };
 
         // Run analysis

--- a/src/cli/commands/gotcha-survey.test.ts
+++ b/src/cli/commands/gotcha-survey.test.ts
@@ -31,4 +31,22 @@ describe("runGotchaSurvey", () => {
     expect(GotchaSurveySchema.safeParse(strict).success).toBe(true);
     expect(GotchaSurveySchema.safeParse(relaxed).success).toBe(true);
   });
+
+  it("accepts --scope override and still produces a valid survey (#404)", async () => {
+    // Fixture root is COMPONENT → auto-detect would be `component`.
+    // Passing `scope: "page"` exercises the same override path the
+    // orchestrator uses for calibration runs and must not break the
+    // downstream survey pipeline (no rule currently branches on scope,
+    // so the question list should remain stable across both overrides).
+    const asPage = await runGotchaSurvey(FIXTURE, { scope: "page", json: true });
+    const asComponent = await runGotchaSurvey(FIXTURE, { scope: "component", json: true });
+
+    expect(GotchaSurveySchema.safeParse(asPage).success).toBe(true);
+    expect(GotchaSurveySchema.safeParse(asComponent).success).toBe(true);
+    // Infrastructure-only wiring: both overrides must produce the same
+    // set of question ruleIds until a rule in a follow-up PR (#403)
+    // actually consumes `ctx.scope`.
+    const ruleIds = (s: typeof asPage) => s.questions.map((q) => q.ruleId).sort();
+    expect(ruleIds(asPage)).toEqual(ruleIds(asComponent));
+  });
 });

--- a/src/cli/commands/gotcha-survey.ts
+++ b/src/cli/commands/gotcha-survey.ts
@@ -19,6 +19,7 @@ const GotchaSurveyOptionsSchema = z.object({
   config: z.string().optional(),
   targetNodeId: z.string().optional(),
   json: z.boolean().optional(),
+  scope: z.enum(["page", "component"]).optional(),
 });
 
 export type GotchaSurveyOptions = z.infer<typeof GotchaSurveyOptionsSchema>;
@@ -47,6 +48,7 @@ export async function runGotchaSurvey(
   const result = analyzeFile(file, {
     configs: configs as Record<RuleId, RuleConfig>,
     ...(effectiveNodeId ? { targetNodeId: effectiveNodeId } : {}),
+    ...(options.scope ? { scope: options.scope } : {}),
   });
 
   const scores = calculateScores(result, configs as Record<RuleId, RuleConfig>);
@@ -73,6 +75,7 @@ export function registerGotchaSurvey(cli: CAC): void {
     .option("--token <token>", "Figma API token (or use FIGMA_TOKEN env var)")
     .option("--config <path>", "Path to config JSON file (override rule scores/settings)")
     .option("--target-node-id <id>", "Scope analysis to a specific node ID")
+    .option("--scope <scope>", "(#404) Override analysis scope: `page` or `component`. Defaults to auto-detection from the root node type.")
     .option("--json", "Output GotchaSurvey JSON to stdout (same format as MCP)")
     .example("  canicode gotcha-survey https://www.figma.com/design/ABC123/MyDesign --json")
     .example("  canicode gotcha-survey ./fixtures/my-design --json")

--- a/src/cli/commands/internal/calibrate-analyze.ts
+++ b/src/cli/commands/internal/calibrate-analyze.ts
@@ -14,6 +14,7 @@ interface CalibrateAnalyzeOptions {
   runDir?: string;
   token?: string;
   targetNodeId?: string;
+  scope?: "page" | "component";
 }
 
 export function registerCalibrateAnalyze(cli: CAC): void {
@@ -26,6 +27,7 @@ export function registerCalibrateAnalyze(cli: CAC): void {
     .option("--run-dir <path>", "Run directory (overrides --output, writes to <run-dir>/analysis.json)")
     .option("--token <token>", "Figma API token (or use FIGMA_TOKEN env var)")
     .option("--target-node-id <nodeId>", "Scope analysis to a specific node")
+    .option("--scope <scope>", "(#404) Override analysis scope (`page` | `component`). Pass-through to the rule engine; `scripts/calibrate.ts` normally sets this to `page` for fixtures/done/* because they are conceptually pages packaged as COMPONENT variants.")
     .action(async (input: string, options: CalibrateAnalyzeOptions) => {
       try {
         console.log("Running calibration analysis...");
@@ -37,6 +39,7 @@ export function registerCalibrateAnalyze(cli: CAC): void {
           outputPath: "logs/calibration/calibration-report.md",
           ...(options.token && { token: options.token }),
           ...(options.targetNodeId && { targetNodeId: options.targetNodeId }),
+          ...(options.scope && { scope: options.scope }),
         };
 
         const { analysisOutput, ruleScores, fileKey } =
@@ -57,6 +60,14 @@ export function registerCalibrateAnalyze(cli: CAC): void {
           analyzedAt: analysisOutput.analysisResult.analyzedAt,
           nodeCount: analysisOutput.analysisResult.nodeCount,
           issueCount: analysisOutput.analysisResult.issues.length,
+          /**
+           * #404: Resolved analysis scope for this calibration run —
+           * surfaced in analysis.json so downstream diff/tuning agents
+           * and post-hoc grade comparisons can see whether a run used
+           * page or component scope (critical once #403 introduces
+           * scope-dependent rule behavior).
+           */
+          scope: analysisOutput.analysisResult.scope,
           calibrationTier,
           scoreReport: analysisOutput.scoreReport,
           nodeIssueSummaries: filteredSummaries,

--- a/src/core/contracts/analysis-scope.test.ts
+++ b/src/core/contracts/analysis-scope.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import type { AnalysisNode } from "./figma-node.js";
+import {
+  AnalysisScopeSchema,
+  detectAnalysisScope,
+} from "./analysis-scope.js";
+
+function makeRoot(type: string, overrides?: Partial<AnalysisNode>): AnalysisNode {
+  return {
+    id: "0:1",
+    name: `root-${type}`,
+    type: type as AnalysisNode["type"],
+    visible: true,
+    ...overrides,
+  };
+}
+
+describe("AnalysisScopeSchema", () => {
+  it("accepts `page` and `component`", () => {
+    expect(AnalysisScopeSchema.parse("page")).toBe("page");
+    expect(AnalysisScopeSchema.parse("component")).toBe("component");
+  });
+
+  it("rejects other values — keeps surface area explicit per #404", () => {
+    expect(AnalysisScopeSchema.safeParse("section").success).toBe(false);
+    expect(AnalysisScopeSchema.safeParse("auto").success).toBe(false);
+    expect(AnalysisScopeSchema.safeParse("").success).toBe(false);
+  });
+});
+
+describe("detectAnalysisScope", () => {
+  it.each([
+    ["COMPONENT", "component"],
+    ["COMPONENT_SET", "component"],
+    ["INSTANCE", "component"],
+  ] as const)("%s root → %s scope", (type, expected) => {
+    expect(detectAnalysisScope(makeRoot(type))).toBe(expected);
+  });
+
+  it.each([
+    ["FRAME", "page"],
+    ["SECTION", "page"],
+    ["CANVAS", "page"],
+    ["DOCUMENT", "page"],
+    ["GROUP", "page"],
+    ["TEXT", "page"],
+    ["VECTOR", "page"],
+    ["RECTANGLE", "page"],
+  ] as const)("%s root → %s scope (default)", (type, expected) => {
+    expect(detectAnalysisScope(makeRoot(type))).toBe(expected);
+  });
+
+  it("ignores children when deciding scope — only the root node type matters", () => {
+    const componentChild = makeRoot("COMPONENT", { id: "0:2", name: "Child" });
+    const frameRoot: AnalysisNode = {
+      ...makeRoot("FRAME"),
+      children: [componentChild],
+    };
+    // A page that happens to contain a component is still page scope —
+    // the component-scope branch is reserved for runs where the user
+    // explicitly targets a component via node-id.
+    expect(detectAnalysisScope(frameRoot)).toBe("page");
+  });
+});

--- a/src/core/contracts/analysis-scope.ts
+++ b/src/core/contracts/analysis-scope.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import type { AnalysisNode } from "./figma-node.js";
+
+/**
+ * #404: Analysis scope — what the user is asking canicode to reason about.
+ *
+ * - `page`: full screen / section / layout. Container frames are
+ *   responsible for bounds; repetition detection is meaningful; rules
+ *   that assume "this is a self-contained screen" apply.
+ * - `component`: standalone reusable UI unit (COMPONENT / COMPONENT_SET
+ *   / INSTANCE analyzed in isolation). Root FILL is the design contract
+ *   rather than a missing bound; repetition detection is generally a
+ *   false signal because a component is itself the unit of reuse.
+ *
+ * The enum is intentionally two-valued; multi-scope analysis (analyzing
+ * a page and its inner components in one run) is explicitly out of scope
+ * per the issue. Each rule decides how (or whether) to switch on `scope`;
+ * this PR only carries the context. Rule-level consumption lands in
+ * follow-up PRs (e.g. #403 for `missing-size-constraint`).
+ */
+export const AnalysisScopeSchema = z.enum(["page", "component"]);
+export type AnalysisScope = z.infer<typeof AnalysisScopeSchema>;
+
+/**
+ * Figma node types that unambiguously indicate a component-scope analysis
+ * when they appear as the analysis **root**.
+ *
+ * - `COMPONENT` / `COMPONENT_SET`: the design unit IS the component.
+ * - `INSTANCE`: the root is a reusable unit's placement; treating it as
+ *   component scope keeps rules like `missing-size-constraint` from
+ *   demanding bounds on a node whose bounds are the container's job.
+ *
+ * Any other root type (`FRAME`, `SECTION`, `CANVAS`, `DOCUMENT`, `GROUP`,
+ * etc.) resolves to page scope — the common case for analyzing a screen
+ * or page section via `?node-id=...`.
+ */
+const COMPONENT_SCOPE_ROOT_TYPES = new Set(["COMPONENT", "COMPONENT_SET", "INSTANCE"]);
+
+/**
+ * Deterministically detect analysis scope from the root node type. Returns
+ * `"component"` for `COMPONENT` / `COMPONENT_SET` / `INSTANCE` roots, and
+ * `"page"` for everything else.
+ *
+ * The CLI / MCP layer may override this with an explicit `scope` flag when
+ * the user knows the heuristic mis-detects (e.g. analyzing a FRAME that
+ * ships as a standalone design-system example rather than a screen).
+ */
+export function detectAnalysisScope(rootNode: AnalysisNode): AnalysisScope {
+  return COMPONENT_SCOPE_ROOT_TYPES.has(rootNode.type) ? "component" : "page";
+}

--- a/src/core/contracts/index.ts
+++ b/src/core/contracts/index.ts
@@ -2,6 +2,7 @@
 
 export * from "./severity.js";
 export * from "./channels.js";
+export * from "./analysis-scope.js";
 export * from "./category.js";
 export * from "./figma-node.js";
 export * from "./rule.js";

--- a/src/core/contracts/mcp-response.ts
+++ b/src/core/contracts/mcp-response.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { SeveritySchema } from "./severity.js";
 import { CategorySchema } from "./category.js";
+import { AnalysisScopeSchema } from "./analysis-scope.js";
 import {
   DetectionSchema,
   OutputChannelSchema,
@@ -58,6 +59,14 @@ export const McpAnalyzeResponseSchema = z.object({
   fileName: z.string(),
   nodeCount: z.number().int().min(0),
   maxDepth: z.number().int().min(0),
+  /**
+   * #404: Resolved analysis scope (`page` vs `component`). Downstream
+   * consumers (e.g. `figma-implement-design`, gotcha UI) branch on this
+   * the same way rules do — a component-scope result should not be
+   * treated as if container bounds are missing, and repetition detection
+   * on a component-scope result is not meaningful.
+   */
+  scope: AnalysisScopeSchema,
   issueCount: z.number().int().min(0),
   isReadyForCodeGen: z.boolean(),
   blockingIssueCount: z.number().int().min(0),

--- a/src/core/contracts/rule.ts
+++ b/src/core/contracts/rule.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { AnalysisScope } from "./analysis-scope.js";
 import { CategorySchema, type Category } from "./category.js";
 import { SeveritySchema } from "./severity.js";
 import type { AnalysisFile, AnalysisNode } from "./figma-node.js";
@@ -46,6 +47,15 @@ export interface RuleContext {
   siblings?: AnalysisNode[] | undefined;
   /** Per-analysis shared state. Created fresh for each analysis run, eliminating module-level mutable state. */
   analysisState: Map<string, unknown>;
+  /**
+   * #404: Scope of the analysis root (`page` vs `component`). Rules use
+   * this to decide whether expectations like "container must define
+   * bounds" or "repetition should become a component" apply. Constant for
+   * all nodes in a single analysis — whether the CURRENT node happens to
+   * be a `COMPONENT` descendant of a page root is already signalled by
+   * `componentDepth`, not by re-deriving scope per node.
+   */
+  scope: AnalysisScope;
 }
 
 /**

--- a/src/core/engine/rule-engine.test.ts
+++ b/src/core/engine/rule-engine.test.ts
@@ -525,3 +525,110 @@ describe("RuleEngine.analyze — acknowledgments", () => {
     expect(anyAcked).toBe(false);
   });
 });
+
+// ─── #404 analysis scope ──────────────────────────────────────────────────────
+
+describe("RuleEngine.analyze — scope detection and injection (#404)", () => {
+  it("auto-detects `page` scope for a FRAME root analyzed directly", () => {
+    const frame = makeNode({ id: "10:1", name: "Screen", type: "FRAME" });
+    const file = makeFile({ document: frame });
+
+    const result = analyzeFile(file);
+    expect(result.scope).toBe("page");
+  });
+
+  it("auto-detects `component` scope when targetNodeId resolves to a COMPONENT", () => {
+    const comp = makeNode({ id: "20:1", name: "Button", type: "COMPONENT" });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [comp],
+    });
+    const file = makeFile({ document: doc });
+
+    const result = analyzeFile(file, { targetNodeId: "20:1" });
+    // Scope is derived from the resolved root after targetNodeId — not the
+    // file's document — so analyzing a component via node-id yields
+    // component scope even when the file is a full page.
+    expect(result.scope).toBe("component");
+  });
+
+  it("auto-detects `component` scope for COMPONENT_SET and INSTANCE roots", () => {
+    const compSetFile = makeFile({
+      document: makeNode({ id: "30:1", name: "Icon-set", type: "COMPONENT_SET" }),
+    });
+    const instanceFile = makeFile({
+      document: makeNode({ id: "31:1", name: "Button/Primary", type: "INSTANCE" }),
+    });
+
+    expect(analyzeFile(compSetFile).scope).toBe("component");
+    expect(analyzeFile(instanceFile).scope).toBe("component");
+  });
+
+  it("explicit scope option overrides auto-detection in both directions", () => {
+    const frame = makeNode({ id: "10:1", name: "Screen", type: "FRAME" });
+    const comp = makeNode({ id: "20:1", name: "Button", type: "COMPONENT" });
+
+    // FRAME root normally detects as page → force component
+    expect(
+      analyzeFile(makeFile({ document: frame }), { scope: "component" }).scope
+    ).toBe("component");
+    // COMPONENT root normally detects as component → force page
+    // (rare, but supported — e.g. a "design-system demo page" packaged as a
+    // top-level COMPONENT that the user wants audited like a screen).
+    expect(
+      analyzeFile(makeFile({ document: comp }), { scope: "page" }).scope
+    ).toBe("page");
+  });
+
+  it("threads scope into every RuleContext a rule receives", () => {
+    const captured: string[] = [];
+
+    ruleRegistry.register({
+      definition: {
+        id: "capture-scope-test" as RuleId,
+        category: "code-quality",
+        label: "Capture scope for test",
+        description: "",
+      },
+      check: (_node, ctx) => {
+        captured.push(ctx.scope);
+        return null;
+      },
+    });
+
+    const cfg: Record<string, RuleConfig> = {
+      ...RULE_CONFIGS,
+      "capture-scope-test": { severity: "suggestion", score: 0, enabled: true },
+    };
+
+    try {
+      const comp = makeNode({ id: "40:1", name: "Card", type: "COMPONENT" });
+      const file = makeFile({
+        document: makeNode({
+          id: "0:1",
+          name: "Document",
+          type: "DOCUMENT",
+          children: [
+            comp,
+            makeNode({ id: "40:2", name: "Inner", type: "FRAME" }),
+          ],
+        }),
+      });
+
+      analyzeFile(file, {
+        targetNodeId: "40:1",
+        configs: cfg as Record<RuleId, RuleConfig>,
+        enabledRules: ["capture-scope-test" as RuleId],
+      });
+
+      expect(captured.length).toBeGreaterThan(0);
+      // Scope is constant per analysis — every visited node must see the
+      // same value (derived from the analysis root, not the current node).
+      expect(new Set(captured)).toEqual(new Set(["component"]));
+    } finally {
+      ruleRegistry.unregister("capture-scope-test" as RuleId);
+    }
+  });
+});

--- a/src/core/engine/rule-engine.ts
+++ b/src/core/engine/rule-engine.ts
@@ -13,6 +13,10 @@ import {
   normalizeNodeId,
   type Acknowledgment,
 } from "../contracts/acknowledgment.js";
+import {
+  detectAnalysisScope,
+  type AnalysisScope,
+} from "../contracts/analysis-scope.js";
 
 /**
  * Analysis issue with calculated score and metadata.
@@ -55,6 +59,13 @@ export interface AnalysisResult {
   maxDepth: number;
   nodeCount: number;
   analyzedAt: string;
+  /**
+   * #404: Resolved analysis scope (`page` vs `component`). Either detected
+   * from the root node type or taken from the caller's explicit override.
+   * Propagated to MCP / JSON output so downstream consumers (code-gen,
+   * reports) can branch the same way rules do.
+   */
+  scope: AnalysisScope;
 }
 
 /**
@@ -75,6 +86,15 @@ export interface RuleEngineOptions {
    * (`123-456`) or Plugin-API form (`123:456`) — both normalize to `:`.
    */
   acknowledgments?: Acknowledgment[];
+  /**
+   * #404: Explicit scope override. When omitted, the engine auto-detects
+   * from the analysis root's node type via `detectAnalysisScope`. Supply
+   * this when the caller knows the heuristic would mis-detect — e.g. a
+   * FRAME that happens to be a design-system demo (component scope) or a
+   * COMPONENT_SET being audited as part of a full page inventory (page
+   * scope).
+   */
+  scope?: AnalysisScope;
 }
 
 /**
@@ -158,6 +178,7 @@ export class RuleEngine {
   private excludeNamePattern: RegExp | null;
   private excludeNodeTypes: Set<string> | null;
   private acknowledgments: ReadonlySet<string>;
+  private scopeOverride: AnalysisScope | undefined;
 
   constructor(options: RuleEngineOptions = {}) {
     this.configs = options.configs ?? RULE_CONFIGS;
@@ -177,6 +198,7 @@ export class RuleEngine {
         (a) => `${normalizeNodeId(a.nodeId)}::${a.ruleId}`
       )
     );
+    this.scopeOverride = options.scope;
   }
 
   /**
@@ -200,6 +222,12 @@ export class RuleEngine {
     const maxDepth = calculateMaxDepth(rootNode);
     const nodeCount = countNodes(rootNode);
 
+    // #404: resolve scope once per analysis. Caller override wins over
+    // type-based detection so CLI/MCP users can correct false positives
+    // (e.g. design-system demo frames classified as page scope).
+    const scope: AnalysisScope =
+      this.scopeOverride ?? detectAnalysisScope(rootNode);
+
     const issues: AnalysisIssue[] = [];
     const failedRules: RuleFailure[] = [];
     const enabledRules = this.getEnabledRules();
@@ -217,6 +245,7 @@ export class RuleEngine {
       [],
       0,
       analysisState,
+      scope,
       undefined,
       undefined
     );
@@ -237,6 +266,7 @@ export class RuleEngine {
       maxDepth,
       nodeCount,
       analyzedAt: new Date().toISOString(),
+      scope,
     };
   }
 
@@ -274,6 +304,7 @@ export class RuleEngine {
     ancestorTypes: string[],
     componentDepth: number,
     analysisState: Map<string, unknown>,
+    scope: AnalysisScope,
     parent?: AnalysisNode,
     siblings?: AnalysisNode[]
   ): void {
@@ -302,6 +333,7 @@ export class RuleEngine {
       ancestorTypes,
       siblings,
       analysisState,
+      scope,
     };
 
     // Run each rule on this node
@@ -361,6 +393,7 @@ export class RuleEngine {
           childAncestorTypes,
           currentComponentDepth + 1,
           analysisState,
+          scope,
           node,
           node.children
         );

--- a/src/core/engine/scoring.test.ts
+++ b/src/core/engine/scoring.test.ts
@@ -46,7 +46,11 @@ function makeIssue(opts: {
   };
 }
 
-function makeResult(issues: AnalysisIssue[], nodeCount = 100): AnalysisResult {
+function makeResult(
+  issues: AnalysisIssue[],
+  nodeCount = 100,
+  overrides?: Partial<AnalysisResult>,
+): AnalysisResult {
   const doc: AnalysisNode = { id: "0:1", name: "Document", type: "DOCUMENT", visible: true };
   const file: AnalysisFile = {
     fileKey: "test",
@@ -57,7 +61,16 @@ function makeResult(issues: AnalysisIssue[], nodeCount = 100): AnalysisResult {
     components: {},
     styles: {},
   };
-  return { file, issues, failedRules: [], maxDepth: 5, nodeCount, analyzedAt: new Date().toISOString() };
+  return {
+    file,
+    issues,
+    failedRules: [],
+    maxDepth: 5,
+    nodeCount,
+    analyzedAt: new Date().toISOString(),
+    scope: "page",
+    ...overrides,
+  };
 }
 
 // ─── calculateScores ──────────────────────────────────────────────────────────
@@ -463,6 +476,21 @@ describe("buildResultJson", () => {
     expect(json.scores).toBeDefined();
     expect(json.summary).toBeDefined();
     expect(typeof json.summary).toBe("string");
+    // #404: scope is surfaced at the top level so downstream consumers
+    // (report HTML, figma-implement-design) can branch on page vs
+    // component without re-walking the tree.
+    expect(json.scope).toBe("page");
+  });
+
+  it("propagates component scope into the JSON output (#404)", () => {
+    const result = makeResult(
+      [makeIssue({ ruleId: "no-auto-layout", category: "pixel-critical", severity: "blocking" })],
+      100,
+      { scope: "component" },
+    );
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+    expect(json.scope).toBe("component");
   });
 
   it("aggregates issuesByRule correctly", () => {

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -471,6 +471,7 @@ export function buildResultJson(
     fileName,
     nodeCount: result.nodeCount,
     maxDepth: result.maxDepth,
+    scope: result.scope,
     issueCount: result.issues.length,
     acknowledgedCount: scores.summary.acknowledgedCount,
     isReadyForCodeGen: isReadyForCodeGen(scores.overall.grade),

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -94,6 +94,7 @@ function makeResult(
     maxDepth: 5,
     nodeCount: 100,
     analyzedAt: new Date().toISOString(),
+    scope: "page",
   };
 }
 

--- a/src/core/rules/component/missing-component.test.ts
+++ b/src/core/rules/component/missing-component.test.ts
@@ -44,6 +44,7 @@ function makeContext(overrides?: Partial<RuleContext>): RuleContext {
     path: ["Page", "Section"],
     ancestorTypes: [],
     analysisState,
+    scope: "page",
     ...overrides,
   };
 }

--- a/src/core/rules/rule-exceptions.test.ts
+++ b/src/core/rules/rule-exceptions.test.ts
@@ -27,6 +27,7 @@ function makeContext(overrides: Partial<RuleContext> = {}): RuleContext {
     path: ["Root", "Test"],
     ancestorTypes: [],
     analysisState: new Map(),
+    scope: "page",
     ...overrides,
   };
 }

--- a/src/core/rules/rule-registry.ts
+++ b/src/core/rules/rule-registry.ts
@@ -16,6 +16,15 @@ class RuleRegistry {
   }
 
   /**
+   * Remove a rule by ID. Primarily used by tests that register a
+   * throwaway rule and need to restore the registry afterwards. Returns
+   * `true` if the rule was present.
+   */
+  unregister(id: RuleId): boolean {
+    return this.rules.delete(id);
+  }
+
+  /**
    * Get a rule by ID
    */
   get(id: RuleId): Rule | undefined {

--- a/src/core/rules/test-helpers.ts
+++ b/src/core/rules/test-helpers.ts
@@ -27,6 +27,7 @@ export function makeContext(overrides?: Partial<RuleContext>): RuleContext {
     path: ["Page", "Section"],
     ancestorTypes: [],
     analysisState: new Map(),
+    scope: "page",
     ...overrides,
   };
 }

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -80,6 +80,7 @@ function makeResult(issues: AnalysisIssue[]): AnalysisResult {
     maxDepth: 5,
     nodeCount: 100,
     analyzedAt: new Date().toISOString(),
+    scope: "page",
   };
 }
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -49,6 +49,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     configPath: z.string().optional().describe("Path to config JSON file for rule overrides"),
     openReport: z.boolean().optional().describe("Open the generated HTML report in the user's browser. Defaults to false — opt in only when a visible report is the explicit user request (#365). The HTML file is always written to disk regardless."),
     acknowledgments: z.array(AcknowledgmentSchema).optional().describe("(#371) Pre-resolved [{ nodeId, ruleId }] pairs harvested from canicode-authored Figma annotations (e.g. via the `readCanicodeAcknowledgments` Plugin helper inside a use_figma batch). Matching issues are flagged `acknowledged: true` and contribute half weight to the density score so re-analyze surfaces movement after a roundtrip even under ADR-012's annotate-by-default policy."),
+    scope: z.enum(["page", "component"]).optional().describe("(#404) Override analysis scope — `page` (screen/section where container bounds are required) or `component` (standalone reusable unit where root FILL is the design contract). Defaults to auto-detection from the root node type: `COMPONENT` / `COMPONENT_SET` / `INSTANCE` roots resolve to `component`, everything else to `page`."),
   },
   {
     readOnlyHint: false,
@@ -56,7 +57,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     openWorldHint: true,
     title: "Analyze Figma Design",
   },
-  async ({ input, token, preset, targetNodeId, configPath, openReport, acknowledgments }) => {
+  async ({ input, token, preset, targetNodeId, configPath, openReport, acknowledgments, scope }) => {
     trackEvent(EVENTS.MCP_TOOL_CALLED, { tool: "analyze" });
     try {
       // Fetch via REST API or load from fixture
@@ -79,6 +80,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
         ...(acknowledgments && acknowledgments.length > 0
           ? { acknowledgments }
           : {}),
+        ...(scope ? { scope } : {}),
       });
 
       const scores = calculateScores(result, configs as Record<RuleId, RuleConfig>);
@@ -160,6 +162,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     preset: z.enum(["relaxed", "dev-friendly", "ai-ready", "strict"]).optional().describe("Analysis preset"),
     targetNodeId: z.string().optional().describe("Scope analysis to a specific node ID"),
     configPath: z.string().optional().describe("Path to config JSON file for rule overrides"),
+    scope: z.enum(["page", "component"]).optional().describe("(#404) Override analysis scope — `page` or `component`. Defaults to auto-detection from the root node type."),
   },
   {
     readOnlyHint: false,
@@ -167,7 +170,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     openWorldHint: true,
     title: "Gotcha Survey",
   },
-  async ({ input, token, preset, targetNodeId, configPath }) => {
+  async ({ input, token, preset, targetNodeId, configPath, scope }) => {
     trackEvent(EVENTS.MCP_TOOL_CALLED, { tool: "gotcha-survey" });
     try {
       const { file, nodeId } = await loadFile(input, token);
@@ -186,6 +189,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
       const result = analyzeFile(file, {
         configs: configs as Record<RuleId, RuleConfig>,
         ...(effectiveNodeId ? { targetNodeId: effectiveNodeId } : {}),
+        ...(scope ? { scope } : {}),
       });
 
       const scores = calculateScores(result, configs as Record<RuleId, RuleConfig>);


### PR DESCRIPTION
Closes #404.

## Summary

Introduces an `AnalysisScope` contract (`"page"` / `"component"`) and threads it through the analysis pipeline so responsive-critical rules can branch on what the user is actually analyzing. **No rule behavior is changed in this PR** — the first consumer is the `missing-size-constraint` redesign (#403). This PR lands the detection, contract, plumbing, override surface, and the calibration-orchestrator policy that prevents #403 from flipping grades across all 24 fixtures at merge time.

## Design decisions

**Detection (Option B with override)** — chose the issue's Option B (auto-detect from root node type) over Option A (interactive prompt) because canicode's primary call sites are CLI/MCP automation, not interactive shells. The heuristic is deterministic:

| Root node type | Resolved scope |
|---|---|
| `COMPONENT`, `COMPONENT_SET`, `INSTANCE` | `component` |
| `FRAME`, `SECTION`, `CANVAS`, `DOCUMENT`, `GROUP`, everything else | `page` |

When the heuristic mis-detects, callers override via:
- CLI: `canicode analyze --scope page` / `--scope component` (also on `gotcha-survey` and `calibrate-analyze`)
- MCP: `scope` parameter on the `analyze` and `gotcha-survey` tools

**Scope is constant per analysis.** Whether the *current* node happens to descend from a `COMPONENT` is already signalled by `componentDepth` — rules should not re-derive scope per node. `RuleContext.scope` reflects the analysis root, not the current subtree.

**No config-file surface.** Scope is a per-run property (depends on what's being analyzed, not team policy), so CLI flag + MCP param are the only override surfaces. `ConfigFileSchema` stays unchanged.

**Calibration orchestrator owns the policy** (review-driven). `scripts/calibrate.ts` injects `--scope page` for every fixture by default, with a per-fixture `.scope` file escape hatch. Policy sits one layer above the CLI rather than baked into the library, so ad-hoc `calibrate-analyze` runs still get neutral auto-detection.

## What changed

**Core contract + plumbing:**
- `src/core/contracts/analysis-scope.ts` (new) — `AnalysisScopeSchema` + `detectAnalysisScope`.
- `src/core/contracts/rule.ts` — `RuleContext.scope`.
- `src/core/contracts/mcp-response.ts` — required `scope` field on `McpAnalyzeResponseSchema`.
- `src/core/engine/rule-engine.ts` — resolves scope once (override ?? detect), propagates to every `RuleContext` and onto `AnalysisResult`.
- `src/core/engine/scoring.ts` — `buildResultJson` surfaces `scope` at top level.

**Override surfaces:**
- `src/cli/commands/analyze.ts`, `src/cli/commands/gotcha-survey.ts` — `--scope` override.
- `src/mcp/server.ts` — `scope` parameter on `analyze` + `gotcha-survey` tools.

**Calibration policy (Δ2):**
- `src/agents/contracts/calibration.ts` + `src/agents/calibration-compute.ts` — `CalibrationConfigSchema.scope` flows into `analyzeFile` options.
- `src/cli/commands/internal/calibrate-analyze.ts` — pass-through `--scope` flag; `analysis.json` now surfaces the resolved scope.
- `scripts/calibrate.ts` — `resolveCalibrationScope()` injects `page` by default, reads `<fixture-dir>/.scope` when present.

**Docs + tests:**
- `.claude/docs/ADR.md` — ADR-018 documenting heuristic + override + "one run, one scope" invariant.
- `README.md` — `--scope` in the Customization table.
- `src/core/rules/rule-registry.ts` — `unregister()` helper for tests that register throwaway rules.
- Tests: `analysis-scope.test.ts` (detection matrix + schema), `rule-engine.test.ts` (auto-detect + override + `RuleContext.scope` injection via a throwaway rule), `scoring.test.ts` (scope in `buildResultJson`), `calibration-compute.test.ts` (scope plumbing through `runCalibrationAnalyze`), `gotcha-survey.test.ts` (--scope override produces valid survey with identical ruleIds under page/component, confirming infra-only). Plus `scope: "page"` added to every `AnalysisResult` / `RuleContext` test-fixture constructor.

## Review deltas (PR #411 round 1)

**Δ1 — fixture/cache JSON baseline impact (verified, no code change).** Audited every call site that parses analyze-shaped JSON:
- `rg 'McpAnalyzeResponseSchema\.(parse|safeParse)'` → **0 matches**. The schema is type-inference / contract-spec only.
- `rg --files-with-matches '"issuesByRule"|"scores"' '**/*.json'` → 0 stored analyze responses.
- `src/experiments/ablation/**/result.json` only carries `{ similarity, ... }` from conversion runs — not analyze output.
- `fixtures/done/*/data.json` are raw Figma file exports, not analyze responses.

Required `scope` addition on `McpAnalyzeResponseSchema` has no parse-time break at any repo boundary. Same vetting pattern that closed the equivalent #409 concern.

**Δ2 — calibration latent-landmine prevention (implemented).** Without an orchestrator-level default, once #403 lands and `missing-size-constraint` starts respecting `ctx.scope`, all 24 `fixtures/done/*` (every one of which has a `COMPONENT` root — verified via `node -e 'require(...).document.type'`) would flow into the `component` branch and flip grades at merge time. `scripts/calibrate.ts` now forces `page` with per-fixture `.scope` override, and `analysis.json` surfaces the resolved scope for post-hoc grade diffing.

**Nits addressed:**
- Added `runGotchaSurvey` test asserting `--scope` override produces a valid survey with identical question ruleIds under both scopes (infra-only invariant).
- Added `runCalibrationAnalyze` tests asserting page / component / auto-fallback scope plumbing.
- `README.md` Customization table documents `--scope`. `docs/CUSTOMIZATION.md` intentionally untouched — it covers config-file surface, and scope was explicitly excluded from that surface by design.

## Empirical note — calibration fixtures

All 24 `fixtures/done/*` store `COMPONENT` as their root ("Simple Design System (Community)" packages each screen as a `Platform=Desktop`/`Platform=Mobile` variant). With no rule consuming scope yet, grades are identical across `--scope page` / `--scope component` / auto-detect — verified via `calibrate-analyze` on `desktop-home-page` (grade `B` in all three modes). The orchestrator's `--scope page` default kicks in the moment #403 (or any other scope-aware rule) lands.

## Out of scope (per #404)

- Rule-specific behavior changes — first consumer is #403.
- Multi-scope analysis — one run, one scope.
- Interactive prompt (Option A) — replaced by deterministic default + explicit override.
- Top-level `scope` in `ConfigFileSchema` — not a team-policy concern.

## Test plan

- [x] `pnpm lint` passes (strict TS).
- [x] `pnpm vitest run` — 1042 tests pass (+new scope tests for contract, engine, scoring, calibration, gotcha-survey).
- [x] CLI smoke: `canicode analyze` emits the correct `scope` field; `--scope` overrides both directions.
- [x] Calibration smoke: `calibrate-analyze --scope page|component|<omitted>` all succeed, `analysis.json` surfaces the resolved value, grade stable across all three.
- [x] Δ1 verified: no `McpAnalyzeResponseSchema.parse` call sites, no stored analyze JSON anywhere in repo.
- [ ] CI green.

## References

- Issue: #404
- Related: #403 (first rule consumer — `missing-size-constraint` redesign), ADR-017 (rule/gotcha channel split), ADR-018 (new — scope contract + override policy).