### PR TITLE
feat: fix(cli): init --help shows '--no-skills (default: true)' cac rendering artifact

### DIFF
--- a/src/cli/commands/init.test.ts
+++ b/src/cli/commands/init.test.ts
@@ -3,7 +3,9 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { figmaMcpRegistered, formatNextSteps } from "./init.js";
+import cac from "cac";
+
+import { figmaMcpRegistered, formatNextSteps, registerInit } from "./init.js";
 
 let tempRoot: string;
 
@@ -113,5 +115,43 @@ describe("formatNextSteps", () => {
     });
     expect(out).toContain(".cursor/mcp.json");
     expect(out).not.toContain("claude mcp add");
+  });
+});
+
+describe("registerInit --help rendering", () => {
+  // Guards against the cac `(default: true)` artifact from issue #432.
+  // cac auto-injects `config.default = true` on any option whose rawName
+  // begins with `--no-`, which then renders as `(default: true)` in help.
+  it("declares the skills option positively so cac does not inject a default", () => {
+    const cli = cac("canicode");
+    registerInit(cli);
+    const initCommand = cli.commands.find(c => c.name === "init");
+    expect(initCommand).toBeDefined();
+    const skillsOption = initCommand!.options.find(o => o.name === "skills");
+    expect(skillsOption).toBeDefined();
+    expect(skillsOption!.rawName).toBe("--skills");
+    expect(skillsOption!.negated).toBe(false);
+    expect(skillsOption!.config.default).toBeUndefined();
+  });
+
+  it("renders init --help without a misleading (default: true) on the skills line", () => {
+    const cli = cac("canicode");
+    registerInit(cli);
+    const initCommand = cli.commands.find(c => c.name === "init")!;
+    const logs: string[] = [];
+    const originalInfo = console.info;
+    console.info = (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    };
+    try {
+      initCommand.outputHelp();
+    } finally {
+      console.info = originalInfo;
+    }
+    const output = logs.join("\n");
+    const skillsLine = output.split("\n").find(line => /--skills\b/.test(line));
+    expect(skillsLine).toBeDefined();
+    expect(skillsLine!).not.toContain("(default: true)");
+    expect(output).toContain("--no-skills");
   });
 });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -83,7 +83,9 @@ export function formatNextSteps(opts: {
 const InitOptionsSchema = z.object({
   token: z.string().optional(),
   global: z.boolean().optional(),
-  // cac maps `--no-skills` to `skills: false` (mirrors `--no-telemetry`).
+  // Declared positively as `--skills`; mri's built-in `--no-` prefix handling
+  // still maps `--no-skills` to `skills: false`. Declaring the option
+  // positively avoids cac's `(default: true)` artifact on negated flags.
   skills: z.boolean().optional(),
   /** Install `skills/cursor/*` into `.cursor/skills/` (canicode, gotchas, roundtrip — issue #407). */
   cursorSkills: z.boolean().optional(),
@@ -95,7 +97,7 @@ export function registerInit(cli: CAC): void {
     .command("init", "Set up canicode with Figma API token")
     .option("--token <token>", "Save Figma API token and install Claude Code skills to .claude/skills/")
     .option("--global", "Install skills to ~/.claude/skills/ instead of ./.claude/skills/")
-    .option("--no-skills", "Skip skill installation (token only)")
+    .option("--skills", "Install Claude Code skills into .claude/skills/ (default: on — pass --no-skills to opt out)")
     .option("--cursor-skills", "Also install Cursor copies of canicode / canicode-gotchas / canicode-roundtrip under .cursor/skills/")
     .option("--force", "Overwrite existing skill files without prompting (also for non-TTY/CI)")
     .action(async (rawOptions: Record<string, unknown>) => {


### PR DESCRIPTION
## Summary

Fix the misleading `(default: true)` artifact in `canicode init --help` for the `--no-skills` flag. cac auto-injects a `default: true` on any option whose rawName begins with `--no-` (cac dist index.js:200) and unconditionally appends `(default: <value>)` to the help row (index.js:339), with no public API to suppress it. The fix is to declare the option positively as `--skills` — cac leaves non-negated options' defaults undefined, so no artifact is rendered — while relying on mri's built-in `--no-` handling (index.js:49-52) so users can still invoke `--no-skills` on the command line. Schema, internal logic (`options.skills !== false`), tests, and manual-docs strings all continue to work unchanged because the parsed option key stays `skills: boolean`.

## Tasks

- Invert the cac option declaration from --no-skills to --skills
- Add a test that asserts the rendered --help has no misleading default marker

## Self-review

Focused, minimal fix for the cac `(default: true)` artifact on `canicode init --help`. The option is flipped from `--no-skills` to `--skills` with no `{ default: true }` config, which leaves cac's `config.default` undefined and thus renders a clean help row; mri's built-in `--no-` prefix handling preserves backward-compatible CLI invocation of `--no-skills`, which was independently verified to still parse to `skills: false`. Tests, schema, downstream read sites, and the hand-rolled setup guide are all consistent. No real issues found.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 0

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #432

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))