### PR TITLE
feat: feat(skill): allow bulk answer across same-rule repeated gotchas

### DIFF
--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -56,6 +56,23 @@ If `isReadyForCodeGen` is `true` or `questions` is empty:
 
 The survey response carries a pre-computed `groupedQuestions.groups[].batches[]` shape so this skill never has to sort, partition, or maintain a batchable-rule whitelist in prose. The sort key, `_no-source` sentinel, and both batchable-rule lists (`BATCHABLE_RULE_IDS` for `safe` mode, `OPT_IN_BATCHABLE_RULE_IDS` for `opt-in` mode) all live in `core/gotcha/group-and-batch-questions.ts` with vitest coverage (per ADR-016). Iterate over it:
 
+**Before presenting the first batch**, display this shortcut notice once so the user knows they can exit early at any point:
+
+```
+Survey: {totalBatchCount} question(s) to answer.
+Tip: reply `skip remaining` at any point to bypass the rest with a default no-op annotation and finish immediately.
+```
+
+Where `totalBatchCount` is `groupedQuestions.groups.flatMap((g) => g.batches).length`.
+
+**After every 3rd batch** (i.e. after batches 3, 6, 9, …), re-surface the shortcut as a brief reminder before presenting the next batch:
+
+```
+(You can still reply `skip remaining` to bypass the remaining questions.)
+```
+
+When the user replies `skip remaining` at any point during Step 3, immediately treat all unanswered batches as skipped (`{ "skipped": true }` for each unanswered `nodeId`) and proceed directly to Step 4 without asking further questions.
+
 For every `batch` in `groupedQuestions.groups.flatMap((g) => g.batches)`, branch on `batch.batchMode`:
 
 - **`batch.batchMode === "none"`** — single-question batch; the helper guarantees `batch.questions.length === 1`. Render the standard prompt for `batch.questions[0]`:
@@ -112,6 +129,7 @@ Wait for the user's answer before moving to the next batch. The user may:
 - Say **split** (batch only) to fall back to per-question prompting for that batch — works the same for both `safe` and `opt-in` batches
 - Say **skip** to skip the question / the entire batch
 - Say **n/a** if the question / the entire batch is not applicable
+- Say **skip remaining** to immediately skip all remaining unanswered batches and proceed to Step 4
 
 When applying the batched answer, expand back to per-question records in Step 4 — the gotcha section format stores one record per `nodeId`.
 

--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -54,11 +54,11 @@ If `isReadyForCodeGen` is `true` or `questions` is empty:
 
 ### Step 3: Present questions to the user
 
-The survey response carries a pre-computed `groupedQuestions.groups[].batches[]` shape so this skill never has to sort, partition, or maintain a batchable-rule whitelist in prose. The sort key, `_no-source` sentinel, and batchable-rule list all live in `core/gotcha/group-and-batch-questions.ts` with vitest coverage (per ADR-016). Iterate over it:
+The survey response carries a pre-computed `groupedQuestions.groups[].batches[]` shape so this skill never has to sort, partition, or maintain a batchable-rule whitelist in prose. The sort key, `_no-source` sentinel, and both batchable-rule lists (`BATCHABLE_RULE_IDS` for `safe` mode, `OPT_IN_BATCHABLE_RULE_IDS` for `opt-in` mode) all live in `core/gotcha/group-and-batch-questions.ts` with vitest coverage (per ADR-016). Iterate over it:
 
-For every `batch` in `groupedQuestions.groups.flatMap((g) => g.batches)`:
+For every `batch` in `groupedQuestions.groups.flatMap((g) => g.batches)`, branch on `batch.batchMode`:
 
-- **Single-question batch (`batch.questions.length === 1`)** — render the standard prompt for `batch.questions[0]`:
+- **`batch.batchMode === "none"`** — single-question batch; the helper guarantees `batch.questions.length === 1`. Render the standard prompt for `batch.questions[0]`:
 
   ```
   **[{severity}] {ruleId}** — node: {nodeName}
@@ -69,7 +69,7 @@ For every `batch` in `groupedQuestions.groups.flatMap((g) => g.batches)`:
   > Example: {example}
   ```
 
