### PR TITLE
feat: docs(cli): top-level --help lacks product tagline

### DIFF
--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -37,6 +37,21 @@ describe.skipIf(!existsSync(CLI_PATH))("CLI --help", () => {
     }
   });
 
+  it("should show product tagline above Usage in --help output", () => {
+    const output = execFileSync("node", [CLI_PATH, "--help"], {
+      encoding: "utf-8",
+    });
+
+    const taglineAnchor = "Lint Figma designs for AI code-gen";
+    expect(output).toContain(taglineAnchor);
+
+    const taglineIndex = output.indexOf(taglineAnchor);
+    const usageIndex = output.indexOf("Usage:");
+    expect(taglineIndex).toBeGreaterThan(-1);
+    expect(usageIndex).toBeGreaterThan(-1);
+    expect(taglineIndex).toBeLessThan(usageIndex);
+  });
+
   it("should allow direct invocation of internal commands", () => {
     const output = execFileSync(
       "node",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -43,7 +43,7 @@ import { registerCalibrateImplement } from "./commands/internal/calibrate-implem
 import { registerCodeMetrics } from "./commands/internal/code-metrics.js";
 
 const require = createRequire(import.meta.url);
-const pkg = require("../../package.json") as { version: string };
+const pkg = require("../../package.json") as { version: string; description: string };
 
 const cli = cac("canicode");
 
@@ -115,6 +115,10 @@ cli.help((sections) => {
         .join("\n");
     }
   }
+
+  // Insert product tagline between the `canicode/<version>` banner (sections[0])
+  // and the Usage block, so first-touch users see what the tool does.
+  sections.splice(1, 0, { body: `  ${pkg.description}` });
 
   sections.push(
     {


### PR DESCRIPTION
## Summary

Add a product tagline between the `canicode/<version>` banner and the Usage block in the top-level `--help` output, so first-touch users see what the tool does without having to read npm/README. Source the tagline from package.json's `description` field (single source of truth — it already contains the recommended copy: 'Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.').

## Tasks

- Inject tagline into top-level --help via cac help callback
- Add CLI test asserting tagline appears in --help output

## Self-review

Minimal, correct, well-tested implementation. Sources the tagline from package.json description (single source of truth), injects at the right slot via the existing cli.help callback, and adds a substring+ordering test that catches both presence and position regressions. Matches plan intent exactly.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 0

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #431

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))