### PR TITLE
fix: sync server.json metadata + CI drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm check:skill-determinism
+      - run: pnpm check:server-json
       - run: pnpm build
       - run: pnpm test:run
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:plugin": "bash scripts/build-plugin.sh",
     "sync-docs": "tsx scripts/sync-rule-docs.ts",
     "check:skill-determinism": "tsx scripts/check-skill-determinism.ts",
+    "check:server-json": "tsx scripts/check-server-json.ts",
     "clean": "rm -rf dist skills"
   },
   "files": [

--- a/scripts/check-server-json.ts
+++ b/scripts/check-server-json.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env tsx
+/**
+ * Verifies server.json (MCP registry manifest) is in sync with package.json
+ * and the rule registry. Prevents stale metadata from reaching the registry
+ * (see #476).
+ *
+ * Checks:
+ * 1. server.json `version` matches package.json `version`
+ * 2. server.json `packages[0].version` matches package.json `version`
+ * 3. server.json `description` rule count matches RULE_ID_CATEGORY entry count
+ *
+ * Run via: pnpm check:server-json
+ */
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { RULE_ID_CATEGORY } from "../src/core/rules/rule-config.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+interface PackageJson {
+  version: string;
+}
+
+interface ServerJson {
+  description: string;
+  version: string;
+  packages: Array<{ version: string }>;
+}
+
+const pkg = JSON.parse(
+  readFileSync(resolve(repoRoot, "package.json"), "utf8")
+) as PackageJson;
+
+const server = JSON.parse(
+  readFileSync(resolve(repoRoot, "server.json"), "utf8")
+) as ServerJson;
+
+const expectedRuleCount = Object.keys(RULE_ID_CATEGORY).length;
+
+const errors: string[] = [];
+
+if (server.version !== pkg.version) {
+  errors.push(
+    `server.json version "${server.version}" !== package.json version "${pkg.version}"`
+  );
+}
+
+const packageVersion = server.packages[0]?.version;
+if (packageVersion !== pkg.version) {
+  errors.push(
+    `server.json packages[0].version "${packageVersion}" !== package.json version "${pkg.version}"`
+  );
+}
+
+const ruleCountMatch = server.description.match(/(\d+)\s+rules/i);
+if (!ruleCountMatch) {
+  errors.push(
+    `server.json description does not contain "<N> rules" — got: ${server.description}`
+  );
+} else {
+  const claimedCount = Number(ruleCountMatch[1]);
+  if (claimedCount !== expectedRuleCount) {
+    errors.push(
+      `server.json description claims ${claimedCount} rules, but rule-config.ts has ${expectedRuleCount}`
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error("server.json is out of sync:");
+  for (const err of errors) {
+    console.error(`  - ${err}`);
+  }
+  console.error(
+    "\nUpdate server.json to match package.json + rule-config.ts, then re-run."
+  );
+  process.exit(1);
+}
+
+console.log(
+  `server.json is in sync (version ${pkg.version}, ${expectedRuleCount} rules)`
+);

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.let-sunny/canicode",
-  "description": "Analyze Figma designs for dev & AI readiness. 39 rules, scoring, HTML reports.",
+  "description": "Analyze Figma designs for dev & AI readiness. 16 rules, scoring, HTML reports.",
   "repository": {
     "url": "https://github.com/let-sunny/canicode",
     "source": "github"
   },
-  "version": "0.5.2",
+  "version": "0.11.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "canicode",
-      "version": "0.5.2",
+      "version": "0.11.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Closes #476

## Summary

- Fix stale `server.json` metadata: `39 rules` → `16 rules`, version `0.5.2` → `0.11.2` (was last touched in v0.11.0 release)
- Add `pnpm check:server-json` script that compares `server.json` to `package.json` version and to `RULE_ID_CATEGORY` count, fails on drift
- Wire it into CI alongside `check:skill-determinism` so any future drift trips a PR check

## Why

A user's AI agent read `server.json` during a roundtrip session and surfaced "39 rules" — a number that hasn't been true since the rule registry was reorganized. Bumping the values fixes today; the CI check prevents the same drift class from recurring on the next release.

## Test plan

- [x] `pnpm check:server-json` passes locally (`server.json is in sync (version 0.11.2, 16 rules)`)
- [x] `pnpm lint` passes
- [ ] CI green on PR