### PR TITLE
feat: fix(roundtrip): helpers.js walk() crashes on TEXT/VECTOR nodes — children getter throws

### DIFF
--- a/.claude/skills/canicode-roundtrip/helpers.js
+++ b/.claude/skills/canicode-roundtrip/helpers.js
@@ -360,17 +360,22 @@ ${footer}`;
     walk(root, canicodeCategoryIds, out);
     return out;
   }
+  function safeChildren(node) {
+    try {
+      const c = node.children;
+      return Array.isArray(c) ? c : [];
+    } catch {
+      return [];
+    }
+  }
   function walk(node, canicodeCategoryIds, out) {
     try {
       const local = extractAcknowledgmentsFromNode(node, canicodeCategoryIds);
       for (const a of local) out.push(a);
     } catch {
     }
-    const children = node.children;
-    if (Array.isArray(children)) {
-      for (const child of children) {
-        if (child && typeof child === "object") walk(child, canicodeCategoryIds, out);
-      }
+    for (const child of safeChildren(node)) {
+      if (child && typeof child === "object") walk(child, canicodeCategoryIds, out);
     }
   }
 

--- a/src/core/roundtrip/read-acknowledgments.test.ts
+++ b/src/core/roundtrip/read-acknowledgments.test.ts
@@ -187,6 +187,27 @@ describe("readCanicodeAcknowledgments", () => {
     );
   });
 
+  it("skips children of nodes whose `children` getter throws (TEXT/VECTOR leaves, #421)", async () => {
+    const throwingChild = makeNode("4:4", []);
+    Object.defineProperty(throwingChild, "children", {
+      get: () => {
+        throw new Error("cannot access children of TEXT node");
+      },
+    });
+    const goodSibling = makeNode("5:5", [
+      { labelMarkdown: "ok — *raw-value*", categoryId: "cat-gotcha" },
+    ]);
+    const root = makeNode("1:1", [], [throwingChild, goodSibling]);
+
+    const figma = {
+      getNodeByIdAsync: async () => root,
+    };
+    (globalThis as { figma?: unknown }).figma = figma;
+
+    const acks = await readCanicodeAcknowledgments("1:1", CATEGORIES);
+    expect(acks).toEqual([{ nodeId: "5:5", ruleId: "raw-value" }]);
+  });
+
   it("swallows per-node read errors so the rest of the sweep proceeds", async () => {
     const noisyChild = makeNode("4:4", []);
     Object.defineProperty(noisyChild, "annotations", {

--- a/src/core/roundtrip/read-acknowledgments.ts
+++ b/src/core/roundtrip/read-acknowledgments.ts
@@ -113,6 +113,17 @@ export async function readCanicodeAcknowledgments(
   return out;
 }
 
+// Plugin API exposes `children` as a throwing getter on TEXT/VECTOR and other
+// leaf nodes (issue #421) — isolate the access so the walk doesn't crash.
+function safeChildren(node: FigmaNode): readonly FigmaNode[] {
+  try {
+    const c = (node as { children?: unknown }).children;
+    return Array.isArray(c) ? (c as FigmaNode[]) : [];
+  } catch {
+    return [];
+  }
+}
+
 function walk(
   node: FigmaNode,
   canicodeCategoryIds: ReadonlySet<string> | undefined,
@@ -125,10 +136,7 @@ function walk(
     // Annotation reads can throw on locked / external nodes; swallow so the
     // sweep covers as much of the subtree as possible.
   }
-  const children = (node as { children?: unknown }).children;
-  if (Array.isArray(children)) {
-    for (const child of children) {
-      if (child && typeof child === "object") walk(child as FigmaNode, canicodeCategoryIds, out);
-    }
+  for (const child of safeChildren(node)) {
+    if (child && typeof child === "object") walk(child, canicodeCategoryIds, out);
   }
 }


### PR DESCRIPTION
## Summary

In src/core/roundtrip/read-acknowledgments.ts, the walk() helper reads `node.children` via a raw property access outside the try/catch that wraps annotation extraction. On TEXT/VECTOR (and other leaf) nodes, Figma's Plugin API exposes `children` as a throwing getter — so the walk crashes the entire roundtrip apply step. Fix by isolating the getter read in a safeChildren() helper that try/catches and returns [] on throw, apply it at every recursion site, add test coverage for the throwing-getter case, and rebuild the bundled helpers.js artifact that skill consumers actually load.

## Tasks

- Wrap node.children access in safeChildren() in read-acknowledgments.ts
- Add test for throwing children getter
- Rebuild bundled helpers.js

## Self-review

Tight, surgical fix that matches the plan intent: `safeChildren()` isolates the throwing `children` getter outside the annotation try/catch, the walk recurses via the helper at its single site, and the co-located test models the exact TEXT/VECTOR failure via `Object.defineProperty` (same pattern as the existing throw-on-annotations test). The tracked `.claude/skills/canicode-roundtrip/helpers.js` bundle is regenerated and mirrors the source diff. Implementer correctly deviated from the plan on `skills/**` — those paths are .gitignore'd (`/skills/` at .gitignore:7), so committing only the tracked `.claude/` copy is right.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 0

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #421

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))