### PR TITLE
chore(hooks): Stop-hook reminder for rule/scoring wiki updates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,10 @@
           {
             "type": "command",
             "command": "[ \"$DEVELOP_SUBAGENT\" = \"1\" ] && exit 0; OUT=$({ pnpm lint && pnpm build; } 2>&1); [ $? -eq 0 ] || { echo '[stop-hook] pnpm lint/build FAILED'; echo \"$OUT\"; exit 1; }"
+          },
+          {
+            "type": "command",
+            "command": "[ \"$DEVELOP_SUBAGENT\" = \"1\" ] && exit 0; CHANGES=$({ git diff --name-only HEAD~1 HEAD; git diff --name-only; git diff --cached --name-only; } 2>/dev/null | sort -u); if echo \"$CHANGES\" | grep -qE '^src/core/(rules/|engine/scoring)'; then printf '%s\\n' '{\"systemMessage\": \"[rule-docs reminder] Rule/scoring files changed. Rule-Reference wiki auto-syncs via sync-rule-docs PostToolUse hook. Check Scoring-Model wiki page (manual) and ADR if scoring philosophy changed.\"}'; fi; exit 0"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add a second Stop hook that detects changes to `src/core/rules/**` or `src/core/engine/scoring**` (working tree + staged + last commit) and emits a `systemMessage` reminder to update the Scoring-Model wiki page (manual) and ADR if scoring philosophy changed.
- Rule-Reference wiki is already auto-synced via the existing PostToolUse `sync-rule-docs` hook — this reminder only covers the manual channels.
- Skips in DEVELOP_SUBAGENT context to avoid pipeline noise.

## Test plan
- [x] Pipe-test negative case (no rule changes) → silent
- [x] Pipe-test positive case (synthetic `src/core/rules/rule-config.ts` change) → emits systemMessage JSON
- [x] `jq -e` validates hook schema
- [ ] Live-fire: next session, edit a rule file and stop — confirm reminder appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)