### PR TITLE
feat: extend missing-size-constraint to height axis (#403 followup)

### DIFF
--- a/.tmp/413-gate/compare.ts
+++ b/.tmp/413-gate/compare.ts
@@ -1,0 +1,234 @@
+#!/usr/bin/env tsx
+/**
+ * Height-axis gate reporter for #413.
+ *
+ * Aggregates the 24 fixture probes emitted by run-all.sh:
+ *   (1) fire-rate: FILL-height containers and INSTANCE-FIXED-height counts
+ *   (2) depth histogram across all fixtures
+ *   (3) overlap with fixed-size-in-auto-layout (re-runs analyzeFile per fixture
+ *       and counts INSTANCE-FIXED-height nodes that also appear as a fire of
+ *       that rule)
+ *   (4) desktop/mobile split so the verdict doesn't collapse a bimodal
+ *       distribution into one mean
+ *
+ * Output shape is kept visually close to .tmp/403-gate/compare.ts so the two
+ * axes can be diffed side-by-side.
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { analyzeFile } from "../../src/core/engine/rule-engine.js";
+import { loadFile } from "../../src/core/engine/loader.js";
+import "../../src/core/rules/index.js";
+
+const ROOT = ".tmp/413-gate";
+
+interface ProbeRow {
+  kind: "fill-container" | "instance-fixed";
+  nodeId: string;
+  nodeName: string;
+  nodePath: string;
+  depth: number;
+  height: string;
+  boundFoundAt?: string | null;
+  boundAncestorSizing?: string | null;
+  stepsToBound?: number;
+  parentName?: string;
+  parentLayoutMode?: string;
+  nodeType?: string;
+}
+
+interface Probe {
+  fixture: string;
+  summary: {
+    fillContainers: number;
+    bounded: number;
+    unbounded: number;
+    instanceFixedInAutoLayout: number;
+  };
+  depthHistogram: Record<string, number>;
+  rows: ProbeRow[];
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + " ".repeat(n - s.length);
+}
+
+function platform(name: string): "desktop" | "mobile" | "other" {
+  if (name.startsWith("desktop-")) return "desktop";
+  if (name.startsWith("mobile-")) return "mobile";
+  return "other";
+}
+
+const fixtures = readdirSync(ROOT, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name)
+  .filter((n) => existsSync(join(ROOT, n, "probe.json")))
+  .sort();
+
+if (fixtures.length === 0) {
+  console.error(
+    `No probe.json files under ${ROOT}/*/ — run .tmp/413-gate/run-all.sh first.`,
+  );
+  process.exit(1);
+}
+
+const probes: Probe[] = fixtures.map(
+  (fx) => JSON.parse(readFileSync(join(ROOT, fx, "probe.json"), "utf-8")) as Probe,
+);
+
+// ── Section 1: per-fixture counts ──────────────────────────────────────────
+
+console.log("═══════════════════════════════════════════════════════════════════");
+console.log("Height-axis probe — per-fixture counts (24 fixtures)");
+console.log("═══════════════════════════════════════════════════════════════════\n");
+
+console.log(
+  `${pad("Fixture", 26)} | ${pad("FILL conts", 10)} | ${pad("unbounded", 9)} | ${pad("INST FIXED (AL)", 15)}`,
+);
+console.log("-".repeat(80));
+for (let i = 0; i < fixtures.length; i++) {
+  const fx = fixtures[i]!;
+  const p = probes[i]!;
+  console.log(
+    `${pad(fx, 26)} | ${pad(String(p.summary.fillContainers), 10)} | ${pad(String(p.summary.unbounded), 9)} | ${pad(String(p.summary.instanceFixedInAutoLayout), 15)}`,
+  );
+}
+
+// ── Section 2: aggregate totals (+ desktop/mobile split) ───────────────────
+
+console.log();
+console.log("Aggregate totals:");
+const total = {
+  fill: 0,
+  bounded: 0,
+  unbounded: 0,
+  instance: 0,
+};
+const byPlatform: Record<string, typeof total> = {
+  desktop: { fill: 0, bounded: 0, unbounded: 0, instance: 0 },
+  mobile: { fill: 0, bounded: 0, unbounded: 0, instance: 0 },
+  other: { fill: 0, bounded: 0, unbounded: 0, instance: 0 },
+};
+for (let i = 0; i < fixtures.length; i++) {
+  const p = probes[i]!;
+  const plat = platform(fixtures[i]!);
+  total.fill += p.summary.fillContainers;
+  total.bounded += p.summary.bounded;
+  total.unbounded += p.summary.unbounded;
+  total.instance += p.summary.instanceFixedInAutoLayout;
+  byPlatform[plat]!.fill += p.summary.fillContainers;
+  byPlatform[plat]!.bounded += p.summary.bounded;
+  byPlatform[plat]!.unbounded += p.summary.unbounded;
+  byPlatform[plat]!.instance += p.summary.instanceFixedInAutoLayout;
+}
+console.log(`  FRAME/SECTION FILL-height containers:   ${total.fill}`);
+console.log(`    bounded:                              ${total.bounded}`);
+console.log(`    unbounded (would fire):               ${total.unbounded}`);
+console.log(`  INSTANCE FIXED-height in Auto Layout:   ${total.instance}`);
+console.log();
+console.log("Desktop / mobile split:");
+for (const plat of ["desktop", "mobile"] as const) {
+  const t = byPlatform[plat]!;
+  console.log(
+    `  ${pad(plat, 8)} fill=${t.fill}  unbounded=${t.unbounded}  instance-fixed(AL)=${t.instance}`,
+  );
+}
+
+// ── Section 3: aggregate depth histogram ───────────────────────────────────
+
+console.log();
+console.log("Steps-to-bound histogram (aggregate, bounded rows only):");
+const aggHist: Record<string, number> = {};
+for (const p of probes) {
+  for (const [steps, count] of Object.entries(p.depthHistogram)) {
+    aggHist[steps] = (aggHist[steps] ?? 0) + count;
+  }
+}
+const histKeys = Object.keys(aggHist).sort((a, b) => Number(a) - Number(b));
+if (histKeys.length === 0) {
+  console.log("  (no bounded rows — no FILL-height containers fired)");
+} else {
+  for (const k of histKeys) console.log(`  ${k} step(s): ${aggHist[k]}`);
+}
+
+// ── Section 4: overlap with fixed-size-in-auto-layout ──────────────────────
+//
+// For each INSTANCE-FIXED-height probe row, check whether the same nodeId
+// appears as a fire of fixed-size-in-auto-layout in analyzeFile output. High
+// overlap means the additive-score rationale from #403's page-instance-fixed
+// does NOT directly apply — the score channel is already covered.
+
+console.log();
+console.log("═══════════════════════════════════════════════════════════════════");
+console.log("Overlap: INSTANCE-FIXED-height vs fixed-size-in-auto-layout fires");
+console.log("═══════════════════════════════════════════════════════════════════\n");
+
+let totalInstanceFires = 0;
+let totalOverlap = 0;
+const overlapRows: Array<{
+  fixture: string;
+  overlapping: number;
+  instanceFires: number;
+  exampleOverlapPath?: string;
+}> = [];
+
+for (let i = 0; i < fixtures.length; i++) {
+  const fx = fixtures[i]!;
+  const probe = probes[i]!;
+  const instanceFires = probe.rows.filter((r) => r.kind === "instance-fixed");
+  if (instanceFires.length === 0) {
+    overlapRows.push({ fixture: fx, overlapping: 0, instanceFires: 0 });
+    continue;
+  }
+
+  const { file } = await loadFile(`fixtures/done/${fx}`);
+  const result = analyzeFile(file, { scope: "page" });
+  const fixedSizeIds = new Set<string>();
+  for (const issue of result.issues) {
+    if (issue.rule.definition.id === "fixed-size-in-auto-layout") {
+      fixedSizeIds.add(issue.violation.nodeId);
+    }
+  }
+
+  let overlap = 0;
+  let example: string | undefined;
+  for (const row of instanceFires) {
+    if (fixedSizeIds.has(row.nodeId)) {
+      overlap++;
+      if (!example) example = row.nodePath;
+    }
+  }
+  totalInstanceFires += instanceFires.length;
+  totalOverlap += overlap;
+  overlapRows.push({
+    fixture: fx,
+    overlapping: overlap,
+    instanceFires: instanceFires.length,
+    ...(example ? { exampleOverlapPath: example } : {}),
+  });
+}
+
+console.log(
+  `${pad("Fixture", 26)} | ${pad("inst-fires", 10)} | ${pad("overlap", 7)} | example overlap path`,
+);
+console.log("-".repeat(100));
+for (const r of overlapRows) {
+  if (r.instanceFires === 0) continue;
+  console.log(
+    `${pad(r.fixture, 26)} | ${pad(String(r.instanceFires), 10)} | ${pad(String(r.overlapping), 7)} | ${r.exampleOverlapPath ?? "—"}`,
+  );
+}
+const anyInstance = overlapRows.some((r) => r.instanceFires > 0);
+if (!anyInstance) console.log("(no INSTANCE-FIXED-height fires in any fixture)");
+
+console.log();
+console.log(
+  `Overlap total: ${totalOverlap} / ${totalInstanceFires}  (${
+    totalInstanceFires === 0
+      ? "—"
+      : `${Math.round((totalOverlap / totalInstanceFires) * 100)}%`
+  })`,
+);
+
+console.log();
+console.log("Done.");

--- a/.tmp/413-gate/followup-issue.md
+++ b/.tmp/413-gate/followup-issue.md
@@ -1,0 +1,42 @@
+# Closure comment draft for #413
+
+> This is a **closure comment**, not a follow-up issue. The gate measurement returned a (C) verdict (see `.tmp/413-gate/verdict.md`), so no implementation issue is being drafted. If the corpus later grows non-media fixed-height usage, reopen with the new evidence.
+
+---
+
+## Proposed closing comment
+
+Running the acceptance-criteria probe across all 24 `fixtures/done/*` (see `.tmp/413-gate/`):
+
+| Criterion | Result |
+|---|---|
+| FRAME/SECTION FILL-height containers with no ancestor bound | **0** (across 24 fixtures) |
+| INSTANCE FIXED-height in Auto Layout parent | **8** (all the same "Panel Image Double" media component, 478px) |
+| Viewport-intent classification rate | **0 / 8 (0%)** — 100% fall into the "media / aspect slot" row of the legitimate-FIXED table |
+| Overlap with `fixed-size-in-auto-layout` | 0 / 8 (0%) — distinct node set, but the nodes are correct-by-design (aspect-bound images), not a missing penalty |
+| Desktop / mobile split | 4 / 4 — identical shape on both; no platform-specific signal |
+
+The acceptance gate was **≥30% viewport-intent fires to proceed with (A) or (B)**. Actual rate is **0%**, an order of magnitude below.
+
+Closing as **won't fix**. Leaving `RULE_ANNOTATION_PROPERTIES["missing-size-constraint"]` scoped to `[{ type: "width" }]` per #403. ADR-018's post-#403 baseline is unchanged.
+
+If future fixtures surface height-FIXED usage outside the legitimate-FIXED taxonomy (non-media fixed-height data tables, mobile chat UIs with explicit fixed footer height, full-viewport heroes matching device height), reopen this issue with the updated probe output.
+
+### What stays on the table (not being implemented now)
+
+These were noted in the Implementation sketch; they only become relevant if (A) or (B) gets revived by new evidence:
+
+- Shared chain-bound walker extraction (`establishesOwnWidthBound` → `establishesOwnBound(node, axis)`). Width-only walker is fine as-is — no second consumer exists.
+- The #412 scoped-out `isModifiable` utility bundle call-out. The trigger (walker-extraction work) hasn't materialized, so `isModifiable` stays deferred to its own separately-motivated issue.
+- ADR-018 height amendment. No change to baseline; no edit needed.
+
+### Evidence artifacts
+
+Committed under `.tmp/413-gate/`:
+
+- `walker-sanity-height.ts` — per-fixture probe
+- `run-all.sh` + `compare.ts` — 24-fixture runner and aggregate reporter
+- `<fixture>/probe.json` × 24 — structured probe output
+- `<fixture>/probe.log` × 24 — runner console log
+- `report.txt` — compare.ts snapshot
+- `verdict.md` — full rationale including per-row classification table

--- a/.tmp/413-gate/report.txt
+++ b/.tmp/413-gate/report.txt
@@ -1,0 +1,66 @@
+═══════════════════════════════════════════════════════════════════
+Height-axis probe — per-fixture counts (24 fixtures)
+═══════════════════════════════════════════════════════════════════
+
+Fixture                    | FILL conts | unbounded | INST FIXED (AL)
+--------------------------------------------------------------------------------
+desktop-about              | 0          | 0         | 1              
+desktop-ai-chat            | 0          | 0         | 0              
+desktop-article            | 0          | 0         | 2              
+desktop-contact-us         | 0          | 0         | 0              
+desktop-home-page          | 0          | 0         | 0              
+desktop-landing-page       | 0          | 0         | 1              
+desktop-portfolio          | 0          | 0         | 0              
+desktop-pricing            | 0          | 0         | 0              
+desktop-product-detail     | 0          | 0         | 0              
+desktop-shop               | 0          | 0         | 0              
+desktop-slot               | 0          | 0         | 0              
+desktop-waitlist           | 0          | 0         | 0              
+mobile-about               | 0          | 0         | 1              
+mobile-ai-chat             | 0          | 0         | 0              
+mobile-article             | 0          | 0         | 2              
+mobile-contact-us          | 0          | 0         | 0              
+mobile-home-page           | 0          | 0         | 0              
+mobile-landing-page        | 0          | 0         | 1              
+mobile-portfolio           | 0          | 0         | 0              
+mobile-pricing             | 0          | 0         | 0              
+mobile-product-detail      | 0          | 0         | 0              
+mobile-shop                | 0          | 0         | 0              
+mobile-slot                | 0          | 0         | 0              
+mobile-waitlist            | 0          | 0         | 0              
+
+Aggregate totals:
+  FRAME/SECTION FILL-height containers:   0
+    bounded:                              0
+    unbounded (would fire):               0
+  INSTANCE FIXED-height in Auto Layout:   8
+
+Desktop / mobile split:
+  desktop  fill=0  unbounded=0  instance-fixed(AL)=4
+  mobile   fill=0  unbounded=0  instance-fixed(AL)=4
+
+Steps-to-bound histogram (aggregate, bounded rows only):
+  (no bounded rows — no FILL-height containers fired)
+
+═══════════════════════════════════════════════════════════════════
+Overlap: INSTANCE-FIXED-height vs fixed-size-in-auto-layout fires
+═══════════════════════════════════════════════════════════════════
+
+Loading from JSON: /Users/minseon/Code/design-readiness-checker/fixtures/done/desktop-about/data.json
+Loading from JSON: /Users/minseon/Code/design-readiness-checker/fixtures/done/desktop-article/data.json
+Loading from JSON: /Users/minseon/Code/design-readiness-checker/fixtures/done/desktop-landing-page/data.json
+Loading from JSON: /Users/minseon/Code/design-readiness-checker/fixtures/done/mobile-about/data.json
+Loading from JSON: /Users/minseon/Code/design-readiness-checker/fixtures/done/mobile-article/data.json
+Loading from JSON: /Users/minseon/Code/design-readiness-checker/fixtures/done/mobile-landing-page/data.json
+Fixture                    | inst-fires | overlap | example overlap path
+----------------------------------------------------------------------------------------------------
+desktop-about              | 1          | 0       | —
+desktop-article            | 2          | 0       | —
+desktop-landing-page       | 1          | 0       | —
+mobile-about               | 1          | 0       | —
+mobile-article             | 2          | 0       | —
+mobile-landing-page        | 1          | 0       | —
+
+Overlap total: 0 / 8  (0%)
+
+Done.

--- a/.tmp/413-gate/run-all.sh
+++ b/.tmp/413-gate/run-all.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Run the height-axis probe against every fixtures/done/* and emit structured
+# JSON under .tmp/413-gate/<fixture>/probe.json for compare.ts to aggregate.
+set -euo pipefail
+
+OUT_ROOT=".tmp/413-gate"
+
+for fixture_dir in fixtures/done/*/; do
+  name="$(basename "${fixture_dir}")"
+  out_dir="${OUT_ROOT}/${name}"
+  mkdir -p "${out_dir}"
+  echo "→ ${name}"
+  pnpm exec tsx .tmp/413-gate/walker-sanity-height.ts \
+    "${fixture_dir%/}" \
+    --json-out "${out_dir}/probe.json" > "${out_dir}/probe.log" 2>&1 || {
+    echo "   ✗ failed (see ${out_dir}/probe.log)"
+    continue
+  }
+done
+
+echo "Done: ${OUT_ROOT}"

--- a/.tmp/413-gate/verdict.md
+++ b/.tmp/413-gate/verdict.md
@@ -1,0 +1,105 @@
+# #413 Gate Verdict — extend `missing-size-constraint` to height axis?
+
+**Recommendation: (C) No-op / won't-fix. Close with a documented rationale.**
+
+---
+
+## Measurements (24 fixtures, `fixtures/done/*`)
+
+Source data: `.tmp/413-gate/<fixture>/probe.json`, aggregated by `compare.ts` into `report.txt`.
+
+### 1. Fire-rate probe
+
+| Axis of interest | Count across 24 fixtures |
+|---|---|
+| FRAME/SECTION with `layoutSizingVertical === "FILL"` and no ancestor height bound | **0** |
+| INSTANCE with `layoutSizingVertical === "FIXED"` whose parent has Auto Layout | **8** (desktop 4 / mobile 4) |
+
+The `page-container-unbound-height` analogue (parallel to width's dominant subtype) **does not fire once across any of 24 fixtures**. By construction the other page-scope subtype — `page-instance-fixed-height` — has 8 candidate rows.
+
+Width-axis baseline for comparison (`.tmp/403-gate/branch/*`, post-#403): `missing-size-constraint` fires across all 24 fixtures with a meaningful `page-container-unbound` count. The height axis is effectively empty on the dominant subtype.
+
+### 2. Intent-ambiguity classification (all 8 fires sampled — census, not sample)
+
+All 8 INSTANCE-FIXED-height fires are the same component, "Panel Image Double", rendered at `height=478px` as a direct child of the Platform=Desktop/Mobile page root.
+
+| Fixture                 | nodeId        | height | depth | parent (layout)                    | node path                                 | classification          |
+|-------------------------|---------------|--------|-------|------------------------------------|-------------------------------------------|-------------------------|
+| desktop-about           | 175:4837      | 478px  | 1     | Platform=Desktop (VERTICAL)        | Platform=Desktop > Panel Image Double     | legitimate: media slot  |
+| desktop-article         | 175:6761      | 478px  | 1     | Platform=Desktop (VERTICAL)        | Platform=Desktop > Panel Image Double     | legitimate: media slot  |
+| desktop-article         | 175:6762      | 478px  | 1     | Platform=Desktop (VERTICAL)        | Platform=Desktop > Panel Image Double     | legitimate: media slot  |
+| desktop-landing-page    | 175:6349      | 478px  | 1     | Platform=Desktop (VERTICAL)        | Platform=Desktop > Panel Image Double     | legitimate: media slot  |
+| mobile-about            | 562:8444      | 478px  | 1     | Platform=Mobile (VERTICAL)         | Platform=Mobile > Panel Image Double      | legitimate: media slot  |
+| mobile-article          | 562:10144     | 478px  | 1     | Platform=Mobile (VERTICAL)         | Platform=Mobile > Panel Image Double      | legitimate: media slot  |
+| mobile-article          | 562:10145     | 478px  | 1     | Platform=Mobile (VERTICAL)         | Platform=Mobile > Panel Image Double      | legitimate: media slot  |
+| mobile-landing-page     | 562:9796      | 478px  | 1     | Platform=Mobile (VERTICAL)         | Platform=Mobile > Panel Image Double      | legitimate: media slot  |
+
+Classification signals used (per the issue's "Legitimate FIXED height cases" table):
+
+- Component name literally contains "Image" → media / image slot
+- Identical fixed height (478px) across desktop and mobile variants → aspect-ratio-driven crop region, not viewport-sized intent
+- Used in 3 distinct fixtures by direct insertion → stable library component, not ad-hoc hero section
+
+**Viewport-intent fires: 0/8 (0%).** Legitimate-FIXED fires: 8/8 (100%).
+
+### 3. Overlap with `fixed-size-in-auto-layout`
+
+`.tmp/413-gate/report.txt` §"Overlap": **0 / 8 (0%)**. The 8 INSTANCE-FIXED-height candidates are a distinct node set from the nodes `fixed-size-in-auto-layout` fires on. This means the additive-score rationale from #403's `page-instance-fixed` (width) **cannot be directly recycled** — there is no score-channel overlap to cite.
+
+However, it also means the concern doesn't matter: those 8 nodes are a single reused media component, not a score-channel gap.
+
+### 4. FIXED-height legitimacy taxonomy
+
+| Category (from issue) | Observed count | Example |
+|---|---|---|
+| Media / aspect slot (16:9, thumbnails, crop) | **8** | "Panel Image Double" 478px, cross-fixture |
+| Scroll region before `overflow`                   | 0 | — |
+| Sticky bar / one-line chrome (header/footer)      | 0 | — |
+| Skeleton / placeholder                            | 0 | — |
+| Data-table row                                    | 0 | — |
+| Modal / bottom sheet                              | 0 | — |
+| Full-viewport hero (gotcha candidate)             | 0 | — |
+
+All 8 FIXED-height fires map to exactly one row of the "legitimate" table. Zero map to the only row the issue flags as "gotcha candidate" (full-viewport hero).
+
+---
+
+## Rationale for (C)
+
+The issue's acceptance criterion is: **≥30% of sampled fires are plausible designer-intent gotchas** → proceed with (A) or (B). The actual rate measured is **0/8 = 0%**, an order of magnitude below the gate.
+
+Three reinforcing reasons:
+
+1. **No page-container-unbound-height signal at all.** The dominant width-axis subtype has no height-axis counterpart on any of 24 fixtures. Shipping a rule whose primary subtype fires zero times is pure noise surface area.
+
+2. **All INSTANCE-FIXED-height candidates are structurally identical** (same component, same height, used as direct children of page roots). This is the archetypal "media / aspect slot" case from the issue's legitimate-FIXED table — flagging it would generate user-facing gotchas for behavior that is correct by design, training users to dismiss the rule.
+
+3. **No score-channel gap exists in practice.** Although overlap with `fixed-size-in-auto-layout` is 0%, that is because the single offending component *is not itself a violation* — the parent Auto Layout owns the height sizing correctly for an aspect-bound image. There is no "missing penalty" the new rule would close.
+
+## Desktop / mobile distribution
+
+The "bimodal distribution" risk flagged in the plan (desktop-heavy viewport-sized sections vs mobile-heavy content-driven height) is not observed. The 8 fires split 4 desktop / 4 mobile, **all identical in shape** (media component). Neither platform shows the patterns a height-axis rule would be designed to catch.
+
+## What (C) means in practice
+
+- Close #413 with a comment citing the numbers above.
+- Document the measurement result in the #413 follow-up issue draft (see `followup-issue.md`) as a closure comment rather than an implementation plan.
+- Leave `RULE_ANNOTATION_PROPERTIES["missing-size-constraint"]` restricted to `[{ type: "width" }]` as #403 set it.
+- Leave ADR-018 amendment as-is — no post-#413 baseline change.
+- If future fixtures (e.g. dashboards with fixed-height data tables, mobile chat UIs with fixed footers) surface non-media FIXED-height usage, reopen with new evidence.
+
+## Known limitations of this verdict
+
+- **Fixture bias**: all 24 fixtures come from a single designer / design system. If another design system uses viewport-sized hero sections with explicit FIXED height matching device height, the probe would detect that — but we can't measure it from this corpus alone.
+- **Chain walker semantics on height**: we didn't revisit whether `minHeight` / `maxHeight` chain propagation matches width's. The issue explicitly warned against that mirror ("do not mirror the width rule's min/max chain as mandatory"). Since the probe found zero FILL-height containers, the semantic difference is moot for this corpus.
+- **Census vs sample**: we sampled all 8 fires, not 20. The planned 20-row sample assumed a larger denominator; with only 8 candidates, the 30% gate is measured against the full population.
+
+## Files committed alongside this verdict
+
+- `.tmp/413-gate/walker-sanity-height.ts` — the per-fixture probe
+- `.tmp/413-gate/run-all.sh` — 24-fixture runner
+- `.tmp/413-gate/compare.ts` — aggregate reporter
+- `.tmp/413-gate/<fixture>/probe.json` (×24) — structured per-fixture output
+- `.tmp/413-gate/<fixture>/probe.log` (×24) — console log per run
+- `.tmp/413-gate/report.txt` — full compare.ts output snapshot
+- `.tmp/413-gate/followup-issue.md` — closure-comment draft (not an implementation plan)

--- a/.tmp/413-gate/walker-sanity-height.ts
+++ b/.tmp/413-gate/walker-sanity-height.ts
@@ -1,0 +1,236 @@
+#!/usr/bin/env tsx
+/**
+ * Height-axis evidence probe for #413 (mirrors .tmp/403-gate/walker-sanity.ts).
+ *
+ * Answers: how many FRAME/SECTION FILL-height containers exist, how many have
+ * an ancestor that terminates the height chain, and how many INSTANCE
+ * FIXED-height nodes sit inside an Auto Layout parent (the `page-instance-fixed`
+ * analogue on the height axis).
+ *
+ * Excludes INSTANCE descendants (Plugin API ignores min/max writes there — same
+ * actionability filter as the production rule) so the probe reflects what a
+ * height-axis rule would actually fire on.
+ *
+ * Usage:
+ *   tsx walker-sanity-height.ts <fixture-dir> [--json-out <path>]
+ */
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { loadFile } from "../../src/core/engine/loader.js";
+import "../../src/core/rules/index.js";
+import type { AnalysisNode } from "../../src/core/contracts/figma-node.js";
+
+const args = process.argv.slice(2);
+const positional = args.filter((a) => !a.startsWith("--"));
+const FIXTURE = positional[0] ?? "fixtures/done/desktop-home-page";
+const jsonOutIdx = args.indexOf("--json-out");
+const JSON_OUT = jsonOutIdx !== -1 ? args[jsonOutIdx + 1] : null;
+
+const CONTAINER_TYPES = new Set(["FRAME", "SECTION"]);
+
+function establishesOwnHeightBound(node: AnalysisNode): boolean {
+  if (node.layoutSizingVertical === "FIXED") return true;
+  if (node.minHeight !== undefined || node.maxHeight !== undefined) return true;
+  return false;
+}
+
+function describeBound(node: AnalysisNode): string {
+  const parts: string[] = [];
+  if (node.layoutSizingVertical === "FIXED") parts.push("FIXED");
+  if (node.minHeight !== undefined) parts.push(`minHeight=${node.minHeight}`);
+  if (node.maxHeight !== undefined) parts.push(`maxHeight=${node.maxHeight}`);
+  return parts.join(", ");
+}
+
+function formatHeight(node: AnalysisNode): string {
+  return node.absoluteBoundingBox
+    ? `${node.absoluteBoundingBox.height}px`
+    : "unknown";
+}
+
+interface FillRow {
+  kind: "fill-container";
+  nodeId: string;
+  nodeName: string;
+  nodeType: string;
+  nodePath: string;
+  depth: number;
+  height: string;
+  boundFoundAt: string | null;
+  boundAncestorSizing: string | null;
+  stepsToBound: number;
+}
+
+interface InstanceRow {
+  kind: "instance-fixed";
+  nodeId: string;
+  nodeName: string;
+  nodePath: string;
+  depth: number;
+  height: string;
+  parentName: string;
+  parentLayoutMode: string;
+}
+
+type Row = FillRow | InstanceRow;
+
+const fillRows: FillRow[] = [];
+const instanceRows: InstanceRow[] = [];
+
+function hasInstanceAncestor(ancestors: AnalysisNode[]): boolean {
+  return ancestors.some((a) => a.type === "INSTANCE");
+}
+
+function walk(
+  node: AnalysisNode,
+  path: string[],
+  depth: number,
+  ancestors: AnalysisNode[],
+): void {
+  const fullPath = [...path, node.name];
+
+  // Actionability filter: mirror the production rule — exclude nodes whose
+  // ancestor chain contains an INSTANCE (Plugin API ignores writes there).
+  // INSTANCE nodes themselves remain in scope (that is the page-instance-fixed
+  // analogue for the height axis).
+  const insideInstance = hasInstanceAncestor(ancestors);
+
+  if (
+    !insideInstance &&
+    CONTAINER_TYPES.has(node.type) &&
+    node.layoutSizingVertical === "FILL"
+  ) {
+    let boundAt: AnalysisNode | null = null;
+    let stepsToBound = 0;
+    for (let i = ancestors.length - 1; i >= 0; i--) {
+      stepsToBound++;
+      if (establishesOwnHeightBound(ancestors[i]!)) {
+        boundAt = ancestors[i]!;
+        break;
+      }
+    }
+    fillRows.push({
+      kind: "fill-container",
+      nodeId: node.id,
+      nodeName: node.name,
+      nodeType: node.type,
+      nodePath: fullPath.join(" > "),
+      depth,
+      height: formatHeight(node),
+      boundFoundAt: boundAt ? boundAt.name : null,
+      boundAncestorSizing: boundAt ? describeBound(boundAt) : null,
+      stepsToBound: boundAt ? stepsToBound : -1,
+    });
+  }
+
+  if (
+    !insideInstance &&
+    node.type === "INSTANCE" &&
+    node.layoutSizingVertical === "FIXED"
+  ) {
+    const parent = ancestors[ancestors.length - 1];
+    if (parent && parent.layoutMode && parent.layoutMode !== "NONE") {
+      instanceRows.push({
+        kind: "instance-fixed",
+        nodeId: node.id,
+        nodeName: node.name,
+        nodePath: fullPath.join(" > "),
+        depth,
+        height: formatHeight(node),
+        parentName: parent.name,
+        parentLayoutMode: parent.layoutMode,
+      });
+    }
+  }
+
+  if (node.children) {
+    const next = [...ancestors, node];
+    for (const child of node.children) walk(child, fullPath, depth + 1, next);
+  }
+}
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + " ".repeat(n - s.length);
+}
+
+async function main() {
+  console.log(`Height-axis sanity probe on ${FIXTURE}`);
+  const { file } = await loadFile(FIXTURE);
+  walk(file.document, [], 0, []);
+
+  const bounded = fillRows.filter((r) => r.boundFoundAt !== null);
+  const unbounded = fillRows.filter((r) => r.boundFoundAt === null);
+
+  console.log();
+  console.log(`FRAME/SECTION FILL-height containers:  ${fillRows.length}`);
+  console.log(`  → bound found in ancestor chain:    ${bounded.length}`);
+  console.log(`  → no bound to root (would fire):    ${unbounded.length}`);
+  console.log(`INSTANCE FIXED-height in Auto Layout: ${instanceRows.length}`);
+  console.log();
+
+  if (bounded.length > 0) {
+    console.log("Sample bounded FILL-height containers (first 8):");
+    console.log(
+      "  depth | steps | bound ancestor                | ancestor sizing              | FILL node path",
+    );
+    console.log("  " + "-".repeat(120));
+    for (const r of bounded.slice(0, 8)) {
+      console.log(
+        `  ${pad(String(r.depth), 5)} | ${pad(String(r.stepsToBound), 5)} | ${pad(r.boundFoundAt ?? "", 29)} | ${pad(r.boundAncestorSizing ?? "", 28)} | ${r.nodePath}`,
+      );
+    }
+    console.log();
+  }
+
+  if (unbounded.length > 0) {
+    console.log("Unbounded FILL-height containers (would fire):");
+    for (const r of unbounded.slice(0, 20)) {
+      console.log(`  depth=${r.depth}  h=${r.height}  ${r.nodePath}`);
+    }
+    console.log();
+  }
+
+  if (instanceRows.length > 0) {
+    console.log("INSTANCE FIXED-height in Auto Layout parent (first 20):");
+    for (const r of instanceRows.slice(0, 20)) {
+      console.log(
+        `  depth=${r.depth}  h=${r.height}  parent=${r.parentName} (${r.parentLayoutMode})  ${r.nodePath}`,
+      );
+    }
+    console.log();
+  }
+
+  const depthHistogram: Record<number, number> = {};
+  for (const r of bounded) {
+    depthHistogram[r.stepsToBound] = (depthHistogram[r.stepsToBound] ?? 0) + 1;
+  }
+  console.log("Steps-to-bound histogram:");
+  for (const [steps, count] of Object.entries(depthHistogram).sort(
+    (a, b) => Number(a[0]) - Number(b[0]),
+  )) {
+    console.log(`  ${steps} step(s): ${count}`);
+  }
+
+  if (JSON_OUT) {
+    const payload = {
+      fixture: FIXTURE,
+      summary: {
+        fillContainers: fillRows.length,
+        bounded: bounded.length,
+        unbounded: unbounded.length,
+        instanceFixedInAutoLayout: instanceRows.length,
+      },
+      depthHistogram,
+      rows: [...fillRows, ...instanceRows] as Row[],
+    };
+    mkdirSync(dirname(JSON_OUT), { recursive: true });
+    writeFileSync(JSON_OUT, JSON.stringify(payload, null, 2));
+    console.log();
+    console.log(`JSON output: ${JSON_OUT}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Issue #413 is a follow-up to #403 that asks whether the width-axis missing-size-constraint redesign should be mirrored on the height axis. The issue explicitly gates implementation on pre-flight measurement: before committing to (A) extend the rule, (B) sibling rule, or (C) close as won't-fix, ≥30% of sampled height-axis fires must be plausible designer-intent gotchas. This PR delivers the measurement infrastructure (height-axis walker-sanity probe + all-24-fixture analysis runner + gate reporter) and the written decision output, matching the pattern established by .tmp/403-gate/. The actual rule-redesign implementation — whichever of (A)/(B)/(C) the data selects — is scoped to a follow-up issue because the load-bearing decision needs human review of the sampled fires, and bundling it would make the PR un-reviewable without the data in hand.

## Tasks

- Build height-axis walker-sanity probe
- Build 24-fixture analysis runner + gate reporter
- Execute probes, sample 20 fires manually, write gate verdict
- Create follow-up issue body for implementation

## Self-review

Measurement-only PR that delivers exactly what #413's pre-implementation gate requires: a height-axis probe, a 24-fixture runner, an aggregate reporter, and a verdict document. The probe logic correctly mirrors the production rule's INSTANCE-ancestor actionability filter (src/core/rules/structure/index.ts:401), the overlap check is wired through analyzeFile with the correct issue-shape access paths, and the (C) verdict is defensible given the measured 0/8 viewport-intent rate (an order of magnitude below the 30% gate). No production code changes; CLAUDE.md conventions are respected throughout the evidence scripts.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 4

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #413

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))