### PR TITLE
feat(cli): add roundtrip-tally command (#427)

### DIFF
--- a/src/cli/commands/roundtrip-tally.test.ts
+++ b/src/cli/commands/roundtrip-tally.test.ts
@@ -16,7 +16,7 @@ afterEach(async () => {
 });
 
 describe("computeRoundtripTallyFromSavedFiles", () => {
-  it("matches computeRoundtripTally for analyze + step4 JSON (#427)", async () => {
+  it("matches computeRoundtripTally for analyze + step4 JSON", async () => {
     const analyzePath = join(tempRoot, "analyze.json");
     const step4Path = join(tempRoot, "step4.json");
 
@@ -103,7 +103,7 @@ describe("computeRoundtripTallyFromSavedFiles", () => {
     ).rejects.toThrow(/--analyze must include issueCount/);
   });
 
-  it("rejects malformed JSON", async () => {
+  it("rejects malformed JSON in --analyze file", async () => {
     const analyzePath = join(tempRoot, "analyze.json");
     const step4Path = join(tempRoot, "step4.json");
 
@@ -113,5 +113,41 @@ describe("computeRoundtripTallyFromSavedFiles", () => {
     await expect(
       computeRoundtripTallyFromSavedFiles({ analyzePath, step4Path }),
     ).rejects.toThrow(/--analyze/);
+  });
+
+  it("rejects malformed JSON in --step4 file", async () => {
+    const analyzePath = join(tempRoot, "analyze.json");
+    const step4Path = join(tempRoot, "step4.json");
+
+    writeFileSync(
+      analyzePath,
+      JSON.stringify({ issueCount: 1, acknowledgedCount: 0 }),
+      "utf-8",
+    );
+    writeFileSync(step4Path, "{ not json", "utf-8");
+
+    await expect(
+      computeRoundtripTallyFromSavedFiles({ analyzePath, step4Path }),
+    ).rejects.toThrow(/--step4/);
+  });
+
+  it("surfaces readable errors when an input file is missing", async () => {
+    const analyzePath = join(tempRoot, "missing-analyze.json");
+    const step4Path = join(tempRoot, "step4.json");
+
+    writeFileSync(
+      step4Path,
+      JSON.stringify({
+        resolved: 0,
+        annotated: 0,
+        definitionWritten: 0,
+        skipped: 0,
+      }),
+      "utf-8",
+    );
+
+    await expect(
+      computeRoundtripTallyFromSavedFiles({ analyzePath, step4Path }),
+    ).rejects.toThrow(/cannot read --analyze/);
   });
 });

--- a/src/cli/commands/roundtrip-tally.test.ts
+++ b/src/cli/commands/roundtrip-tally.test.ts
@@ -1,0 +1,117 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { computeRoundtripTallyFromSavedFiles } from "./roundtrip-tally.js";
+
+let tempRoot: string;
+
+beforeEach(() => {
+  tempRoot = mkdtempSync(join(tmpdir(), "canicode-rt-tally-"));
+});
+
+afterEach(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+describe("computeRoundtripTallyFromSavedFiles", () => {
+  it("matches computeRoundtripTally for analyze + step4 JSON (#427)", async () => {
+    const analyzePath = join(tempRoot, "analyze.json");
+    const step4Path = join(tempRoot, "step4.json");
+
+    writeFileSync(
+      analyzePath,
+      JSON.stringify({
+        version: "test",
+        issueCount: 7,
+        acknowledgedCount: 3,
+      }),
+      "utf-8",
+    );
+    writeFileSync(
+      step4Path,
+      JSON.stringify({
+        resolved: 2,
+        annotated: 1,
+        definitionWritten: 1,
+        skipped: 4,
+      }),
+      "utf-8",
+    );
+
+    const tally = await computeRoundtripTallyFromSavedFiles({
+      analyzePath,
+      step4Path,
+    });
+
+    expect(tally).toEqual({
+      X: 2,
+      Y: 1,
+      Z: 1,
+      W: 4,
+      N: 8,
+      V: 7,
+      V_ack: 3,
+      V_open: 4,
+    });
+  });
+
+  it("throws when acknowledgedCount exceeds issueCount", async () => {
+    const analyzePath = join(tempRoot, "analyze.json");
+    const step4Path = join(tempRoot, "step4.json");
+
+    writeFileSync(
+      analyzePath,
+      JSON.stringify({ issueCount: 2, acknowledgedCount: 5 }),
+      "utf-8",
+    );
+    writeFileSync(
+      step4Path,
+      JSON.stringify({
+        resolved: 0,
+        annotated: 0,
+        definitionWritten: 0,
+        skipped: 0,
+      }),
+      "utf-8",
+    );
+
+    await expect(
+      computeRoundtripTallyFromSavedFiles({ analyzePath, step4Path }),
+    ).rejects.toThrow(/cannot exceed issueCount/);
+  });
+
+  it("rejects analyze JSON missing issueCount", async () => {
+    const analyzePath = join(tempRoot, "analyze.json");
+    const step4Path = join(tempRoot, "step4.json");
+
+    writeFileSync(analyzePath, JSON.stringify({ acknowledgedCount: 0 }), "utf-8");
+    writeFileSync(
+      step4Path,
+      JSON.stringify({
+        resolved: 0,
+        annotated: 0,
+        definitionWritten: 0,
+        skipped: 0,
+      }),
+      "utf-8",
+    );
+
+    await expect(
+      computeRoundtripTallyFromSavedFiles({ analyzePath, step4Path }),
+    ).rejects.toThrow(/--analyze must include issueCount/);
+  });
+
+  it("rejects malformed JSON", async () => {
+    const analyzePath = join(tempRoot, "analyze.json");
+    const step4Path = join(tempRoot, "step4.json");
+
+    writeFileSync(analyzePath, "{ not json", "utf-8");
+    writeFileSync(step4Path, "{}", "utf-8");
+
+    await expect(
+      computeRoundtripTallyFromSavedFiles({ analyzePath, step4Path }),
+    ).rejects.toThrow(/--analyze/);
+  });
+});

--- a/src/cli/commands/roundtrip-tally.ts
+++ b/src/cli/commands/roundtrip-tally.ts
@@ -7,6 +7,7 @@ import {
   ReanalyzeForTallySchema,
   StepFourReportSchema,
 } from "../../core/contracts/roundtrip-tally.js";
+import { EVENTS, trackError, trackEvent } from "../../core/monitoring/index.js";
 import { computeRoundtripTally } from "../../core/roundtrip/compute-roundtrip-tally.js";
 
 const RoundtripTallyCliOptionsSchema = z.object({
@@ -25,18 +26,29 @@ function parseJsonFile(label: string, path: string, raw: string): unknown {
   }
 }
 
+async function readUtf8File(label: string, path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf-8");
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`roundtrip-tally: cannot read ${label} (${path}): ${detail}`, {
+      cause: err,
+    });
+  }
+}
+
 /**
  * Reads a `canicode analyze --json` (re-analyze) file and a Step 4 structured
  * outcome-count file, then returns the same tally the canicode-roundtrip SKILL
- * renders after Step 5 (#427).
+ * renders after Step 5.
  */
 export async function computeRoundtripTallyFromSavedFiles(args: {
   analyzePath: string;
   step4Path: string;
 }): Promise<ReturnType<typeof computeRoundtripTally>> {
   const [analyzeRaw, step4Raw] = await Promise.all([
-    readFile(args.analyzePath, "utf-8"),
-    readFile(args.step4Path, "utf-8"),
+    readUtf8File("--analyze", args.analyzePath),
+    readUtf8File("--step4", args.step4Path),
   ]);
 
   const analyzeParsed = parseJsonFile("--analyze", args.analyzePath, analyzeRaw);
@@ -72,7 +84,7 @@ export function registerRoundtripTally(cli: CAC): void {
   cli
     .command(
       "roundtrip-tally",
-      "Print the Step 5 roundtrip tally from re-analyze JSON and Step 4 outcome counts (#427)",
+      "Print the Step 5 roundtrip tally from re-analyze JSON and Step 4 outcome counts",
     )
     .option("--analyze <path>", "Path to re-analyze JSON (`canicode analyze --json` output)")
     .option("--step4 <path>", "Path to Step 4 structured counts (resolved / annotated / definitionWritten / skipped)")
@@ -93,8 +105,14 @@ export function registerRoundtripTally(cli: CAC): void {
           step4Path: parsed.data.step4,
         });
         console.log(JSON.stringify(tally, null, 2));
+        trackEvent(EVENTS.ROUNDTRIP_TALLY);
       } catch (err) {
-        console.error(err instanceof Error ? err.message : err);
+        if (err instanceof Error) {
+          trackError(err, { command: "roundtrip-tally" });
+          console.error(err.message);
+        } else {
+          console.error(err);
+        }
         process.exit(1);
       }
     });

--- a/src/cli/commands/roundtrip-tally.ts
+++ b/src/cli/commands/roundtrip-tally.ts
@@ -1,0 +1,101 @@
+import { readFile } from "node:fs/promises";
+
+import type { CAC } from "cac";
+import { z } from "zod";
+
+import {
+  ReanalyzeForTallySchema,
+  StepFourReportSchema,
+} from "../../core/contracts/roundtrip-tally.js";
+import { computeRoundtripTally } from "../../core/roundtrip/compute-roundtrip-tally.js";
+
+const RoundtripTallyCliOptionsSchema = z.object({
+  analyze: z.string().min(1),
+  step4: z.string().min(1),
+});
+
+function parseJsonFile(label: string, path: string, raw: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch (err) {
+    throw new Error(
+      `roundtrip-tally: ${label} is not valid JSON (${path})`,
+      { cause: err },
+    );
+  }
+}
+
+/**
+ * Reads a `canicode analyze --json` (re-analyze) file and a Step 4 structured
+ * outcome-count file, then returns the same tally the canicode-roundtrip SKILL
+ * renders after Step 5 (#427).
+ */
+export async function computeRoundtripTallyFromSavedFiles(args: {
+  analyzePath: string;
+  step4Path: string;
+}): Promise<ReturnType<typeof computeRoundtripTally>> {
+  const [analyzeRaw, step4Raw] = await Promise.all([
+    readFile(args.analyzePath, "utf-8"),
+    readFile(args.step4Path, "utf-8"),
+  ]);
+
+  const analyzeParsed = parseJsonFile("--analyze", args.analyzePath, analyzeRaw);
+  const step4Parsed = parseJsonFile("--step4", args.step4Path, step4Raw);
+
+  const reanalyzeResult = ReanalyzeForTallySchema.safeParse(analyzeParsed);
+  if (!reanalyzeResult.success) {
+    const msg = reanalyzeResult.error.issues
+      .map((i) => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    throw new Error(
+      `roundtrip-tally: --analyze must include issueCount and acknowledgedCount (${args.analyzePath}): ${msg}`,
+    );
+  }
+
+  const stepFourResult = StepFourReportSchema.safeParse(step4Parsed);
+  if (!stepFourResult.success) {
+    const msg = stepFourResult.error.issues
+      .map((i) => `${i.path.join(".")}: ${i.message}`)
+      .join("; ");
+    throw new Error(
+      `roundtrip-tally: --step4 must match StepFourReport (${args.step4Path}): ${msg}`,
+    );
+  }
+
+  return computeRoundtripTally({
+    stepFourReport: stepFourResult.data,
+    reanalyzeResponse: reanalyzeResult.data,
+  });
+}
+
+export function registerRoundtripTally(cli: CAC): void {
+  cli
+    .command(
+      "roundtrip-tally",
+      "Print the Step 5 roundtrip tally from re-analyze JSON and Step 4 outcome counts (#427)",
+    )
+    .option("--analyze <path>", "Path to re-analyze JSON (`canicode analyze --json` output)")
+    .option("--step4 <path>", "Path to Step 4 structured counts (resolved / annotated / definitionWritten / skipped)")
+    .example("  canicode roundtrip-tally --analyze ./reanalyze.json --step4 ./step4-report.json")
+    .action(async (rawOptions: Record<string, unknown>) => {
+      const parsed = RoundtripTallyCliOptionsSchema.safeParse(rawOptions);
+      if (!parsed.success) {
+        const msg = parsed.error.issues
+          .map((i) => `--${i.path.join(".")}: ${i.message}`)
+          .join("\n");
+        console.error(`\nroundtrip-tally requires --analyze and --step4:\n${msg}`);
+        process.exit(1);
+      }
+
+      try {
+        const tally = await computeRoundtripTallyFromSavedFiles({
+          analyzePath: parsed.data.analyze,
+          step4Path: parsed.data.step4,
+        });
+        console.log(JSON.stringify(tally, null, 2));
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : err);
+        process.exit(1);
+      }
+    });
+}

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -41,6 +41,7 @@ describe.skipIf(!existsSync(CLI_PATH))("CLI --help", () => {
       "init",
       "config",
       "list-rules",
+      "roundtrip-tally",
       "docs",
     ];
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import { registerVisualCompare } from "./commands/visual-compare.js";
 import { registerInit } from "./commands/init.js";
 import { registerConfig } from "./commands/config.js";
 import { registerListRules } from "./commands/list-rules.js";
+import { registerRoundtripTally } from "./commands/roundtrip-tally.js";
 
 import { INTERNAL_COMMANDS } from "./internal-commands.js";
 
@@ -77,6 +78,7 @@ registerVisualCompare(cli);
 registerInit(cli);
 registerConfig(cli);
 registerListRules(cli);
+registerRoundtripTally(cli);
 
 // ============================================
 // Internal commands (calibration & fixtures)
@@ -143,6 +145,7 @@ cli.help((sections) => {
         `  $ canicode analyze "https://www.figma.com/design/..." --preset strict`,
         `  $ canicode analyze "https://www.figma.com/design/..." --config ./my-config.json`,
         `  $ canicode gotcha-survey "https://www.figma.com/design/..." --json`,
+        `  $ canicode roundtrip-tally --analyze ./reanalyze.json --step4 ./step4.json`,
       ].join("\n"),
     },
     {

--- a/src/core/monitoring/events.ts
+++ b/src/core/monitoring/events.ts
@@ -34,6 +34,8 @@ export const EVENTS = {
   // caller-supplied callback. Define the typed name here so a future consumer
   // has a single place to wire it up.
   ROUNDTRIP_DEFINITION_WRITE_SKIPPED: `${EVENT_PREFIX}roundtrip_definition_write_skipped`,
+  /** CLI `canicode roundtrip-tally` completed successfully. */
+  ROUNDTRIP_TALLY: `${EVENT_PREFIX}roundtrip_tally`,
 } as const;
 
 export type EventName = (typeof EVENTS)[keyof typeof EVENTS];

--- a/src/core/monitoring/index.test.ts
+++ b/src/core/monitoring/index.test.ts
@@ -73,6 +73,10 @@ describe("monitoring module", () => {
       expect(EVENTS.MCP_TOOL_CALLED).toBe("cic_mcp_tool_called");
       expect(EVENTS.CLI_COMMAND).toBe("cic_cli_command");
       expect(EVENTS.CLI_INIT).toBe("cic_cli_init");
+      expect(EVENTS.ROUNDTRIP_DEFINITION_WRITE_SKIPPED).toBe(
+        "cic_roundtrip_definition_write_skipped",
+      );
+      expect(EVENTS.ROUNDTRIP_TALLY).toBe("cic_roundtrip_tally");
     });
   });
 


### PR DESCRIPTION
## Summary
Adds `canicode roundtrip-tally --analyze <path> --step4 <path>` to print the same Step 5 tally as `computeRoundtripTally` (X/Y/Z/W/N/V/V_ack/V_open) from saved re-analyze JSON and Step 4 outcome counts.

## Inputs
- **`--analyze`**: `canicode analyze --json` output (needs top-level `issueCount`, `acknowledgedCount`).
- **`--step4`**: `{ resolved, annotated, definitionWritten, skipped }`.

## Follow-ups (review)
- Telemetry: `EVENTS.ROUNDTRIP_TALLY` on success; `trackError` on failure (no paths in analytics).
- Clear errors for missing/unreadable files and malformed JSON per-input (`--analyze` vs `--step4`).
- Extra tests for broken `--step4` JSON and missing analyze path.

## Testing
- `pnpm lint`, `pnpm build`, `pnpm test:run`
- Unit tests in `src/cli/commands/roundtrip-tally.test.ts`

Closes #427