### PR TITLE
feat: docs(cli): 'canicode docs setup' missing Cursor section (0.11.0 drift)

### DIFF
--- a/src/cli/docs.ts
+++ b/src/cli/docs.ts
@@ -80,6 +80,35 @@ CANICODE SETUP GUIDE
     /canicode-roundtrip <url>    Analyze, fix gotchas in Figma, re-analyze
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ 3. CURSOR SKILLS (requires FIGMA_TOKEN)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  (Same token safety as above — env var or interactive prompt, not chat.)
+
+  Setup:
+    canicode init --token figd_xxxxxxxxxxxxx --cursor-skills
+    (installs Cursor copies of the three skills into ./.cursor/skills/)
+
+  Installed skills:
+    canicode             Lightweight CLI wrapper
+    canicode-gotchas     Standalone gotcha survey
+    canicode-roundtrip   Full analyze -> gotcha -> apply roundtrip
+
+  Flags:
+    --cursor-skills   Install Cursor copies of all three skills into .cursor/skills/
+    --no-skills       Skip Claude Code skills (with --cursor-skills, still installs
+                      the Cursor bundle plus the shared gotchas answer file)
+    --force           Overwrite existing skill files without prompting
+
+  Use (in Cursor Agent chat):
+    @canicode <figma-url>
+    @canicode-gotchas <figma-url>      Run a gotcha survey
+    @canicode-roundtrip <figma-url>    Analyze, fix gotchas in Figma, re-analyze
+
+  See also: docs/CUSTOMIZATION.md#cursor-mcp-canicode (Figma MCP required for roundtrip
+  writes; analyze-only works without it).
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  TOKEN PRIORITY
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -94,6 +123,7 @@ CANICODE SETUP GUIDE
   CI/CD, automation        -> CLI + FIGMA_TOKEN env var
   Claude Code (full)       -> canicode MCP server + FIGMA_TOKEN
   Claude Code (light)      -> /canicode skill + FIGMA_TOKEN
+  Cursor Agent             -> canicode init --cursor-skills + Figma MCP
   In Figma                 -> Figma Plugin
   Browser                  -> Web App (GitHub Pages)
   Quick trial, offline     -> CLI + JSON fixtures


### PR DESCRIPTION
## Summary

The `canicode docs setup` output (src/cli/docs.ts:printDocsSetup) is missing a Cursor section and a Cursor row in the 'WHICH ONE SHOULD I USE?' table, even though 0.11.0 shipped `canicode init --cursor-skills` and `.cursor/skills/` parity. Add a '3. CURSOR SKILLS' section mirroring the structure of section 2 (CLAUDE CODE SKILLS) using the flag semantics already implemented in src/cli/commands/init.ts, and add a Cursor row to the decision table. Content should align with the existing README 'CanICode in Cursor' block (README.md:73-77).

## Tasks

- Add Cursor Skills section and Cursor row to `canicode docs setup` output

## Self-review

Docs-only change that accurately addresses the 0.11.0 drift in #430. The new '3. CURSOR SKILLS' section mirrors section 2's structure, flag semantics match src/cli/commands/init.ts:107 and :152-187, and the WHICH ONE table row slots cleanly after 'Claude Code (light)'. No conventions violated; no new runtime logic to test.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 1

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #430

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))