### PR TITLE
fix(cli): remove unused --api flag from analyze (#463)

### DIFF
--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -26,7 +26,6 @@ const AnalyzeOptionsSchema = z.object({
   preset: z.enum(["relaxed", "dev-friendly", "ai-ready", "strict"]).optional(),
   output: z.string().optional(),
   token: z.string().optional(),
-  api: z.boolean().optional(),
   screenshot: z.boolean().optional(),
   config: z.string().optional(),
   noOpen: z.boolean().optional(),
@@ -42,7 +41,6 @@ export function registerAnalyze(cli: CAC): void {
     .option("--preset <preset>", "Analysis preset (relaxed | dev-friendly | ai-ready | strict)")
     .option("--output <path>", "HTML report output path")
     .option("--token <token>", "Figma API token (or use FIGMA_TOKEN env var)")
-    .option("--api", "Load via Figma REST API (requires FIGMA_TOKEN)")
     .option("--screenshot", "Include screenshot comparison in report (requires ANTHROPIC_API_KEY)")
     .option("--config <path>", "Path to config JSON file (override rule scores/settings)")
     .option("--no-open", "Don't open report in browser after analysis")
@@ -50,7 +48,6 @@ export function registerAnalyze(cli: CAC): void {
     .option("--acknowledgments <path>", "(#371 / ADR-019) Path to JSON acknowledgments from canicode Figma annotations (nodeId, ruleId; optional intent / sceneWriteOutcome / codegenDirective per #444). Matching issues are flagged acknowledged and contribute half weight to density.")
     .option("--scope <scope>", "(#404) Override analysis scope: `page` (screen/section — container bounds are required) or `component` (standalone reusable unit — root FILL is the design contract). Defaults to auto-detection from the root node type.")
     .example("  canicode analyze https://www.figma.com/design/ABC123/MyDesign")
-    .example("  canicode analyze https://www.figma.com/design/ABC123/MyDesign --api --token YOUR_TOKEN")
     .example("  canicode analyze ./fixtures/my-design --output report.html")
     .example("  canicode analyze ./fixtures/my-design --config ./my-config.json")
     .action(async (input: string, rawOptions: Record<string, unknown>) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -129,10 +129,7 @@ cli.help((sections) => {
     },
     {
       title: "\nData source",
-      body: [
-        `  --api                   Load via Figma REST API (needs FIGMA_TOKEN)`,
-        `  --token <token>         Figma API token (or use FIGMA_TOKEN env var)`,
-      ].join("\n"),
+      body: `  --token <token>         Figma API token (or use FIGMA_TOKEN env var)`,
     },
     {
       title: "\nCustomization",
@@ -141,7 +138,6 @@ cli.help((sections) => {
     {
       title: "\nExamples",
       body: [
-        `  $ canicode analyze "https://www.figma.com/design/..." --api`,
         `  $ canicode analyze "https://www.figma.com/design/..." --preset strict`,
         `  $ canicode analyze "https://www.figma.com/design/..." --config ./my-config.json`,
         `  $ canicode gotcha-survey "https://www.figma.com/design/..." --json`,


### PR DESCRIPTION
## Summary

Remove the unused --api flag from `canicode analyze`. It's declared in the CLI, parsed into the Zod schema, and mentioned in help text/examples, but never read after parse — `loadFile` always takes the REST path for Figma URLs regardless. The flag sets a false expectation (implying it toggles a load mode) and creates confusing non-parity with `gotcha-survey`, which has no --api. Since there's no non-REST code path for Figma URLs to toggle into, deletion is cleaner than keeping a documented no-op: one of the two options the issue explicitly endorses ("if such a code path is never intended, just delete the flag"). Parity with gotcha-survey is then automatic — neither command has the flag.

## Tasks

- Remove --api from analyze command
- Update help output in src/cli/index.ts

## Self-review

Clean, minimal removal of the no-op `--api` flag across both surfaces where it existed (analyze command + global help). Diff matches the plan exactly and the CLAUDE.md 'don't add features beyond what the task requires' scope policy. Verified no remaining `--api` references in the repo (src/, README.md, .claude/docs/) and no `options.api` readers were left behind.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 1

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #463

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))