-- **Batch of N ≥ 2 with `batch.batchable === true`** (#369) — render one shared prompt covering every member:
+- **`batch.batchMode === "safe"` with `batch.questions.length >= 2`** (#369) — rule in `BATCHABLE_RULE_IDS`; one answer is uniformly applicable. Render one shared prompt:
 
   ```
   **[{severity}] {ruleId}** — {batch.questions.length} instances:
@@ -87,11 +87,29 @@ For every `batch` in `groupedQuestions.groups.flatMap((g) => g.batches)`:
 
   Where `sharedQuestionPrompt` reuses the rule's `question` text with the per-node noun replaced by the rule's plural noun (e.g. "These layers all use FILL sizing without min/max constraints. What size boundaries should they share?" instead of repeating the singular phrasing N times).
 
-- **Any batch with `batch.batchable === false`** is always rendered as a single-question prompt — the helper guarantees `questions.length === 1` for those (identity-typed answers like `non-semantic-name`, structural-mod rules).
+- **`batch.batchMode === "opt-in"` with `batch.questions.length >= 2`** (#426) — rule in `OPT_IN_BATCHABLE_RULE_IDS` (currently `missing-prototype`). The same answer is usually shareable across siblings but may legitimately differ per node — signal that explicitly so the user can opt out of the shared answer with `split`:
+
+  ```
+  **[{severity}] {batch.ruleId}** — {batch.questions.length} instances of the same rule:
+    - {nodeName₁}
+    - {nodeName₂}
+    - …
+
+  {sharedQuestionPrompt}
+
+  Apply this answer to all {batch.questions.length} occurrences of `{batch.ruleId}`, or reply **split** to answer each individually.
+
+  > Hint: {hint}
+  > Example: {example}
+  ```
+
+  Unlike `safe` batches, the prompt frames the answer as a suggested default, not a uniform truth — reuse the rule's existing `example` (e.g. `missing-prototype`'s "navigates to `/product/{id}` detail page") so the user knows the answer can be a pattern, not a literal string shared character-for-character.
+
+- **Single-member `safe` or `opt-in` batch (`batch.questions.length === 1`)** — render the single-question template above; the shared-prompt framing collapses to the rule's own wording when there is only one node.
 
 Wait for the user's answer before moving to the next batch. The user may:
-- Answer the question / batch directly
-- Say **split** (batch only) to fall back to per-question prompting for that batch
+- Answer the question / batch directly (single value or pattern covers all batch members)
+- Say **split** (batch only) to fall back to per-question prompting for that batch — works the same for both `safe` and `opt-in` batches
 - Say **skip** to skip the question / the entire batch
 - Say **n/a** if the question / the entire batch is not applicable
 

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -97,7 +97,7 @@ If `questions` is empty, skip to **Step 6**.
 
 #### Step 3 — grouped survey (`groupedQuestions`)
 
-Iterate `groupedQuestions.groups[].batches[]` and branch on `batch.batchMode` (`"safe"` — one uniform answer, `"opt-in"` — shared answer offered as default with per-node `split` override (#426), `"none"` — single-question). Instance notes, batch prompt templates per mode, replicas, split/skip/n/a, stdin upsert — **[Appendix Step 3](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md#appendix--step-3-grouped-survey-groupedquestions)**. Per ADR-016, do not re-implement grouping.
+Iterate `groupedQuestions.groups[].batches[]` and branch on `batch.batchMode` (`"safe"` — one uniform answer, `"opt-in"` — shared answer offered as default with per-node `split` override (#426), `"none"` — single-question). Instance notes, batch prompt templates per mode, replicas, split/skip/n/a, "skip remaining" early-exit affordance (surface before the first batch, re-surface every 3rd), stdin upsert — **[Appendix Step 3](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md#appendix--step-3-grouped-survey-groupedquestions)**. Per ADR-016, do not re-implement grouping.
 
 
 ### Step 4: Apply gotcha answers to Figma design

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -97,7 +97,7 @@ If `questions` is empty, skip to **Step 6**.
 
 #### Step 3 — grouped survey (`groupedQuestions`)
 
-Iterate `groupedQuestions.groups[].batches[]`. Instance notes, batch prompts, replicas, split/skip/n/a, stdin upsert — **[Appendix Step 3](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md#appendix--step-3-grouped-survey-groupedquestions)**. Per ADR-016, do not re-implement grouping.
+Iterate `groupedQuestions.groups[].batches[]` and branch on `batch.batchMode` (`"safe"` — one uniform answer, `"opt-in"` — shared answer offered as default with per-node `split` override (#426), `"none"` — single-question). Instance notes, batch prompt templates per mode, replicas, split/skip/n/a, stdin upsert — **[Appendix Step 3](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md#appendix--step-3-grouped-survey-groupedquestions)**. Per ADR-016, do not re-implement grouping.
 
 
 ### Step 4: Apply gotcha answers to Figma design

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -140,7 +140,7 @@ Every gotcha-survey question (and every entry in `analyzeResult.issues[]`) carri
 
 #### Instance-child matrix, annotation enum matrix, write tiers, probe, helpers
 
-Full tables, Experiment 08/09 references, definition-write probe branches, and the bundled `CanICodeRoundtrip` API catalogue live in [`docs/roundtrip-protocol.md`](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md) on `main`. Open it when you need the matrices or helper list — do not re-derive write rules from memory (ADR-016).
+Full tables, Experiment 08/09 references, definition-write probe branches, the `suggestedDefaultApply` threshold heuristic for the picker (#428), and the bundled `CanICodeRoundtrip` API catalogue live in [`docs/roundtrip-protocol.md`](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md) on `main`. Open it when you need the matrices or helper list — do not re-derive write rules from memory (ADR-016).
 
 #### Strategy A: Property Modification — apply directly
 

--- a/docs/roundtrip-protocol.md
+++ b/docs/roundtrip-protocol.md
@@ -223,11 +223,29 @@ For each `batch` inside the group:
 
 - **`batch.batchMode === "none"`** is always rendered as a single-question prompt — the helper guarantees `questions.length === 1` for those (identity-typed answers like `non-semantic-name`, structural-mod rules, and anything not in either whitelist).
 
+**Before presenting the first batch**, display this shortcut notice once so the user knows they can exit early:
+
+```
+Survey: {totalBatchCount} question(s) to answer.
+Tip: reply `skip remaining` at any point to bypass the rest with a default no-op annotation and finish immediately.
+```
+
+Where `totalBatchCount` is `groupedQuestions.groups.flatMap((g) => g.batches).length`.
+
+**After every 3rd batch** (i.e. after batches 3, 6, 9, …), re-surface the shortcut as a brief reminder before presenting the next batch:
+
+```
+(You can still reply `skip remaining` to bypass the remaining questions.)
+```
+
+When the user replies `skip remaining` at any point during Step 3, immediately treat all unanswered batches as skipped (`{ "skipped": true }` for each unanswered `nodeId`) and proceed directly to Step 4 without asking further questions.
+
 Wait for the user's answer before moving to the next batch. For each batch, the user may:
 - Answer the question directly (single value covers all batch members)
 - Say **split** (batch only) to fall back to per-question prompting for that batch
 - Say **skip** to skip the question / the entire batch
 - Say **n/a** if the question / the entire batch is not applicable
+- Say **skip remaining** to immediately skip all remaining unanswered batches and proceed to Step 4
 
 When applying the batched answer, expand back to per-question records before storing — the gotcha section format and Step 4 apply loop both expect one record per `nodeId`.
 

--- a/docs/roundtrip-protocol.md
+++ b/docs/roundtrip-protocol.md
@@ -135,7 +135,12 @@ The naive "one-question-at-a-time" loop produces two well-known UX failures on r
 - **Repeated Instance note (#370)** — when 10 consecutive questions share the same `instanceContext.sourceComponentId`, the standard "_Instance note: …source component **X**…_" paragraph prints 10 times. After the first occurrence it adds zero new information and consumes ~2 screens of vertical space.
 - **Repeated identical answer (#369)** — when 7 consecutive questions all carry the same `ruleId` (e.g. `missing-size-constraint`) and the user's reasonable answer would be the same for all of them (e.g. `min-width: 320px, max-width: 1200px`), the user types the same thing 7 times in a row.
 
-`gotcha-survey` already ships the resolution on its `groupedQuestions` field. Sort key (`(sourceComponentId ?? "_no-source", ruleId, nodeName)`), source-component grouping, and the batchable-rule whitelist (`missing-size-constraint`, `irregular-spacing`, `no-auto-layout`, `fixed-size-in-auto-layout`) all live in `core/gotcha/group-and-batch-questions.ts` with vitest coverage. Per ADR-016, do **not** re-implement the sort, partition, or whitelist in prose — iterate over `groupedQuestions.groups[].batches[]` directly.
+`gotcha-survey` already ships the resolution on its `groupedQuestions` field. Sort key (`(sourceComponentId ?? "_no-source", ruleId, nodeName)`), source-component grouping, and both batchable-rule whitelists all live in `core/gotcha/group-and-batch-questions.ts` with vitest coverage:
+
+- **`BATCHABLE_RULE_IDS`** (`safe` batch mode — one uniform answer by definition): `missing-size-constraint`, `irregular-spacing`, `no-auto-layout`, `fixed-size-in-auto-layout`.
+- **`OPT_IN_BATCHABLE_RULE_IDS`** (`opt-in` batch mode — shared answer offered as a default with per-node override via `split`): `missing-prototype` (#426).
+
+Each batch carries a pre-computed `batchMode: "safe" | "opt-in" | "none"` so the prompt template branches without re-deriving the whitelist in prose. Per ADR-016, do **not** re-implement the sort, partition, or whitelists in prose — iterate over `groupedQuestions.groups[].batches[]` directly.
 
 #### Step 3b: Prompt each group, then each batch within it
 
@@ -169,7 +174,7 @@ For each `batch` inside the group:
   _Replicas: This question represents **{replicas} instances** of the same source-component child sharing the same rule. Your single answer will be applied to all of them in Step 4 (one annotation/write per instance scene)._
   ```
 
-- **`batch.questions.length >= 2 && batch.batchable === true`** (#369) — render one batch prompt covering all members. Use `batch.totalScenes` (already summed across each member's `replicas`) for the Figma-scene fan-out hint:
+- **`batch.batchMode === "safe"` && `batch.questions.length >= 2`** (#369) — every member's answer is uniformly applicable (rule in `BATCHABLE_RULE_IDS`). Render one batch prompt covering all members. Use `batch.totalScenes` (already summed across each member's `replicas`) for the Figma-scene fan-out hint:
 
   ```
   **[{severity}] {batch.ruleId}** — {batch.questions.length} instances:
@@ -196,7 +201,27 @@ For each `batch` inside the group:
   _Replicas: your one answer will land on **{batch.totalScenes}** Figma scenes total in Step 4 (some of these {batch.questions.length} questions already represent multiple instances of the same source-component child)._
   ```
 
-- **`batch.batchable === false`** is always rendered as a single-question prompt — the helper guarantees `questions.length === 1` for those (identity-typed answers like `non-semantic-name`, structural-mod rules).
+- **`batch.batchMode === "opt-in"` && `batch.questions.length >= 2`** (#426) — rule in `OPT_IN_BATCHABLE_RULE_IDS` (currently `missing-prototype`). The shared answer is offered as a suggested default rather than a uniform truth, because the per-node specifics (target routes, modals vs pages, etc.) may legitimately diverge. Render a variant header that calls out the opt-in framing explicitly:
+
+  ```
+  **[{severity}] {batch.ruleId}** — {batch.questions.length} instances of the same rule:
+    - {nodeName₁}{ruleSpecificContext₁}
+    - {nodeName₂}{ruleSpecificContext₂}
+    - …
+
+  {sharedQuestionPrompt}
+
+  Apply this answer to all {batch.questions.length} occurrences of `{batch.ruleId}`, or reply **split** to answer each individually.
+
+  > Hint: {hint}
+  > Example: {example}
+  ```
+
+  Reuse the rule's existing `example` (e.g. for `missing-prototype`, "navigates to `/product/{id}` detail page") so the user knows the shared answer can be a **pattern** that templates per-node specifics in Step 4 — not a literal string copied character-for-character to every node. The same `split` / `skip` / `n/a` verbs apply; no new vocabulary.
+
+  When `batch.totalScenes > batch.questions.length`, append the same `_Replicas:_` note as the `safe` branch so the user knows the fan-out count.
+
+- **`batch.batchMode === "none"`** is always rendered as a single-question prompt — the helper guarantees `questions.length === 1` for those (identity-typed answers like `non-semantic-name`, structural-mod rules, and anything not in either whitelist).
 
 Wait for the user's answer before moving to the next batch. For each batch, the user may:
 - Answer the question directly (single value covers all batch members)

--- a/docs/roundtrip-protocol.md
+++ b/docs/roundtrip-protocol.md
@@ -51,6 +51,13 @@ The helper walks the tiers in order; variable binding is an alternative writeFn 
 
 **Confirmation is a batch-level concern — and only needed when opting in.** A `use_figma` call runs one JavaScript batch and cannot pause mid-batch for user input. Under the ADR-012 default (`allowDefinitionWrite: false`), no propagation happens, so no confirmation is required — override-errors annotate and move on. The orchestrator sets `allowDefinitionWrite: true` only after enumerating the likely propagation set to the user up-front and collecting **one confirmation for the whole batch** that names the source component(s) and the affected instance set. When describing impact, note that the write reaches every **non-overridden** instance — any instance with a local override for the same property keeps its override. The helper below never prompts — it assumes that if the flag is on, confirmation already happened.
 
+**Threshold heuristic — when to surface the picker (#428).** The `allowDefinitionWrite` opt-in flow is over-engineered for tiny surveys. Use `survey.suggestedDefaultApply` (a boolean computed server-side by `generateGotchaSurvey`) to gate the picker:
+
+- **`survey.suggestedDefaultApply === false`** (fewer than 3 instance-child questions in the survey) — skip the picker entirely and call the helpers with the default `allowDefinitionWrite: false`. Every override-error routes to a scene annotation per ADR-012. Do not ask the user about propagation.
+- **`survey.suggestedDefaultApply === true`** (3 or more instance-child questions) — surface the pre-flight probe and picker as usual. The threshold is `propagationCandidates >= 3` where `propagationCandidates = questions.filter(q => q.isInstanceChild).length`.
+
+The skill may still override this hint — for example, when `probeDefinitionWritability` returns `allUnwritable === true`, drop to annotate-only regardless of `suggestedDefaultApply`.
+
 **Pre-flight writability probe (#357).** Before showing the user the Definition write picker, call `CanICodeRoundtrip.probeDefinitionWritability(questions)` inside a small `use_figma` batch. The probe loads every distinct `sourceChildId` once and classifies it as writable or unwritable using the same detection as the runtime fallback (Experiment 10 `remote === true` and Experiment 11 unresolved-`null`). The result decides which version of the picker to show:
 
 ```javascript

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -107,13 +107,17 @@ export type GotchaSurveyQuestion = z.infer<typeof GotchaSurveyQuestionSchema>;
 export const SurveyQuestionBatchSchema = z.object({
   ruleId: z.string(),
   /**
-   * `true` when every member shares an answer-shape uniformly applicable to
-   * all of them (e.g. one `min-width` value covers all FILL children).
-   * The SKILL renders one shared prompt for `batchable: true` batches with
-   * `questions.length >= 2`; everything else falls through to the
-   * single-question template.
+   * Rendering mode for this batch (see `BatchMode` in
+   * `src/core/gotcha/group-and-batch-questions.ts` — the authoritative
+   * whitelists `BATCHABLE_RULE_IDS` and `OPT_IN_BATCHABLE_RULE_IDS` live
+   * there):
+   * - `"safe"` — one answer uniformly applies to every member (#369).
+   * - `"opt-in"` — one shared answer is a suggested default; the user may
+   *   reply `split` for per-node override (#426).
+   * - `"none"` — single-member batch, renders the standard per-question
+   *   template.
    */
-  batchable: z.boolean(),
+  batchMode: z.enum(["safe", "opt-in", "none"]),
   questions: z.array(GotchaSurveyQuestionSchema),
   /**
    * Sum of `max(question.replicas, 1)` across `questions`. Counts the

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -161,6 +161,20 @@ export const GotchaSurveySchema = z.object({
    * prose no longer parses URLs (per ADR-016).
    */
   designKey: z.string(),
+  /**
+   * #428 — threshold hint for the `allowDefinitionWrite` picker in the
+   * `canicode-roundtrip` skill. `true` when `propagationCandidates >= 3`
+   * (i.e. three or more questions target instance children that could
+   * benefit from definition-level writes). When `false`, the skill silently
+   * uses the annotation default (ADR-012) without surfacing the picker —
+   * the opt-in flow is over-engineered for tiny surveys.
+   *
+   * Computed server-side from `questions` so the skill doesn't have to
+   * count `isInstanceChild` manually; the skill may still override this
+   * hint when it has additional context (e.g. all candidates are
+   * read-only per probe result).
+   */
+  suggestedDefaultApply: z.boolean(),
 });
 
 export type GotchaSurvey = z.infer<typeof GotchaSurveySchema>;

--- a/src/core/gotcha/group-and-batch-questions.test.ts
+++ b/src/core/gotcha/group-and-batch-questions.test.ts
@@ -1,6 +1,7 @@
 import type { GotchaSurveyQuestion } from "../contracts/gotcha-survey.js";
 import {
   BATCHABLE_RULE_IDS,
+  OPT_IN_BATCHABLE_RULE_IDS,
   groupAndBatchSurveyQuestions,
 } from "./group-and-batch-questions.js";
 
@@ -53,6 +54,23 @@ describe("BATCHABLE_RULE_IDS", () => {
     expect(BATCHABLE_RULE_IDS).not.toContain("non-semantic-name");
     expect(BATCHABLE_RULE_IDS).not.toContain("missing-component");
     expect(BATCHABLE_RULE_IDS).not.toContain("non-layout-container");
+  });
+});
+
+describe("OPT_IN_BATCHABLE_RULE_IDS", () => {
+  it("contains missing-prototype (#426)", () => {
+    expect(OPT_IN_BATCHABLE_RULE_IDS).toEqual(["missing-prototype"]);
+  });
+
+  it("does not list identity-typed rules whose answer differs per node", () => {
+    expect(OPT_IN_BATCHABLE_RULE_IDS).not.toContain("non-semantic-name");
+    expect(OPT_IN_BATCHABLE_RULE_IDS).not.toContain("missing-component");
+  });
+
+  it("is disjoint from BATCHABLE_RULE_IDS so each rule has exactly one batchMode", () => {
+    for (const id of OPT_IN_BATCHABLE_RULE_IDS) {
+      expect(BATCHABLE_RULE_IDS).not.toContain(id);
+    }
   });
 });
 
@@ -156,7 +174,7 @@ describe("groupAndBatchSurveyQuestions", () => {
 
     const group = result.groups[0]!;
     expect(group.batches).toHaveLength(1);
-    expect(group.batches[0]?.batchable).toBe(true);
+    expect(group.batches[0]?.batchMode).toBe("safe");
     expect(group.batches[0]?.questions.map((q) => q.nodeId)).toEqual([
       "1",
       "2",
@@ -186,7 +204,110 @@ describe("groupAndBatchSurveyQuestions", () => {
 
     const group = result.groups[0]!;
     expect(group.batches).toHaveLength(2);
-    expect(group.batches.every((b) => b.batchable === false)).toBe(true);
+    expect(group.batches.every((b) => b.batchMode === "none")).toBe(true);
+    expect(group.batches.every((b) => b.questions.length === 1)).toBe(true);
+  });
+
+  it("collapses consecutive missing-prototype siblings into one opt-in batch (#426)", () => {
+    const ctx = {
+      parentInstanceNodeId: "p:A",
+      sourceNodeId: "src:A",
+      sourceComponentId: "comp:A",
+      sourceComponentName: "ProductCard",
+    };
+    const result = groupAndBatchSurveyQuestions([
+      makeQuestion({
+        nodeId: "card-1",
+        nodeName: "card-1",
+        ruleId: "missing-prototype",
+        instanceContext: ctx,
+      }),
+      makeQuestion({
+        nodeId: "card-2",
+        nodeName: "card-2",
+        ruleId: "missing-prototype",
+        instanceContext: ctx,
+      }),
+      makeQuestion({
+        nodeId: "card-3",
+        nodeName: "card-3",
+        ruleId: "missing-prototype",
+        instanceContext: ctx,
+      }),
+    ]);
+
+    const group = result.groups[0]!;
+    expect(group.batches).toHaveLength(1);
+    const batch = group.batches[0]!;
+    expect(batch.batchMode).toBe("opt-in");
+    expect(batch.ruleId).toBe("missing-prototype");
+    expect(batch.questions.map((q) => q.nodeId)).toEqual([
+      "card-1",
+      "card-2",
+      "card-3",
+    ]);
+    expect(batch.totalScenes).toBe(3);
+  });
+
+  it("sums replicas into totalScenes on opt-in batches the same way as safe batches", () => {
+    const ctx = {
+      parentInstanceNodeId: "p:A",
+      sourceNodeId: "src:A",
+      sourceComponentId: "comp:A",
+    };
+    const result = groupAndBatchSurveyQuestions([
+      makeQuestion({
+        nodeId: "1",
+        ruleId: "missing-prototype",
+        instanceContext: ctx,
+        replicas: 4,
+        replicaNodeIds: ["1a", "1b", "1c"],
+      }),
+      makeQuestion({
+        nodeId: "2",
+        ruleId: "missing-prototype",
+        instanceContext: ctx,
+      }),
+    ]);
+
+    const batch = result.groups[0]!.batches[0]!;
+    expect(batch.batchMode).toBe("opt-in");
+    expect(batch.questions).toHaveLength(2);
+    expect(batch.totalScenes).toBe(4 + 1);
+  });
+
+  it("emits safe / opt-in / none batches side by side when a group mixes all three modes", () => {
+    const ctx = {
+      parentInstanceNodeId: "p:A",
+      sourceNodeId: "src:A",
+      sourceComponentId: "comp:A",
+    };
+    const result = groupAndBatchSurveyQuestions([
+      makeQuestion({
+        nodeId: "1",
+        ruleId: "missing-size-constraint",
+        instanceContext: ctx,
+      }),
+      makeQuestion({
+        nodeId: "2",
+        ruleId: "missing-prototype",
+        instanceContext: ctx,
+      }),
+      makeQuestion({
+        nodeId: "3",
+        ruleId: "non-semantic-name",
+        instanceContext: ctx,
+      }),
+    ]);
+
+    const group = result.groups[0]!;
+    // Batches are laid out in ruleId sort order: missing-prototype,
+    // missing-size-constraint, non-semantic-name.
+    expect(group.batches.map((b) => [b.ruleId, b.batchMode])).toEqual([
+      ["missing-prototype", "opt-in"],
+      ["missing-size-constraint", "safe"],
+      ["non-semantic-name", "none"],
+    ]);
     expect(group.batches.every((b) => b.questions.length === 1)).toBe(true);
   });
 

--- a/src/core/gotcha/group-and-batch-questions.ts
+++ b/src/core/gotcha/group-and-batch-questions.ts
@@ -25,20 +25,62 @@ export const BATCHABLE_RULE_IDS = [
   "fixed-size-in-auto-layout",
 ] as const satisfies readonly RuleId[];
 
+/**
+ * Rules whose answer is **usually** shareable across same-rule siblings but
+ * may legitimately differ per node — so batching is offered as an opt-in
+ * default with a per-node override escape hatch (the existing `split` verb).
+ *
+ * #426: `missing-prototype` on 9 sibling product cards produces 9 near-
+ * identical "Where does this navigate?" prompts. A single shared answer (e.g.
+ * "navigates to `/product/{id}` detail page") usually fits all of them — but
+ * the user can reply `split` to answer each individually when, e.g., one card
+ * opens a modal instead of a route.
+ *
+ * Unlike `BATCHABLE_RULE_IDS` (safe-mode — one uniform answer by definition),
+ * opt-in members are rendered with an "Apply this answer to all N?" header
+ * so the user knows the shared answer is a suggested default, not a uniform
+ * truth. Grow this list one rule at a time with a justifying commit message —
+ * same cadence `BATCHABLE_RULE_IDS` follows. Per ADR-016, the whitelist lives
+ * here (vitest-covered) and the SKILL.md prose cites it rather than
+ * duplicating it.
+ */
+export const OPT_IN_BATCHABLE_RULE_IDS = [
+  "missing-prototype",
+] as const satisfies readonly RuleId[];
+
 const BATCHABLE_SET: ReadonlySet<string> = new Set(BATCHABLE_RULE_IDS);
+const OPT_IN_BATCHABLE_SET: ReadonlySet<string> = new Set(
+  OPT_IN_BATCHABLE_RULE_IDS,
+);
 
 const NO_SOURCE_SENTINEL = "_no-source";
+
+/**
+ * Tri-state batch rendering mode consumed by `canicode-gotchas` /
+ * `canicode-roundtrip` Step 3:
+ *
+ * - `"safe"` — rule is in `BATCHABLE_RULE_IDS`. One answer covers every
+ *   member by definition (#369).
+ * - `"opt-in"` — rule is in `OPT_IN_BATCHABLE_RULE_IDS`. One shared answer is
+ *   offered as a suggested default; the user can reply `split` for per-node
+ *   override (#426).
+ * - `"none"` — rule is in neither whitelist. The helper emits the question as
+ *   its own single-member batch; same-rule repeats stay separate so the SKILL
+ *   always renders the single-question template.
+ */
+export type BatchMode = "safe" | "opt-in" | "none";
 
 export interface SurveyQuestionBatch {
   ruleId: string;
   /**
-   * `true` when every member's answer is uniformly applicable (rule is in
-   * `BATCHABLE_RULE_IDS`). The SKILL still emits a single-question prompt
-   * when `questions.length === 1`, but the flag stays useful: a batch of one
-   * for a batchable rule keeps the prompt template aligned with subsequent
-   * batches in the same group.
+   * Rendering mode for this batch. `"safe"` and `"opt-in"` both imply
+   * `questions.length >= 1` with a shared-prompt template; the difference is
+   * whether the shared answer is uniform (`safe`) or a suggested default with
+   * a per-node override escape hatch (`opt-in`). `"none"` guarantees
+   * `questions.length === 1` — same-rule repeats for non-batchable rules do
+   * not merge.
    */
-  batchable: boolean;
+  batchMode: BatchMode;
   questions: GotchaSurveyQuestion[];
   /**
    * Sum of `max(question.replicas, 1)` across members. Counts the actual
@@ -140,14 +182,14 @@ function pushIntoBatch(
   question: GotchaSurveyQuestion,
 ): void {
   const sceneWeight = Math.max(question.replicas ?? 1, 1);
-  const isBatchable = BATCHABLE_SET.has(question.ruleId);
+  const batchMode = resolveBatchMode(question.ruleId);
   const last = group.batches.at(-1);
 
   if (
     last !== undefined &&
     last.ruleId === question.ruleId &&
-    isBatchable &&
-    last.batchable
+    batchMode !== "none" &&
+    last.batchMode === batchMode
   ) {
     last.questions.push(question);
     last.totalScenes += sceneWeight;
@@ -156,8 +198,14 @@ function pushIntoBatch(
 
   group.batches.push({
     ruleId: question.ruleId,
-    batchable: isBatchable,
+    batchMode,
     questions: [question],
     totalScenes: sceneWeight,
   });
+}
+
+function resolveBatchMode(ruleId: string): BatchMode {
+  if (BATCHABLE_SET.has(ruleId)) return "safe";
+  if (OPT_IN_BATCHABLE_SET.has(ruleId)) return "opt-in";
+  return "none";
 }

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -1386,4 +1386,124 @@ describe("generateGotchaSurvey", () => {
       expect(result.success).toBe(true);
     });
   });
+
+  // ============================================
+  // #428 suggestedDefaultApply threshold
+  // ============================================
+
+  describe("suggestedDefaultApply (#428)", () => {
+    it("is false when there are no instance-child questions", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "no-auto-layout",
+          category: "pixel-critical",
+          severity: "blocking",
+          nodeId: "1:1",
+          nodePath: "Root > Hero",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(makeResult(issues), makeScoreReport("D"));
+
+      expect(survey.suggestedDefaultApply).toBe(false);
+    });
+
+    it("is false when fewer than 3 instance-child questions are present", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:11111",
+          nodePath: "Root > Card A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:22222",
+          nodePath: "Root > Card A > Subtitle",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(makeResult(issues), makeScoreReport("D"));
+
+      // 2 instance-child questions — below the threshold of 3
+      expect(survey.suggestedDefaultApply).toBe(false);
+    });
+
+    it("is true when 3 or more instance-child questions are present", () => {
+      const document: AnalysisNode = {
+        id: "0:1",
+        name: "Document",
+        type: "DOCUMENT",
+        visible: true,
+        children: [
+          {
+            id: "100:1",
+            name: "Card A",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+          {
+            id: "100:2",
+            name: "Card B",
+            type: "INSTANCE",
+            visible: true,
+            componentId: "C:1",
+          },
+        ],
+      };
+      const components = {
+        "C:1": { key: "k1", name: "Card", description: "" },
+      };
+      // Three distinct instance-child questions (different sourceNodeIds so
+      // source-component dedupe keeps them separate — each counts individually).
+      const issues = [
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:11111",
+          nodePath: "Root > Card A > Title",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:22222",
+          nodePath: "Root > Card A > Subtitle",
+          subType: "wrap",
+        }),
+        makeIssue({
+          ruleId: "missing-size-constraint",
+          category: "responsive-critical",
+          severity: "risk",
+          nodeId: "I100:1;2143:33333",
+          nodePath: "Root > Card A > Body",
+          subType: "wrap",
+        }),
+      ];
+
+      const survey = generateGotchaSurvey(
+        makeResult(issues, { document, components }),
+        makeScoreReport("D"),
+      );
+
+      // 3 instance-child questions — meets the threshold
+      expect(survey.suggestedDefaultApply).toBe(true);
+    });
+
+    it("is included in the GotchaSurveySchema output for zero-issue surveys", () => {
+      const survey = generateGotchaSurvey(makeResult([]), makeScoreReport("S"));
+
+      expect(typeof survey.suggestedDefaultApply).toBe("boolean");
+      const result = GotchaSurveySchema.safeParse(survey);
+      expect(result.success).toBe(true);
+    });
+  });
 });

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -79,12 +79,25 @@ export function generateGotchaSurvey(
   // logic in prose. ADR-016.
   const groupedQuestions = groupAndBatchSurveyQuestions(questions);
 
+  // Step 7 (#428): compute the threshold hint for the `allowDefinitionWrite`
+  // picker. Count questions that target instance children — these are the only
+  // candidates that benefit from definition-level writes. When fewer than 3
+  // propagation candidates exist, surfacing the picker is over-engineered;
+  // the skill silently uses the annotation default (ADR-012).
+  const PROPAGATION_CANDIDATE_THRESHOLD = 3;
+  const propagationCandidates = questions.filter(
+    (q) => q.isInstanceChild,
+  ).length;
+  const suggestedDefaultApply =
+    propagationCandidates >= PROPAGATION_CANDIDATE_THRESHOLD;
+
   return {
     designGrade: grade,
     isReadyForCodeGen: isReadyForCodeGen(grade),
     questions,
     groupedQuestions,
     designKey: options.designKey ?? "",
+    suggestedDefaultApply,
   };
 }
 


### PR DESCRIPTION
## Summary

Gotcha-survey UX bundle across three issues:

- **#426** — Extend batching to opt-in rules (`missing-prototype`): same-rule repeats collapse into one shared prompt with a `split` escape hatch. `batchMode: "safe" | "opt-in" | "none"` replaces the old `batchable: boolean` flag; whitelist and shape classification stay in TypeScript per ADR-016.
- **#438** — Surface "skip remaining" early-exit affordance in the gotcha flow: notice shown before the first batch, brief reminder after every 3rd. Both `canicode-gotchas/SKILL.md` and the `roundtrip-protocol.md` appendix updated.
- **#428** — Threshold heuristic for the `allowDefinitionWrite` picker: `suggestedDefaultApply: boolean` added to `GotchaSurveySchema` (computed as `propagationCandidates >= 3`). When false, the roundtrip skill silently uses the annotation default (ADR-012) and skips the picker. Documented in `roundtrip-protocol.md`; survey-generator tests extended.

## Tasks

- Add opt-in batchable rule constant + batchMode classification in grouping helper (#426)
- Mirror the schema change on the survey contract (#426)
- Tests for opt-in batching + the new batchMode field (#426)
- Render the opt-in batch prompt in canicode-roundtrip protocol appendix + canicode-gotchas SKILL (#426)
- Add "skip remaining" affordance to canicode-gotchas SKILL and roundtrip-protocol appendix (#438)
- Update roundtrip SKILL.md pointer to mention the new affordance (#438)
- Add `suggestedDefaultApply` to GotchaSurveySchema + generateGotchaSurvey (#428)
- Document threshold in roundtrip-protocol.md; cross-reference from SKILL.md (#428)
- Extend survey-generator tests for `suggestedDefaultApply` (#428)

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes (1090 tests, 67 files)
- [ ] `pnpm build` passes

Closes #426
Closes #438
Closes #428

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))