### PR TITLE
feat: feat(skill): gotcha-survey — match question language to user's conversation language

### DIFF
--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -52,6 +52,16 @@ If `isReadyForCodeGen` is `true` or `questions` is empty:
 - Do NOT write to `.claude/skills/canicode-gotchas/SKILL.md`.
 - Stop here.
 
+### Step 3 — preamble: match the user's language
+
+Before rendering any question, detect the user's conversation language from their recent messages in **this** session. Korean vs. English vs. other is usually unambiguous; when ambiguous, default to English and ask the user once which language they prefer.
+
+When the user's language is non-English, localize only the **human-readable** strings rendered in the prompt templates below: the `question` text, the `why` line (if shown), the `Hint:` body, the `Example:` body, and the batch shared-prompt wording — including the "Reply with one answer to apply to all …, or **split** to answer each individually" sentence and the `skip` / `n/a` affordance sentence that follows it. Translate at render time only; the rule templates in `core/rules/*` stay English-only per CLAUDE.md and the issue's "Out of scope" list — do not rewrite source.
+
+Keep the following English even when localizing, because they are identifiers or structural markers that downstream tools grep for: `ruleId`, `nodeId`, `nodeName`, the severity label in brackets (`[blocking]`, `[risk]`, `[missing-info]`, `[suggestion]`), and the entire markdown scaffolding of the Step 4 upsert section (`## #NNN — …` headings, `Design key`, `#### Skipped (N)`, the per-record field labels). `renderGotchaSection` is the source of truth for that on-disk markdown (ADR-016) and its output stays English.
+
+In Step 4, pass the user's answer through **verbatim** into the `answers[<nodeId>].answer` field — do **not** back-translate answers to English. `figma-implement-design` is cross-language by design (see #461), and a round-trip to English introduces translation loss and defeats the "shared language for designer/PM" framing.
+
 ### Step 3: Present questions to the user
 
 The survey response carries a pre-computed `groupedQuestions.groups[].batches[]` shape so this skill never has to sort, partition, or maintain a batchable-rule whitelist in prose. The sort key, `_no-source` sentinel, and batchable-rule list all live in `core/gotcha/group-and-batch-questions.ts` with vitest coverage (per ADR-016). Iterate over it:

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -95,6 +95,10 @@ npx canicode gotcha-survey "<figma-url>" --json
 
 If `questions` is empty, skip to **Step 6**.
 
+#### Step 3 — preamble: match the user's language
+
+Detect the user's conversation language from their recent messages in **this** session (Korean vs. English vs. other is usually unambiguous; when ambiguous, default to English and ask once). When the user's language is non-English, localize only the human-readable rendering of questions, `why`, `Hint:`, `Example:`, and the batch shared-prompt wording (including the `split` / `skip` / `n/a` affordance sentence). Keep identifiers and structural markers English: `ruleId`, `nodeId`, severity label in brackets, and the entire upsert-section markdown scaffolding (`## #NNN — …`, `Design key`, `#### Skipped (N)`) — downstream tools grep these, and `renderGotchaSection` is the source of truth for on-disk markdown (ADR-016). In the Appendix Step 3 upsert, pass the user's answer through **verbatim** into `answers[<nodeId>].answer`; do **not** back-translate — `figma-implement-design` is cross-language by design (#461). See `.claude/skills/canicode-gotchas/SKILL.md` Step 3 preamble for the full rule.
+
 #### Step 3 — grouped survey (`groupedQuestions`)
 
 Iterate `groupedQuestions.groups[].batches[]`. Instance notes, batch prompts, replicas, split/skip/n/a, stdin upsert — **[Appendix Step 3](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md#appendix--step-3-grouped-survey-groupedquestions)**. Per ADR-016, do not re-implement grouping.


### PR DESCRIPTION
## Summary

Add a prose-only language-awareness instruction to the two gotcha-collection skills so question/hint/example text is localized to the user's conversation language before presentation, while preserving English rule templates in source and accepting non-English user answers verbatim into the upsert payload. Scope is limited to two SKILL.md files under `.claude/skills/`; cursor copies are regenerated by `scripts/bundle-skills.sh` + `scripts/strip-cursor-gotcha-skill.mjs` at build time, so no separate cursor edits are needed.

## Tasks

- Add language-aware presentation sub-step to canicode-gotchas SKILL.md
- Add the same language-aware preamble to canicode-roundtrip SKILL.md Step 3

## Self-review

Prose-only change fully aligned with plan intent and issue scope. Both SKILL.md files now carry a language-aware preamble at the correct placement (after the Step 2 gate, before question rendering), preserve English identifiers and on-disk markdown scaffolding (ADR-016), and keep user answers verbatim per #461. No source code touched, no Cursor copies hand-edited (correctly deferred to `scripts/bundle-skills.sh` + `strip-cursor-gotcha-skill.mjs`). One minor readability suggestion on the duplicated `### Step 3` heading in canicode-gotchas.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 1

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #466

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))