### PR TITLE
docs(roundtrip): Step 4 preflight + Cursor MCP troubleshooting (#462 #464)

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -93,6 +93,22 @@ Iterate `groupedQuestions.groups[].batches[]`. Instance notes, batch prompts, re
 
 ### Step 4: Apply gotcha answers to Figma design
 
+#### Mandatory preflight — prepend `helpers.js` before any `CanICodeRoundtrip.*` call
+
+`CanICodeRoundtrip` is **not** a Figma or MCP built-in. It is the global registered by the bundled IIFE in `helpers.js` shipped next to this skill — it only exists after you read that file and prepend its contents verbatim at the top of every `use_figma` script string. Skipping this step throws `ReferenceError: 'CanICodeRoundtrip' is not defined` on the first `use_figma` batch.
+
+- **Claude Code / default `canicode init`:** `.claude/skills/canicode-roundtrip/helpers.js`
+- **Cursor after `canicode init --cursor-skills`:** `.cursor/skills/canicode-roundtrip/helpers.js`
+
+Optional smoke check — run this as the first `use_figma` call of Step 4 (with `helpers.js` prepended) before any real apply batch:
+
+```javascript
+// <contents of helpers.js prepended here>
+return { ok: typeof CanICodeRoundtrip !== 'undefined' };
+```
+
+See [`docs/roundtrip-protocol.md` → Shared helpers (bundled)](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md#shared-helpers-bundled) for the full helper catalogue (ADR-016 — deterministic logic lives in the bundled helpers, not skill prose).
+
 For each answered gotcha (skip questions answered with "skip" or "n/a"), branch on the pre-computed `question.applyStrategy`. The routing table, target properties, and instance-child resolution are resolved server-side by `canicode` — do NOT re-derive them from the rule id. The `fileKey` is not needed at this step — the bundled helpers operate on `nodeId` directly.
 
 Use the **`nodeId` from the answered question**. When `question.isInstanceChild` is `true`, treat layout and size-constraint changes as **high impact**: applying them on the source definition affects **every instance** of that component in the file. Ask for explicit user confirmation before writing to the definition node.

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -34,6 +34,15 @@ See the Edge Case **No Figma MCP server** below for the one-way fallback when Fi
 
 **canicode MCP (same cold-session pattern):** If `analyze` / `gotcha-survey` MCP tools are missing but `.mcp.json` lists canicode, you are on the `npx canicode …` fallback. Tell the user to restart the host or reload MCP after `claude mcp add canicode …` (or the Cursor equivalent) so the canicode tools appear — same communication fix as #433; the CLI path is not an error.
 
+### Debugging: MCP not available or Step 4 fails
+
+Work through this matrix before concluding a server is broken. Full detail and the symptom → cause table are in [CUSTOMIZATION.md — Troubleshooting](https://github.com/let-sunny/canicode/blob/main/docs/CUSTOMIZATION.md#troubleshooting-mcp-not-available-or-roundtrip-step-4-fails).
+
+1. **Settings + reload** — open **Settings → MCP**, confirm the server shows as enabled for this workspace, and reload MCP or restart the host. The live tool list (not the on-disk JSON) is what the model can actually call.
+2. **Figma + canicode both present** — canicode provides `analyze` / `gotcha-survey`; Figma provides `use_figma`. A failure in Step 4 is a Figma MCP issue; a failure in Steps 1–3 is a canicode issue. Identify which server exposes the missing tool before editing config.
+3. **Prepend + smoke check** — `helpers.js` must be prepended to every `use_figma` `code` string; if `typeof CanICodeRoundtrip === 'undefined'`, the bundle was not in the string. See the Step 4 preflight block above for the exact prepend procedure and smoke-check snippet. This is distinct from "canicode MCP missing."
+4. **Size / paste fallback** — if the host cannot pass the full code string (truncation or tool-payload limit), measure `Buffer.byteLength(code, "utf8")` (or `wc -c`) and, if too large, paste the code directly into the MCP `use_figma` UI instead of relying on the model to pass it inline. See [`docs/roundtrip-protocol.md`](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md) for delivery notes.
+
 ### Step 1: Analyze the design
 
 If the `analyze` MCP tool is available, call it with the user's Figma URL:

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -234,6 +234,33 @@ Cursor may show an MCP **server id** in the UI that is **not** literally the key
 - [ ] After the Q&A loop, `npx canicode upsert-gotcha-section --file … --design-key … --input=-` (JSON payload on stdin per `canicode-gotchas` Step 4b) succeeds and updates `.claude/skills/canicode-gotchas/SKILL.md`.
 - [ ] Optional: @ **canicode-roundtrip** — Step 4 reads `helpers.js` from `.cursor/skills/canicode-roundtrip/helpers.js` after `canicode init --cursor-skills`.
 
+### Troubleshooting: MCP not available or roundtrip Step 4 fails
+
+Work through these checks in order before concluding that an MCP server is broken.
+
+1. **Cursor host — ensure the server is enabled and the tools appear in the live session.**
+   MCP servers are not always active immediately after install. Open **Settings → MCP** and verify the server shows a connected status. If the entry is present but the tools are missing from the active tool list, use the reload MCP action (or restart Cursor). The live tool list — not the on-disk JSON — is what the model can actually call.
+
+2. **Two separate servers — identify which step failed before attributing blame.**
+   canicode (provides `analyze` and `gotcha-survey`) and Figma (provides `use_figma`) are independent MCP servers. Step 1 (analyze) and Step 3 (gotcha-survey) use the canicode server. Step 4 (canvas write) uses the Figma server. A failure in Step 4 is a Figma MCP issue, not a canicode issue — and vice versa. Check which server exposes the missing tool before editing config.
+
+3. **Step 4 (canvas write) — `helpers.js` must be prepended to every `use_figma` `code` string.**
+   `CanICodeRoundtrip` is not a Figma built-in. It is the global registered by the bundled IIFE in `helpers.js` (at `.claude/skills/canicode-roundtrip/helpers.js` for Claude Code, or `.cursor/skills/canicode-roundtrip/helpers.js` after `canicode init --cursor-skills`). If the bundle is missing from the string, the first Plugin API call throws `ReferenceError: CanICodeRoundtrip is not defined`. This is **not** the same as "canicode MCP is missing" — the canicode server may be healthy; only the Step 4 `use_figma` script is incomplete. Smoke-check with:
+   ```javascript
+   // <contents of helpers.js prepended here>
+   return { ok: typeof CanICodeRoundtrip !== 'undefined' };
+   ```
+   See the Step 4 preflight block in [`docs/roundtrip-protocol.md`](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md) and the corresponding preflight check in the `canicode-roundtrip` SKILL.md for the full prepend procedure.
+
+4. **Size / delivery — measure the code string before assuming a server bug.**
+   If the `use_figma` call silently fails, truncates, or the host reports the tool payload is too large, the `helpers.js` bundle combined with the apply script may exceed the host's per-message or per-tool-call limit. Measure with `Buffer.byteLength(code, "utf8")` (Node) or `wc -c` (shell). If the string is too large for the chat/tool input, write it to a file and paste it into the MCP `use_figma` UI directly instead of relying on the model to pass the full string inline. See also the delivery notes in [#462](https://github.com/let-sunny/canicode/issues/462) and [`docs/roundtrip-protocol.md`](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md).
+
+5. **Common symptom → likely cause mapping:**
+   - `ReferenceError: CanICodeRoundtrip is not defined` → `helpers.js` was not prepended (check 3 above).
+   - Truncated response or no server round-trip returned → delivery size issue (check 4 above).
+   - Permission error or "cannot edit" → Figma file seat or edit access; a Viewer seat cannot write via Plugin API.
+   - Tools missing from live tool list despite on-disk config → MCP server not enabled or not restarted (check 1 above).
+
 ---
 
 ## Telemetry

--- a/docs/roundtrip-protocol.md
+++ b/docs/roundtrip-protocol.md
@@ -102,6 +102,9 @@ The probe is read-only and idempotent; running it before the picker adds one rou
 
 1. Read `helpers.js` from the same directory as this skill once at the start of Step 4 — typically `.claude/skills/canicode-roundtrip/helpers.js` (Claude Code / default `canicode init`) or `.cursor/skills/canicode-roundtrip/helpers.js` (Cursor with `canicode init --cursor-skills`).
 2. Prepend its contents verbatim at the top of every `use_figma` batch body — it registers a single global `CanICodeRoundtrip`.
+
+See the "Mandatory preflight" block at the start of Step 4 in [`.claude/skills/canicode-roundtrip/SKILL.md`](https://github.com/let-sunny/canicode/blob/main/.claude/skills/canicode-roundtrip/SKILL.md#step-4-apply-gotcha-answers-to-figma-design) for the agent-facing checklist.
+
 3. Reference exposed globals as `CanICodeRoundtrip.*`:
    - `stripAnnotations(annotations)` — normalizes the D1 label/labelMarkdown mutex on readback.
    - `ensureCanicodeCategories()` — returns `{ gotcha, flag, fallback }` category id map (D4); idempotent, safe to call at the top of every batch. May also include `legacyAutoFix` when the file already carries the pre-#355 `canicode:auto-fix` category from earlier roundtrips — read-only on the canicode side, used only by Step 5 cleanup to sweep old annotations.


### PR DESCRIPTION
## Summary

This PR bundles two related documentation improvements for the canicode roundtrip flow:

**#462 — Step 4 preflight block (commit 56b9b1f6)**
- Add a high-visibility 'Mandatory preflight' subsection at the start of Step 4 in the canicode-roundtrip SKILL.md so agents cannot miss that `CanICodeRoundtrip` only exists after `helpers.js` is prepended to every `use_figma` batch
- Cross-link from `docs/roundtrip-protocol.md`'s 'Usage in a roundtrip session'

**#464 — Cursor MCP troubleshooting + roundtrip debug matrix (commit 82a29410)**
- Add a Troubleshooting subsection to `docs/CUSTOMIZATION.md` under the Cursor MCP section with ordered checks: settings+reload, two-server attribution, helpers.js prepend + smoke check, size/paste fallback, and symptom → cause table
- Add a condensed Debugging block to the canicode-roundtrip SKILL.md immediately after Step 0, cross-linking to the CUSTOMIZATION.md Troubleshooting section and `docs/roundtrip-protocol.md` for full detail

Both changes are documentation-only — no TypeScript, no behavior changes, no new helpers.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (67 files, 1080 tests)
- [x] `pnpm bundle:skills` runs cleanly and updates bundled copies

Closes #462
Closes #464

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))