### PR TITLE
feat(cursor): Cursor skills bundle + init --cursor-skills (#407)

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -21,6 +21,7 @@
 
 **3a. Claude Code Skill (`/canicode-gotchas`)**
 - Location: `.claude/skills/canicode-gotchas/SKILL.md` (copy to any project)
+- **Cursor (#407)**: `pnpm build` fills `skills/cursor/` — `canicode-gotchas` is stripped after `# Collected Gotchas`; `canicode` and `canicode-roundtrip` (+ `helpers.js`) are full copies of the Claude skills. `canicode init --cursor-skills` installs all three into `.cursor/skills/`. Gotcha answers still upsert only to `.claude/skills/canicode-gotchas/SKILL.md`. Roundtrip still requires Figma MCP `use_figma`. MCP: `docs/CUSTOMIZATION.md` (Cursor MCP section).
 - Data source: `gotcha-survey` MCP tool OR `npx canicode gotcha-survey --json` CLI fallback (canicode MCP server is optional)
 - Workflow: calls gotcha-survey → presents questions to user → collects answers → writes `.claude/skills/canicode-gotchas/SKILL.md` in the user's project
 - Output: skill file with design gotcha Q&A pairs (nodeId, ruleId, severity, question, answer)

--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: canicode-gotchas
-description: Gotcha survey workflow plus accumulating per-design answers — one Workflow region on top, numbered sections appended per Figma design
+description: Gotcha survey (Claude Code or Cursor) — Q&A workflow; answers accumulate in .claude/skills/canicode-gotchas/SKILL.md for figma-implement-design
 ---
 
-# CanICode Gotchas -- Design Gotcha Survey & Skill Writer
+# CanICode Gotchas — Design Gotcha Survey
 
-Run a gotcha survey on a Figma design to collect implementation context that Figma cannot encode natively, capture developer/designer answers, and upsert them into this skill file so downstream `figma-implement-design` runs have annotation-ready context. In this model, rules do rule-based best-practice detection, and gotcha is the annotation output from that detection. Some gotchas come from violation rules (what is wrong and how to resolve it); others come from info-collection rules (neutral context Figma cannot represent, like interaction intent/state). The file has two regions: the **Workflow** below (installed by `canicode init`, never overwritten) and the **Collected Gotchas** region at the bottom (one numbered section per design, replaced in place on re-runs).
+Run a gotcha survey on a Figma design to collect implementation context that Figma cannot encode natively, capture developer/designer answers, and upsert them into **`.claude/skills/canicode-gotchas/SKILL.md`** so downstream `figma-implement-design` runs have annotation-ready context. In this model, rules do rule-based best-practice detection, and gotcha is the annotation output from that detection. Some gotchas come from violation rules (what is wrong and how to resolve it); others come from info-collection rules (neutral context Figma cannot represent, like interaction intent/state).
+
+**Install location:** The workflow prose may live under `.claude/skills/canicode-gotchas/SKILL.md` (default `canicode init`) or be copied to `.cursor/skills/canicode-gotchas/SKILL.md` (`canicode init --cursor-skills`). The **authoritative gotcha store** is always **`.claude/skills/canicode-gotchas/SKILL.md`** — the CLI `upsert-gotcha-section` writes there only. In the `.claude` copy, this file has two regions: the **Workflow** below (installed by `canicode init`, never overwritten manually) and the **Collected Gotchas** region at the bottom (one numbered section per design, replaced in place on re-runs).
 
 ## Prerequisites
 
-- **canicode MCP server** (preferred): `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp` — long-form flags only; the short-form `-y -p` collides with `claude mcp add`'s parser (#366). The MCP server reads `FIGMA_TOKEN` from `~/.canicode/config.json` or the host environment, so do **not** pass `-e FIGMA_TOKEN=…` here (#364).
-- **Without canicode MCP** (fallback): the `canicode gotcha-survey --json` CLI produces the same response shape — no MCP installation required.
-- **FIGMA_TOKEN** configured for live Figma URLs
+- **canicode MCP** (recommended): Register the server with your host — **Claude Code:** `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp` — long-form flags only; the short-form `-y -p` collides with `claude mcp add`'s parser (#366); do **not** pass `-e FIGMA_TOKEN=…` here (#364). **Cursor / other hosts:** add `canicode-mcp` to your MCP config — see [Customization guide](https://github.com/let-sunny/canicode/blob/main/docs/CUSTOMIZATION.md#cursor-mcp-canicode) (`~/.cursor/mcp.json` or project `.cursor/mcp.json`). The MCP server reads `FIGMA_TOKEN` from `~/.canicode/config.json` or the environment.
+- **Without canicode MCP** (fallback): `npx canicode gotcha-survey "<input>" --json` — same JSON shape as the MCP tool.
+- **FIGMA_TOKEN** configured for live Figma URLs.
+- **Gotcha destination on disk:** `.claude/skills/canicode-gotchas/SKILL.md` must exist before upsert — run `npx canicode init --token …` (add `--cursor-skills` if you also want the workflow file under `.cursor/skills/`).
 
 ## Workflow
 
@@ -38,12 +41,12 @@ Either channel returns:
 
 If `isReadyForCodeGen` is `true` or `questions` is empty:
 - Tell the user: "This design scored **{designGrade}** and is ready for code generation — no gotchas to resolve."
-- Do NOT write to the skill file.
+- Do NOT write to `.claude/skills/canicode-gotchas/SKILL.md`.
 - Stop here.
 
 ### Step 3: Present questions to the user
 
-The survey response carries a pre-computed `groupedQuestions.groups[].batches[]` shape so the SKILL never has to sort, partition, or maintain a batchable-rule whitelist in prose. The sort key, `_no-source` sentinel, and batchable-rule list all live in `core/gotcha/group-and-batch-questions.ts` with vitest coverage (per ADR-016). Iterate over it:
+The survey response carries a pre-computed `groupedQuestions.groups[].batches[]` shape so this skill never has to sort, partition, or maintain a batchable-rule whitelist in prose. The sort key, `_no-source` sentinel, and batchable-rule list all live in `core/gotcha/group-and-batch-questions.ts` with vitest coverage (per ADR-016). Iterate over it:
 
 For every `batch` in `groupedQuestions.groups.flatMap((g) => g.batches)`:
 
@@ -90,19 +93,19 @@ When applying the batched answer, expand back to per-question records in Step 4 
 
 ### Step 4: Upsert the gotcha section
 
-After collecting all answers, **upsert** this design's section into the `# Collected Gotchas` region at the bottom of this file:
+After collecting all answers, **upsert** this design's section into the `# Collected Gotchas` region at the bottom of:
 
 ```
 .claude/skills/canicode-gotchas/SKILL.md
 ```
 
-This file goes in the **user's project** (current working directory), NOT in the canicode repo. The Workflow region above **must never be modified** — only the `# Collected Gotchas` region below is touched.
+That path is in the **user's project** (current working directory), NOT in the canicode repo. If you are following this workflow from a copy under `.cursor/skills/`, still upsert into **`.claude/skills/...`** only — never write gotcha answers into the `.cursor` copy. The Workflow region in the `.claude` file **must never be modified manually** — only the `# Collected Gotchas` region is touched (via the CLI below).
 
 #### Step 4a: Use the `designKey` from the survey response
 
 `designKey` uniquely identifies the design so re-running on the same URL replaces the existing section in place. The survey response carries it on `survey.designKey` — read it directly. Do **not** parse the input URL in prose.
 
-The `core/contracts/design-key.ts` helper (`computeDesignKey`) handles every shape with vitest coverage so the SKILL stays ADR-016-compliant:
+The `core/contracts/design-key.ts` helper (`computeDesignKey`) handles every shape with vitest coverage so this workflow stays ADR-016-compliant:
 
 - **Figma URL** → `<fileKey>#<nodeId>` with `-` → `:` normalization on the nodeId. Example: `https://figma.com/design/abc123XYZ/My-File?node-id=42-100&t=ref` → `designKey = "abc123XYZ#42:100"`. Trailing query parameters (`?t=...`, `?mode=...`) are dropped.
 - **Figma URL without `node-id`** → just `<fileKey>` (file-level key).
@@ -110,7 +113,7 @@ The `core/contracts/design-key.ts` helper (`computeDesignKey`) handles every sha
 
 #### Step 4b: Upsert via the canicode CLI
 
-File-state detection (4-way: missing / valid / missing-heading / clobbered) and section walking (find existing `## #NNN — ...` by `Design key` substring, otherwise compute the next monotonic zero-padded NNN) are deterministic markdown operations and live in `core/gotcha/upsert-gotcha-section.ts` with vitest coverage — the SKILL never re-implements them in prose (per ADR-016).
+File-state detection (4-way: missing / valid / missing-heading / clobbered) and section walking (find existing `## #NNN — ...` by `Design key` substring, otherwise compute the next monotonic zero-padded NNN) are deterministic markdown operations and live in `core/gotcha/upsert-gotcha-section.ts` with vitest coverage — do not re-implement them in prose (per ADR-016).
 
 Render the per-design section markdown using the **Output Template** below with the literal string `{{SECTION_NUMBER}}` in the header (the CLI substitutes the right NNN for you — preserves it on replace, computes the next monotonic value on append). Then invoke:
 
@@ -186,7 +189,7 @@ This ensures the code generation agent knows the gotcha exists even if no answer
 
 ## Edge Cases
 
-- **No questions returned**: The design is ready for code generation. Inform the user and stop (Step 2). Do not touch the file.
+- **No questions returned**: The design is ready for code generation. Inform the user and stop (Step 2). Do not touch `.claude/skills/canicode-gotchas/SKILL.md`.
 - **Re-run on the same design**: Replace that design's section in place (matched by `Design key`) — preserve the original `#NNN` number. Do NOT append a duplicate.
 - **Re-run on a different design**: Append a new section with the next `#NNN`. Prior designs' sections are untouched.
 - **Workflow region**: Never modified. If you notice the Workflow region has been edited by the user, leave their edits alone — only the `# Collected Gotchas` region is under skill control.

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -10,8 +10,8 @@ Orchestrate the full design-to-code roundtrip: analyze a Figma design for readin
 
 ## Prerequisites
 
-- **Figma MCP server** installed (provides `get_design_context`, `get_screenshot`, `use_figma`, and other Figma tools) — REQUIRED, there is no CLI fallback for `use_figma`
-- **canicode MCP server** (preferred): `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp` — long-form flags only; the short-form `-y -p` collides with `claude mcp add`'s parser (#366). The MCP server reads `FIGMA_TOKEN` from `~/.canicode/config.json` or the host environment, so do **not** pass `-e FIGMA_TOKEN=…` here (#364).
+- **Figma MCP server** installed (provides `get_design_context`, `get_screenshot`, `use_figma`, and other Figma tools) — REQUIRED, there is no CLI fallback for `use_figma`. Register it with your host (e.g. Claude Code: `claude mcp add -s project -t http figma https://mcp.figma.com/mcp`; Cursor: add the Figma MCP entry per host docs / project `.mcp.json`).
+- **canicode MCP** (preferred): **Claude Code:** `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp` — long-form flags only; short `-y -p` collides with `claude mcp add`'s parser (#366); do **not** pass `-e FIGMA_TOKEN=…` here (#364). **Cursor / other hosts:** add `canicode-mcp` to MCP config — see [Customization guide](https://github.com/let-sunny/canicode/blob/main/docs/CUSTOMIZATION.md#cursor-mcp-canicode). The server reads `FIGMA_TOKEN` from `~/.canicode/config.json` or the environment.
 - **Without canicode MCP** (fallback): Steps 1 (analyze) and 3 (gotcha-survey) shell out to `npx canicode <command> --json` — same JSON shape as the MCP tools. Step 4 (apply to Figma) still requires Figma MCP `use_figma`.
 - **FIGMA_TOKEN** configured for live Figma URLs
 - **Figma Full seat + file edit permission** (required for `use_figma` to modify the design)
@@ -20,13 +20,13 @@ Orchestrate the full design-to-code roundtrip: analyze a Figma design for readin
 
 ### Step 0: Verify Figma MCP tools are loaded
 
-Before Step 1, verify that `use_figma` is callable in **this** session — not merely listed in `.mcp.json`. Newly registered MCP servers (e.g. via `claude mcp add -s project -t http figma https://mcp.figma.com/mcp`) require a Claude Code restart to load their tools; reading `.mcp.json` is not a substitute for checking the live tool list you have access to right now.
+Before Step 1, verify that `use_figma` is callable in **this** session — not merely listed in `.mcp.json`. Newly registered MCP servers require a **host restart or MCP reload** so tools appear (e.g. Claude Code: restart after `claude mcp add …`; Cursor: restart Cursor or reload MCP after editing `.cursor/mcp.json`). Reading `.mcp.json` is not a substitute for checking the live tool list you have access to right now.
 
 If `use_figma` is unavailable in the current session, **Do NOT proceed to Step 1**. Steps 1 (analyze) and 3 (gotcha-survey) spend real Figma API calls and 5–15 minutes of human survey time before Step 4 would otherwise discover `use_figma` is missing. Halt immediately and tell the user:
 
-1. Confirm `.mcp.json` registers the Figma MCP entry (e.g. `figma` under `mcpServers`).
-2. Restart Claude Code so the newly registered tools load.
-3. Re-invoke `/canicode-roundtrip <url>`.
+1. Confirm `.mcp.json` (project or user) registers the Figma MCP entry (e.g. `figma` under `mcpServers`).
+2. Restart the IDE / agent host (or reload MCP) so the newly registered tools load.
+3. Re-invoke the roundtrip (Claude Code slash command `/canicode-roundtrip`, or Cursor: @ **canicode-roundtrip** with the Figma URL).
 
 See the Edge Case **No Figma MCP server** below for the one-way fallback when Figma MCP genuinely cannot be installed — the precheck above is for the common "installed but not restarted" case, not a replacement for that fallback.
 
@@ -276,11 +276,11 @@ Branches on `probe`:
 
 The probe is read-only and idempotent; running it before the picker adds one round-trip but saves the user a confusing "I opted in, why did I get annotations?" moment that #342 surfaced live on Simple Design System (Community).
 
-**Shared helpers (bundled)** — the deterministic helpers live in TypeScript at `src/core/roundtrip/*.ts` and are bundled to a single IIFE at `.claude/skills/canicode-roundtrip/helpers.js`. `use_figma` only accepts a self-contained JS string, so the source of truth is TypeScript (with vitest coverage) and the bundle is the delivery artifact.
+**Shared helpers (bundled)** — the deterministic helpers live in TypeScript at `src/core/roundtrip/*.ts` and are bundled to a single IIFE shipped next to this skill as `helpers.js`. `use_figma` only accepts a self-contained JS string, so the source of truth is TypeScript (with vitest coverage) and the bundle is the delivery artifact.
 
 **Usage in a roundtrip session:**
 
-1. Read `.claude/skills/canicode-roundtrip/helpers.js` once at the start of Step 4.
+1. Read `helpers.js` from the same directory as this skill once at the start of Step 4 — typically `.claude/skills/canicode-roundtrip/helpers.js` (Claude Code / default `canicode init`) or `.cursor/skills/canicode-roundtrip/helpers.js` (Cursor with `canicode init --cursor-skills`).
 2. Prepend its contents verbatim at the top of every `use_figma` batch body — it registers a single global `CanICodeRoundtrip`.
 3. Reference exposed globals as `CanICodeRoundtrip.*`:
    - `stripAnnotations(annotations)` — normalizes the D1 label/labelMarkdown mutex on readback.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ npx canicode init --token figd_xxxxxxxxxxxxx
 
 > **Prerequisite:** the roundtrip skill calls the Figma MCP server to read and write the design. Install it once with `claude mcp add -s project -t http figma https://mcp.figma.com/mcp` — see the **MCP Server** install section below.
 
+**CanICode in Cursor (no Claude Code required):**
+
+1. Add **canicode** and **Figma** MCPs — [Cursor MCP](docs/CUSTOMIZATION.md#cursor-mcp-canicode) for `npx` → `canicode-mcp`; Figma MCP is required for **`use_figma`** if you run **roundtrip** (design writes), not for analyze-only.
+2. `npx canicode init --token figd_xxxxxxxxxxxxx --cursor-skills` — installs the same three skills as Claude under `.cursor/skills/` (`canicode`, `canicode-gotchas`, `canicode-roundtrip` + `helpers.js`) plus the shared `.claude/skills/canicode-gotchas/SKILL.md` answer file when needed.
+3. In Agent chat, @-mention **canicode-gotchas** (survey) or **canicode-roundtrip** (full roundtrip) and pass a Figma URL — same tool names and JSON as Claude Code (`gotcha-survey`, `analyze`, etc.).
+
 **If you only want analysis (no writes back to Figma):**
 
 ```bash
@@ -114,7 +120,7 @@ Each row below is a **complete** install. Don't run more than one — they cover
 | If you use… | Install |
 |-------------|---------|
 | **Claude Code** (recommended for the roundtrip workflow) | `npx canicode init --token figd_xxxxxxxxxxxxx` — saves the token AND drops `/canicode`, `/canicode-gotchas`, `/canicode-roundtrip` skills into `./.claude/skills/`. The skills already know how to call canicode via `npx canicode …`, no MCP install needed. |
-| **Cursor / Claude Desktop / other MCP host** | `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp` — registers the MCP server. |
+| **Cursor / Claude Desktop / other MCP host** | Add canicode to the host’s MCP config — see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md#cursor-mcp-canicode). Example (Cursor project file): `npx` + `canicode-mcp` via `--package=canicode`. |
 | **Just the CLI** (CI, scripts) | Nothing. `npx canicode analyze "<figma-url>"` works directly. Run `canicode init --token …` once if you want the token persisted to `~/.canicode/config.json`. |
 
 > **Get your token:** Figma → Settings → Security → Personal access tokens → Generate new token
@@ -153,7 +159,7 @@ canicode's rule engine analyzes the design data — the AI assistant just orches
 
 If you genuinely need a per-server token without using `canicode init`, export it on the calling shell instead: `export FIGMA_TOKEN=figd_xxxxxxxxxxxxx`.
 
-For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md).
+For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md) — especially [Cursor MCP (canicode)](docs/CUSTOMIZATION.md#cursor-mcp-canicode) and the **Manual test checklist (#407)** for verifying `gotcha-survey` end-to-end.
 
 </details>
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -176,6 +176,42 @@ Override score, severity, or enable/disable individual rules:
 
 ---
 
+## Cursor MCP (canicode)
+
+Configure the canicode MCP server so Cursor exposes `analyze`, `gotcha-survey`, and other tools.
+
+### Project config (`.cursor/mcp.json`)
+
+Create or merge into `.cursor/mcp.json` in your repository root:
+
+```json
+{
+  "mcpServers": {
+    "canicode": {
+      "command": "npx",
+      "args": ["-y", "--package=canicode", "canicode-mcp"]
+    }
+  }
+}
+```
+
+Use long-form `--package` (short `-p` can confuse some parsers). Set your Figma token once with `npx canicode init --token figd_…` — the MCP server reads `~/.canicode/config.json`; you do not need `FIGMA_TOKEN` in the MCP block unless your team prefers env injection.
+
+### Gotcha survey in Cursor
+
+1. Add the MCP config above and restart Cursor (or reload MCP).
+2. Run `npx canicode init --token … --cursor-skills` to install **canicode**, **canicode-gotchas**, and **canicode-roundtrip** (with `helpers.js`) under `.cursor/skills/`, and ensure the shared answer file exists at `.claude/skills/canicode-gotchas/SKILL.md` when needed (or run full `canicode init` and add `--cursor-skills`). Authoring is single-source under `.claude/skills/` in the repo; the npm build writes `skills/cursor/` (gotchas strip `# Collected Gotchas`; other skills are full copies).
+3. In chat, @-mention **canicode**, **canicode-gotchas**, or **canicode-roundtrip** as needed. For roundtrip, the Figma MCP must expose **`use_figma`** in the session — same requirement as Claude Code.
+
+### Manual test checklist (#407)
+
+- [ ] MCP: Cursor shows `canicode` connected and the tools list includes `gotcha-survey` (and `analyze` if testing roundtrip Step 1).
+- [ ] Figma MCP: `use_figma` is available when testing **roundtrip** (install + restart host if tools are missing).
+- [ ] Calling `gotcha-survey` with a local fixture path returns JSON with `designGrade` and `questions` / `isReadyForCodeGen`.
+- [ ] After the Q&A loop, `npx canicode upsert-gotcha-section …` succeeds and updates `.claude/skills/canicode-gotchas/SKILL.md`.
+- [ ] Optional: @ **canicode-roundtrip** — Step 4 reads `helpers.js` from `.cursor/skills/canicode-roundtrip/helpers.js` after `canicode init --cursor-skills`.
+
+---
 
 ## Telemetry
 

--- a/scripts/bundle-skills.sh
+++ b/scripts/bundle-skills.sh
@@ -47,4 +47,26 @@ for f in "${REQUIRED[@]}"; do
   fi
 done
 
+# Cursor skills (issue #407) — single source: gotchas stripped; canicode + roundtrip are full copies (same SKILL.md + helpers.js as Claude).
+node "$ROOT/scripts/strip-cursor-gotcha-skill.mjs"
+echo "  wrote cursor/canicode-gotchas/SKILL.md (stripped from canonical gotchas skill)"
+
+mkdir -p "$DEST/cursor"
+cp -R "$DEST/canicode" "$DEST/cursor/canicode"
+cp -R "$DEST/canicode-roundtrip" "$DEST/cursor/canicode-roundtrip"
+echo "  copied cursor/canicode and cursor/canicode-roundtrip"
+
+CURSOR_REQUIRED=(
+  "$DEST/cursor/canicode-gotchas/SKILL.md"
+  "$DEST/cursor/canicode/SKILL.md"
+  "$DEST/cursor/canicode-roundtrip/SKILL.md"
+  "$DEST/cursor/canicode-roundtrip/helpers.js"
+)
+for f in "${CURSOR_REQUIRED[@]}"; do
+  if [ ! -f "$f" ]; then
+    echo "ERROR: expected Cursor bundle file missing: $f"
+    exit 1
+  fi
+done
+
 echo "=== Skills bundled into $DEST ==="

--- a/scripts/strip-cursor-gotcha-skill.mjs
+++ b/scripts/strip-cursor-gotcha-skill.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Emit `skills/cursor/canicode-gotchas/SKILL.md` from the canonical gotchas skill.
+ * Cursor installs this copy under `.cursor/skills/`; answers still upsert only to
+ * `.claude/skills/canicode-gotchas/SKILL.md`, so the Collected Gotchas region is
+ * omitted here to avoid a stale duplicate (issue #407, single-source follow-up).
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const canonical = join(root, ".claude/skills/canicode-gotchas/SKILL.md");
+const outPath = join(root, "skills/cursor/canicode-gotchas/SKILL.md");
+
+const raw = readFileSync(canonical, "utf8");
+const marker = "\n# Collected Gotchas";
+const idx = raw.indexOf(marker);
+const body = idx >= 0 ? `${raw.slice(0, idx).trimEnd()}\n` : `${raw.trimEnd()}\n`;
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, body, "utf8");

--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -51,6 +51,17 @@ describe("figmaMcpRegistered", () => {
     );
     expect(figmaMcpRegistered(tempRoot)).toBe(false);
   });
+
+  it("returns true when only .cursor/mcp.json registers figma (Cursor project layout)", () => {
+    const cursorDir = join(tempRoot, ".cursor");
+    mkdirSync(cursorDir, { recursive: true });
+    writeFileSync(
+      join(cursorDir, "mcp.json"),
+      JSON.stringify({ mcpServers: { figma: { url: "https://mcp.figma.com/mcp" } } }),
+      "utf-8",
+    );
+    expect(figmaMcpRegistered(tempRoot)).toBe(true);
+  });
 });
 
 describe("formatNextSteps", () => {
@@ -81,5 +92,26 @@ describe("formatNextSteps", () => {
     const out = formatNextSteps({ figmaMcpPresent: true, skillsInstalled: false });
     expect(out).toContain(`Next: canicode analyze`);
     expect(out).not.toContain("Restart Claude Code");
+  });
+
+  it("when cursorSkillsInstalled, omits Claude slash commands and mentions @ canicode-roundtrip", () => {
+    const out = formatNextSteps({
+      figmaMcpPresent: true,
+      skillsInstalled: true,
+      cursorSkillsInstalled: true,
+    });
+    expect(out).toContain("@ canicode-roundtrip");
+    expect(out).not.toContain("/canicode-roundtrip");
+    expect(out).not.toContain("Claude Code");
+  });
+
+  it("when cursorSkillsInstalled and Figma MCP missing, points at .cursor/mcp.json", () => {
+    const out = formatNextSteps({
+      figmaMcpPresent: false,
+      skillsInstalled: true,
+      cursorSkillsInstalled: true,
+    });
+    expect(out).toContain(".cursor/mcp.json");
+    expect(out).not.toContain("claude mcp add");
   });
 });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -7,12 +7,16 @@ import { z } from "zod";
 import {
   initAiready, getConfigPath, getReportsDir,
 } from "../../core/engine/config-store.js";
