### PR TITLE
chore(release): bump version to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
   "type": "module",


### PR DESCRIPTION
## Summary

Bump `package.json` version from `0.11.0` to `0.11.1` in preparation for tagging `v0.11.1` after merge.

## After merge

1. On the merge commit on `main`: `git tag v0.11.1 && git push origin v0.11.1`
2. GitHub Actions publishes to npm on tag push (do not run `npm publish` manually).

## Release notes

See commits since `v0.11.0` on `main` for the full list; group as fix / feat / docs in the GitHub Release.

Made with [Cursor](https://cursor.com)