### PR TITLE
chore: release v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.10.5",
+  "version": "0.11.0",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
   "type": "module",


### PR DESCRIPTION
## Summary
Bump to **0.11.0** (minor). Rule behavior + CLI surface changes since 0.10.5 — not patch.

### Highlights
- feat(rules): info-collection rule subtype (#410)
- feat(analysis): detect analysis scope (page vs component) (#411)
- feat(rules): missing-size-constraint scope-aware info-collection redesign (#403 / #412)
- feat(contracts): separate rule-score and gotcha-annotation channels (#409)
- feat(cursor): bundle skills + \`canicode init --cursor-skills\` (#407 / #416)

### Release steps (after merge)
1. Merge this PR to main
2. \`git tag v0.11.0 && git push origin v0.11.0\` on the merged commit
3. CI publishes to npm on tag push

## Test plan
- [ ] \`pnpm lint && pnpm test:run && pnpm build\` locally
- [ ] Pre-launch smoke checklist (\`docs/PRE-LAUNCH-CHECKLIST.md\`) — spot-check CLI + MCP + init --cursor-skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)