### PR TITLE
feat: fix(cli): upsert-gotcha-section --section - flag mismatch (cac parser rejects bare '-')

### DIFF
--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -121,7 +121,7 @@ Render the per-design section markdown using the **Output Template** below with 
 npx canicode upsert-gotcha-section \
   --file .claude/skills/canicode-gotchas/SKILL.md \
   --design-key "<designKey from Step 4a>" \
-  --section -   # then pipe the rendered section markdown through stdin
+  --section=-   # then pipe the rendered section markdown through stdin
 ```
 
 The CLI prints a JSON result `{ state, action, sectionNumber, wrote, userMessage }`:

--- a/src/cli/commands/upsert-gotcha-section.test.ts
+++ b/src/cli/commands/upsert-gotcha-section.test.ts
@@ -3,7 +3,12 @@ import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { runUpsertGotchaSection } from "./upsert-gotcha-section.js";
+import cac from "cac";
+
+import {
+  registerUpsertGotchaSection,
+  runUpsertGotchaSection,
+} from "./upsert-gotcha-section.js";
 
 let tempRoot: string;
 
@@ -92,6 +97,32 @@ describe("runUpsertGotchaSection", () => {
     expect(readFileSync(file, "utf-8")).toBe(
       "# Single-design content\n\n- **Design key**: x\n",
     );
+  });
+
+  it("parses --section=- through cac (SKILL.md invocation shape)", () => {
+    // Regression guard for #420: the skill's documented invocation uses
+    // `--section=-` (not `--section -`) because cac treats a bare `-` as
+    // the start of another flag and drops the sentinel value. This test
+    // exercises the actual argv parser so the SKILL.md shape is covered.
+    const cli = cac("canicode");
+    registerUpsertGotchaSection(cli);
+    const parsed = cli.parse(
+      [
+        "node",
+        "canicode",
+        "upsert-gotcha-section",
+        "--file",
+        "/tmp/does-not-matter.md",
+        "--design-key",
+        "abc#1:1",
+        "--section=-",
+      ],
+      { run: false },
+    );
+
+    expect(parsed.options.section).toBe("-");
+    expect(parsed.options.file).toBe("/tmp/does-not-matter.md");
+    expect(parsed.options.designKey).toBe("abc#1:1");
   });
 
   it("preserves NNN on replace by Design key match", async () => {

--- a/src/cli/commands/upsert-gotcha-section.ts
+++ b/src/cli/commands/upsert-gotcha-section.ts
@@ -20,7 +20,8 @@ import { renderUpsertedFile } from "../../core/gotcha/upsert-gotcha-section.js";
  *   command substitutes with either the preserved existing NNN (replace)
  *   or the next monotonic NNN (append). If the placeholder is absent the
  *   section markdown is written verbatim. Either pass via `--section` or
- *   pipe through stdin (`--section -`).
+ *   pipe through stdin (`--section=-`). Note: cac parses a bare `-` as the
+ *   start of a flag, so the `=` form is required for the stdin sentinel.
  *
  * Outputs (stdout, JSON):
  * ```
@@ -40,7 +41,9 @@ import { renderUpsertedFile } from "../../core/gotcha/upsert-gotcha-section.js";
 const UpsertOptionsSchema = z.object({
   file: z.string().min(1, "--file is required"),
   designKey: z.string().min(1, "--design-key is required"),
-  section: z.string().min(1, "--section is required (use '-' to read stdin)"),
+  section: z
+    .string()
+    .min(1, "--section is required (use '--section=-' to read stdin)"),
 });
 
 type UpsertOptions = z.infer<typeof UpsertOptionsSchema>;
@@ -117,7 +120,7 @@ export function registerUpsertGotchaSection(cli: CAC): void {
     )
     .option(
       "--section <markdown>",
-      "Already-rendered per-design section markdown. Use '-' to read from stdin.",
+      "Already-rendered per-design section markdown. Use '--section=-' to read from stdin (cac parses a bare '-' as a flag, so the '=' form is required).",
     )
     .action(async (rawOptions: Record<string, unknown>) => {
       const parseResult = UpsertOptionsSchema.safeParse(rawOptions);


### PR DESCRIPTION
## Summary

Fix the SKILL.md instructions and CLI docstring for `canicode upsert-gotcha-section` so the stdin invocation shape actually parses under cac. The skill tells users `--section -` (space-separated), but cac treats a bare `-` as the start of a flag and rejects the value; only `--section=-` parses. Update the SKILL.md step and the command's option help/docstring to use the `=` form, and add a CLI-level test that actually runs through cac's argv parser so this shape is pinned down by a test (existing tests only exercise `runUpsertGotchaSection` directly, which bypassed the regression).

## Tasks

- Update SKILL.md step 4b to use `--section=-`
- Align CLI docstring + help text with the `=` form and pin it with a cac-parsed test

## Self-review

The CLI-side fix (JSDoc, cac .option help, Zod error message) and the new argv-parse regression test are well-executed and match the plan's intent. However, plan task 1 — the one-line edit to .claude/skills/canicode-gotchas/SKILL.md:124 — was not applied, so the primary user-facing source of the #420 bug (the broken `--section -` line that skill users copy-paste) is still present on the branch. The issue is not actually resolved until that edit ships.
- Verdict: request-changes
- Errors: 1, Warnings: 0, Total: 1

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #420

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))