-import { installSkills } from "../skill-installer.js";
+import {
+  installSkills,
+  installClaudeGotchasSkillOnly,
+  installCursorBundledSkills,
+} from "../skill-installer.js";
 import { trackEvent, EVENTS } from "../../core/monitoring/index.js";
 
-export function figmaMcpRegistered(cwd: string = process.cwd()): boolean {
+function figmaEntryInMcpFile(filePath: string): boolean {
   try {
-    const raw = readFileSync(join(cwd, ".mcp.json"), "utf-8");
+    const raw = readFileSync(filePath, "utf-8");
     const parsed = JSON.parse(raw) as { mcpServers?: Record<string, unknown> };
     const figma = parsed?.mcpServers?.["figma"];
     return typeof figma === "object" && figma !== null;
@@ -21,14 +25,33 @@ export function figmaMcpRegistered(cwd: string = process.cwd()): boolean {
   }
 }
 
+/** True if project `.mcp.json` or Cursor's `.cursor/mcp.json` registers a Figma MCP server. */
+export function figmaMcpRegistered(cwd: string = process.cwd()): boolean {
+  return figmaEntryInMcpFile(join(cwd, ".mcp.json"))
+    || figmaEntryInMcpFile(join(cwd, ".cursor", "mcp.json"));
+}
+
 export function formatNextSteps(opts: {
   figmaMcpPresent: boolean;
   skillsInstalled: boolean;
+  /** User ran `canicode init --cursor-skills` — next steps reference Cursor + @ skills, not slash commands. */
+  cursorSkillsInstalled?: boolean;
 }): string {
   if (!opts.skillsInstalled) {
     return `\n  Next: canicode analyze "https://www.figma.com/design/..."`;
   }
+
+  const cursor = opts.cursorSkillsInstalled === true;
+
   if (opts.figmaMcpPresent) {
+    if (cursor) {
+      return [
+        "",
+        "  Next:",
+        "    1. Restart Cursor or reload MCP (so skills + MCP tools load in a fresh session)",
+        "    2. In Agent chat, @ canicode-roundtrip with your Figma URL (or @ canicode-gotchas for survey-only)",
+      ].join("\n");
+    }
     return [
       "",
       "  Next:",
@@ -36,6 +59,17 @@ export function formatNextSteps(opts: {
       "    2. Run /canicode-roundtrip <figma-url>",
     ].join("\n");
   }
+
+  if (cursor) {
+    return [
+      "",
+      "  Next:",
+      "    1. Add Figma MCP to .cursor/mcp.json (see https://github.com/let-sunny/canicode/blob/main/docs/CUSTOMIZATION.md#cursor-mcp-canicode and Figma MCP docs)",
+      "    2. Restart Cursor so Figma tools (e.g. use_figma) load",
+      "    3. @ canicode-roundtrip with your Figma URL for full roundtrip",
+    ].join("\n");
+  }
+
   return [
     "",
     "  Next:",
@@ -51,6 +85,8 @@ const InitOptionsSchema = z.object({
   global: z.boolean().optional(),
   // cac maps `--no-skills` to `skills: false` (mirrors `--no-telemetry`).
   skills: z.boolean().optional(),
+  /** Install `skills/cursor/*` into `.cursor/skills/` (canicode, gotchas, roundtrip — issue #407). */
+  cursorSkills: z.boolean().optional(),
   force: z.boolean().optional(),
 });
 
@@ -60,6 +96,7 @@ export function registerInit(cli: CAC): void {
     .option("--token <token>", "Save Figma API token and install Claude Code skills to .claude/skills/")
     .option("--global", "Install skills to ~/.claude/skills/ instead of ./.claude/skills/")
     .option("--no-skills", "Skip skill installation (token only)")
+    .option("--cursor-skills", "Also install Cursor copies of canicode / canicode-gotchas / canicode-roundtrip under .cursor/skills/")
     .option("--force", "Overwrite existing skill files without prompting (also for non-TTY/CI)")
     .action(async (rawOptions: Record<string, unknown>) => {
       try {
@@ -104,10 +141,54 @@ export function registerInit(cli: CAC): void {
               process.exitCode = 1;
               skillStepOk = false;
             }
+          } else if (options.cursorSkills) {
+            try {
+              const summary = await installClaudeGotchasSkillOnly({
+                force: options.force ?? false,
+              });
+              console.log(`\n  Gotchas store (Claude Code skills path) installed to: ${summary.targetDir}/`);
+              console.log(`    installed:   ${summary.installed.length}`);
+              console.log(`    overwritten: ${summary.overwritten.length}`);
+              console.log(`    skipped:     ${summary.skipped.length}`);
+              skillSummary = {
+                installed: summary.installed.length,
+                overwritten: summary.overwritten.length,
+                skipped: summary.skipped.length,
+              };
+            } catch (skillError) {
+              console.error(
+                `\n  Gotchas skill install failed: ${skillError instanceof Error ? skillError.message : String(skillError)}`,
+              );
+              process.exitCode = 1;
+              skillStepOk = false;
+            }
+          }
+
+          if (options.cursorSkills && skillStepOk) {
+            try {
+              const cSummary = await installCursorBundledSkills({
+                force: options.force ?? false,
+              });
+              console.log(`\n  Cursor skills installed to: ${cSummary.targetDir}/`);
+              console.log(`    installed:   ${cSummary.installed.length}`);
+              console.log(`    overwritten: ${cSummary.overwritten.length}`);
+              console.log(`    skipped:     ${cSummary.skipped.length}`);
+              if (cSummary.skipped.length > 0) {
+                console.log(`  (Re-run with --force to overwrite skipped files.)`);
+              }
+              console.log(`  Open a new chat and @-mention canicode, canicode-gotchas, or canicode-roundtrip if skills do not appear immediately.`);
+            } catch (cursorError) {
+              console.error(
+                `\n  Cursor skill install failed: ${cursorError instanceof Error ? cursorError.message : String(cursorError)}`,
+              );
+              process.exitCode = 1;
+              skillStepOk = false;
+            }
           }
 
           trackEvent(EVENTS.CLI_INIT, {
             skillsRequested: options.skills !== false,
+            cursorSkillsRequested: options.cursorSkills === true,
             skillStepOk,
             target: options.global ? "global" : "project",
             force: options.force ?? false,
@@ -119,6 +200,7 @@ export function registerInit(cli: CAC): void {
               formatNextSteps({
                 figmaMcpPresent: figmaMcpRegistered(),
                 skillsInstalled: options.skills !== false,
+                cursorSkillsInstalled: options.cursorSkills === true,
               }),
             );
           }
@@ -134,6 +216,7 @@ export function registerInit(cli: CAC): void {
         console.log(`  (canicode, canicode-gotchas, canicode-roundtrip).`);
         console.log(`  --global       Install to ~/.claude/skills/ instead`);
         console.log(`  --no-skills    Skip skill install (token only)`);
+        console.log(`  --cursor-skills Also install Cursor copies of all three skills (.cursor/skills/); with --no-skills, still installs .claude gotcha store + Cursor bundle`);
         console.log(`  --force        Overwrite existing skill files without prompting\n`);
         console.log(`After setup:`);
         console.log(`  canicode analyze "https://www.figma.com/design/..."`);

--- a/src/cli/skill-installer.test.ts
+++ b/src/cli/skill-installer.test.ts
@@ -6,7 +6,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { vi } from "vitest";
 
-import { installSkills } from "./skill-installer.js";
+import {
+  installSkills,
+  installClaudeGotchasSkillOnly,
+  installCursorBundledSkills,
+} from "./skill-installer.js";
 
 vi.mock("node:readline/promises", () => ({
   createInterface: vi.fn(),
@@ -242,5 +246,51 @@ describe("installSkills", () => {
     for (const p of staleFiles) {
       expect(readFileSync(p, "utf-8")).toBe("# stale\n");
     }
+  });
+});
+
+describe("installClaudeGotchasSkillOnly", () => {
+  it("copies only canicode-gotchas into ./.claude/skills/", async () => {
+    const summary = await installClaudeGotchasSkillOnly({
+      force: false,
+      cwd,
+      sourceDir,
+    });
+
+    expect(summary.targetDir).toBe(join(cwd, ".claude", "skills"));
+    expect(summary.installed).toEqual([join("canicode-gotchas", "SKILL.md")]);
+    expect(existsSync(join(cwd, ".claude", "skills", "canicode", "SKILL.md"))).toBe(false);
+    expect(readFileSync(join(summary.targetDir, "canicode-gotchas", "SKILL.md"), "utf-8"))
+      .toBe("# canicode-gotchas\nfresh\n");
+  });
+});
+
+describe("installCursorBundledSkills", () => {
+  it("copies every directory under skills/cursor into the target skills root", async () => {
+    const cursorBundle = join(tempRoot, "cursor-bundle");
+    for (const name of ["canicode", "canicode-gotchas"]) {
+      const dir = join(cursorBundle, name);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "SKILL.md"), `# ${name}\n`, "utf-8");
+    }
+    mkdirSync(join(cursorBundle, "canicode-roundtrip"), { recursive: true });
+    writeFileSync(join(cursorBundle, "canicode-roundtrip", "helpers.js"), "// h\n", "utf-8");
+    writeFileSync(join(cursorBundle, "canicode-roundtrip", "SKILL.md"), "# rt\n", "utf-8");
+
+    const targetSkillsRoot = join(cwd, "cursor-skill-target");
+    const summary = await installCursorBundledSkills({
+      force: false,
+      cwd,
+      sourceRoot: cursorBundle,
+      targetSkillsRoot,
+    });
+
+    expect(summary.targetDir).toBe(targetSkillsRoot);
+    expect(summary.installed.sort()).toEqual([
+      join("canicode", "SKILL.md"),
+      join("canicode-gotchas", "SKILL.md"),
+      join("canicode-roundtrip", "SKILL.md"),
+      join("canicode-roundtrip", "helpers.js"),
+    ].sort());
   });
 });

--- a/src/cli/skill-installer.ts
+++ b/src/cli/skill-installer.ts
@@ -35,6 +35,138 @@ function defaultSourceDir(): string {
   return fileURLToPath(new URL("../../skills/", import.meta.url));
 }
 
+/** Bundled Cursor skills under `skills/cursor/<name>/` (see `scripts/bundle-skills.sh`). */
+function defaultCursorBundleRoot(): string {
+  return fileURLToPath(new URL("../../skills/cursor", import.meta.url));
+}
+
+type Action = "install" | "force-overwrite" | "needs-decision";
+interface CopyOp {
+  src: string;
+  dest: string;
+  label: string;
+  action: Action;
+}
+
+async function copySkillTree(
+  skillName: string,
+  srcSkillDir: string,
+  destSkillDir: string,
+  force: boolean,
+): Promise<{ installed: string[]; overwritten: string[]; skipped: string[] }> {
+  if (!existsSync(srcSkillDir)) {
+    throw new Error(`Bundled skill directory missing: ${srcSkillDir}`);
+  }
+
+  mkdirSync(destSkillDir, { recursive: true });
+
+  const ops: CopyOp[] = [];
+  const files = listFilesRecursive(srcSkillDir);
+  for (const relPath of files) {
+    const src = join(srcSkillDir, relPath);
+    const dest = join(destSkillDir, relPath);
+    mkdirSync(dirname(dest), { recursive: true });
+
+    const label = join(skillName, relPath);
+    let action: Action;
+    if (!existsSync(dest)) {
+      action = "install";
+    } else if (force) {
+      action = "force-overwrite";
+    } else {
+      action = "needs-decision";
+    }
+    ops.push({ src, dest, label, action });
+  }
+
+  const candidates = ops.filter(op => op.action === "needs-decision");
+  const decisions = candidates.length > 0
+    ? await promptOverwriteBatch(candidates.map(op => ({ label: op.label, dest: op.dest })))
+    : new Map<string, "overwrite" | "skip">();
+
+  const installed: string[] = [];
+  const overwritten: string[] = [];
+  const skipped: string[] = [];
+
+  for (const op of ops) {
+    if (op.action === "install") {
+      copyFileSync(op.src, op.dest);
+      installed.push(op.label);
+    } else if (op.action === "force-overwrite") {
+      copyFileSync(op.src, op.dest);
+      overwritten.push(op.label);
+    } else {
+      const decision = decisions.get(op.label) ?? "skip";
+      if (decision === "overwrite") {
+        copyFileSync(op.src, op.dest);
+        overwritten.push(op.label);
+      } else {
+        skipped.push(op.label);
+      }
+    }
+  }
+
+  return { installed, overwritten, skipped };
+}
+
+/**
+ * Copy several skill directories with a single overwrite prompt batch (same UX as `installSkills`).
+ */
+async function copyMultipleSkillTrees(
+  entries: Array<{ skillName: string; srcSkillDir: string; destSkillDir: string }>,
+  force: boolean,
+): Promise<{ installed: string[]; overwritten: string[]; skipped: string[] }> {
+  const ops: CopyOp[] = [];
+  for (const { skillName, srcSkillDir, destSkillDir } of entries) {
+    mkdirSync(destSkillDir, { recursive: true });
+    const files = listFilesRecursive(srcSkillDir);
+    for (const relPath of files) {
+      const src = join(srcSkillDir, relPath);
+      const dest = join(destSkillDir, relPath);
+      mkdirSync(dirname(dest), { recursive: true });
+      const label = join(skillName, relPath);
+      let action: Action;
+      if (!existsSync(dest)) {
+        action = "install";
+      } else if (force) {
+        action = "force-overwrite";
+      } else {
+        action = "needs-decision";
+      }
+      ops.push({ src, dest, label, action });
+    }
+  }
+
+  const candidates = ops.filter(op => op.action === "needs-decision");
+  const decisions = candidates.length > 0
+    ? await promptOverwriteBatch(candidates.map(op => ({ label: op.label, dest: op.dest })))
+    : new Map<string, "overwrite" | "skip">();
+
+  const installed: string[] = [];
+  const overwritten: string[] = [];
+  const skipped: string[] = [];
+
+  for (const op of ops) {
+    if (op.action === "install") {
+      copyFileSync(op.src, op.dest);
+      installed.push(op.label);
+    } else if (op.action === "force-overwrite") {
+      copyFileSync(op.src, op.dest);
+      overwritten.push(op.label);
+    } else {
+      const decision = decisions.get(op.label) ?? "skip";
+      if (decision === "overwrite") {
+        copyFileSync(op.src, op.dest);
+        overwritten.push(op.label);
+      } else {
+        skipped.push(op.label);
+      }
+    }
+  }
+
+  return { installed, overwritten, skipped };
+}
+
 export async function installSkills(rawOptions: InstallSkillsOptions): Promise<InstallSummary> {
   const options = InstallSkillsOptionsSchema.parse(rawOptions);
   const sourceDir = options.sourceDir ?? defaultSourceDir();
@@ -61,14 +193,7 @@ export async function installSkills(rawOptions: InstallSkillsOptions): Promise<I
     targetDir,
   };
 
-  type Action = "install" | "force-overwrite" | "needs-decision";
-  interface Op {
-    src: string;
-    dest: string;
-    label: string;
-    action: Action;
-  }
-  const ops: Op[] = [];
+  const ops: CopyOp[] = [];
 
   for (const skillName of SKILL_NAMES) {
     const srcSkillDir = join(sourceDir, skillName);
@@ -122,6 +247,103 @@ export async function installSkills(rawOptions: InstallSkillsOptions): Promise<I
   }
 
   return summary;
+}
+
+const InstallClaudeGotchasOnlySchema = z.object({
+  force: z.boolean(),
+  cwd: z.string().optional(),
+  sourceDir: z.string().optional(),
+});
+
+/**
+ * Install only `canicode-gotchas` into `.claude/skills/` (shared gotcha store for upsert-gotcha-section).
+ * Used when `--no-skills --cursor-skills` so Cursor users still get the on-disk SKILL.md target.
+ */
+export async function installClaudeGotchasSkillOnly(
+  rawOptions: z.input<typeof InstallClaudeGotchasOnlySchema>,
+): Promise<InstallSummary> {
+  const options = InstallClaudeGotchasOnlySchema.parse(rawOptions);
+  const sourceDir = options.sourceDir ?? defaultSourceDir();
+  const skillName = "canicode-gotchas";
+  const srcSkillDir = join(sourceDir, skillName);
+  const cwd = options.cwd ?? process.cwd();
+  const targetDir = join(cwd, ".claude", "skills");
+  const destSkillDir = join(targetDir, skillName);
+
+  if (!existsSync(sourceDir)) {
+    throw new Error(
+      `Bundled skills directory not found: ${sourceDir}\n` +
+      `If you are developing canicode, run 'pnpm build' first.\n` +
+      `If you installed canicode from npm, please file a bug report — the tarball is missing skills/.`,
+    );
+  }
+
+  mkdirSync(targetDir, { recursive: true });
+  const part = await copySkillTree(skillName, srcSkillDir, destSkillDir, options.force);
+
+  return {
+    installed: part.installed,
+    overwritten: part.overwritten,
+    skipped: part.skipped,
+    targetDir,
+  };
+}
+
+const InstallCursorBundledSchema = z.object({
+  force: z.boolean(),
+  cwd: z.string().optional(),
+  /** Defaults to bundled `skills/cursor/` (build output). */
+  sourceRoot: z.string().optional(),
+  /**
+   * Parent of per-skill dirs (defaults to `<cwd>/.cursor/skills`).
+   * Tests may use a non-`.cursor` path when the runner blocks hidden directories.
+   */
+  targetSkillsRoot: z.string().optional(),
+});
+
+/**
+ * Install all skills from `skills/cursor/` into `.cursor/skills/` — canicode, canicode-gotchas (stripped), canicode-roundtrip (+ helpers.js). Issue #407.
+ */
+export async function installCursorBundledSkills(
+  rawOptions: z.input<typeof InstallCursorBundledSchema>,
+): Promise<InstallSummary> {
+  const options = InstallCursorBundledSchema.parse(rawOptions);
+  const sourceRoot = options.sourceRoot ?? defaultCursorBundleRoot();
+  const cwd = options.cwd ?? process.cwd();
+  const targetDir = options.targetSkillsRoot ?? join(cwd, ".cursor", "skills");
+
+  if (!existsSync(sourceRoot)) {
+    throw new Error(
+      `Bundled Cursor skills directory not found: ${sourceRoot}\n` +
+      `If you are developing canicode, run 'pnpm build' first (bundle populates skills/cursor/).\n` +
+      `If you installed canicode from npm, please file a bug report — the tarball is missing skills/cursor/.`,
+    );
+  }
+
+  mkdirSync(targetDir, { recursive: true });
+
+  const skillNames = readdirSync(sourceRoot)
+    .filter((name) => statSync(join(sourceRoot, name)).isDirectory())
+    .sort();
+
+  if (skillNames.length === 0) {
+    throw new Error(`No skill directories under: ${sourceRoot}`);
+  }
+
+  const entries = skillNames.map((skillName) => ({
+    skillName,
+    srcSkillDir: join(sourceRoot, skillName),
+    destSkillDir: join(targetDir, skillName),
+  }));
+
+  const part = await copyMultipleSkillTrees(entries, options.force);
+
+  return {
+    installed: part.installed,
+    overwritten: part.overwritten,
+    skipped: part.skipped,
+    targetDir,
+  };
 }
 
 function listFilesRecursive(dir: string): string[] {

--- a/src/mcp/mcp-tools.contract.test.ts
+++ b/src/mcp/mcp-tools.contract.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * MCP tool names are part of the public contract for MCP hosts (Cursor, Claude Desktop, etc.).
+ * Renaming a tool is a breaking change for stored configs and agent skills — bump major or keep aliases.
+ */
+describe("MCP tool registry contract", () => {
+  it("registers gotcha-survey for Cursor and other MCP clients (issue #407)", () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const serverSrc = readFileSync(join(here, "server.ts"), "utf-8");
+    expect(serverSrc).toContain('  "gotcha-survey",');
+  });
+});


### PR DESCRIPTION
## Summary

Implements [issue #407](https://github.com/let-sunny/canicode/issues/407): Cursor-compatible gotcha + roundtrip workflow without maintaining a second hand-authored SKILL copy.

### What changed

- **Single source**: Author only `.claude/skills/*`. `pnpm build` fills `skills/cursor/` — `canicode-gotchas` strips `# Collected Gotchas` and below; `canicode` and `canicode-roundtrip` (+ `helpers.js`) are full copies.
- **CLI**: `canicode init --token … --cursor-skills` installs the bundled tree into `.cursor/skills/`. With `--no-skills --cursor-skills`, still installs the `.claude` gotcha store plus the Cursor bundle.
- **Skills**: Host-neutral prerequisites and paths in `canicode-gotchas` / `canicode-roundtrip` SKILL.md (Cursor vs Claude Code, `helpers.js` location).
- **Init UX**: `figmaMcpRegistered()` also reads `.cursor/mcp.json`. `formatNextSteps` uses Cursor-oriented hints when `--cursor-skills` was passed.
- **Docs**: `README.md`, `docs/CUSTOMIZATION.md` (Cursor MCP + manual checklist), `.claude/docs/ARCHITECTURE.md`.
- **Tests**: `installCursorBundledSkills`, init/Figma detection, `gotcha-survey` MCP contract.

### How to verify locally

```bash
pnpm lint && pnpm build && pnpm test:run && pnpm check:skill-determinism
npm pack --dry-run
```

### Checklist

- [ ] Reviewer: skills wording stays ADR-016 clean (determinism script passes)
- [ ] Optional: smoke Cursor MCP after release with published tarball


Made with [Cursor](https://cursor.com)