### PR TITLE
chore: bump version to 0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/let-sunny/canicode",
     "source": "github"
   },
-  "version": "0.11.2",
+  "version": "0.11.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "canicode",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Bump \`package.json\` and \`server.json\` to **0.11.3** so npm publish CI can release the changes accumulated since v0.11.2.

Includes (since v0.11.2):
- #478 fix: sync server.json metadata + add CI drift check
- #479 docs(mcp): add server instructions + channels topic to disambiguate skills
- #482 fix(skills): always show gotcha survey, let user decide on code-gen
- #483 feat: make codegen-ready grade threshold user-configurable
- #484 chore: remove stray implement-log.json pipeline artifact
- #485 chore: gitignore develop pipeline artifacts at repo root

After merge: tag \`v0.11.3\` on main and push — CI auto-publishes.

## Test plan

- [x] \`pnpm check:server-json\` passes (in sync at 0.11.3)
- [x] \`pnpm lint\` passes
- [ ] After merge: \`git tag v0.11.3 && git push origin v0.11.3\` triggers npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)