### PR TITLE
feat: Tighten skill `description` frontmatter for stronger model invocation

### DIFF
--- a/.claude/skills/canicode-gotchas/SKILL.md
+++ b/.claude/skills/canicode-gotchas/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: canicode-gotchas
-description: Gotcha survey (Claude Code or Cursor) — Q&A workflow; answers accumulate in .claude/skills/canicode-gotchas/SKILL.md for figma-implement-design
+description: |
+  Run a gotcha survey on a Figma design — Q&A workflow that captures
+  designer/developer answers locally in .claude/skills/canicode-gotchas/SKILL.md so
+  figma-implement-design can read them at code-gen time. Memo-only: this skill never writes
+  to the Figma canvas.
+
+  TRIGGER when: the user shares a figma.com/design/... URL and asks to capture
+  implementation context, run a gotcha survey, collect design Q&A, or prepare context for
+  figma-implement-design without mutating the Figma file; the user wants to answer
+  implementation questions for a design before code generation; the user mentions "gotcha
+  survey" or "design Q&A".
+
+  SKIP when: the user wants the answers written back into the Figma file as annotations or
+  property fixes (route to canicode-roundtrip); the user only wants a one-shot readiness
+  report with no Q&A loop (route to canicode); the user wants to generate code directly
+  with no survey step (route to figma-implement-design).
 ---
 
 # CanICode Gotchas — Design Gotcha Survey

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -1,6 +1,21 @@
 ---
 name: canicode-roundtrip
-description: Analyze Figma design, fix gotchas via Plugin API, re-analyze, then implement — true design-to-code roundtrip
+description: |
+  Run the full design-to-code roundtrip — analyze a Figma design, surface gotchas, write
+  designer answers back into the file via the Figma Plugin API (use_figma), re-analyze to
+  confirm the gotchas were captured, then hand off to figma-implement-design. Mutates the
+  Figma file: requires Figma full seat + edit access.
+
+  TRIGGER when: the user shares a figma.com/design/... URL and wants production-quality
+  code, or asks for "design-to-code roundtrip", "fix the gotchas", or "annotate the Figma
+  file" with implementation context; the user wants a single command for analyze → survey →
+  apply → implement; the user wants Figma annotations or property fixes written before code
+  generation.
+
+  SKIP when: the user only wants a one-shot readiness report (route to canicode); the user
+  only wants Q&A captured locally without touching the Figma file (route to
+  canicode-gotchas); the user has no Figma edit access; the Figma MCP `use_figma` tool is
+  not loaded in this session (Step 0 will halt anyway).
 disable-model-invocation: false
 ---
 

--- a/.claude/skills/canicode/SKILL.md
+++ b/.claude/skills/canicode/SKILL.md
@@ -1,6 +1,19 @@
 ---
 name: canicode
-description: Analyze Figma designs for development-friendliness and AI-friendliness scores
+description: |
+  Analyze a Figma design for development-friendliness and AI-friendliness — produces a
+  graded readiness report listing rule-based issues with severity, affected nodes, and fix
+  suggestions. Read-only: this skill never modifies the Figma file.
+
+  TRIGGER when: the user shares a figma.com/design/... URL and asks to analyze, score, lint,
+  audit, or check readiness of a Figma design; the user asks "how AI-friendly is this design"
+  or "is this Figma file ready for code generation"; the user wants a one-shot readiness
+  report without a survey or write-back.
+
+  SKIP when: the user wants to capture designer/developer answers about implementation
+  context (route to canicode-gotchas); the user wants to fix or annotate the Figma file
+  itself (route to canicode-roundtrip); the user wants to generate code directly from the
+  design with no readiness analysis (route to figma-implement-design).
 ---
 
 # CanICode -- Figma Design Analysis

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Drops three skills into `./.claude/skills/`:
 - **canicode-gotchas** — standalone gotcha survey (use `/canicode-gotchas <figma-url>`)
 - **canicode-roundtrip** — full analyze → gotcha → apply roundtrip (use `/canicode-roundtrip <figma-url>`)
 
+> **Explicit invocation:** the SKILL.md `description` fields advertise TRIGGER conditions so the model auto-routes Figma-URL prompts to the right skill, but routing is non-deterministic. For deterministic invocation, type `/canicode <figma-url>`, `/canicode-gotchas <figma-url>`, or `/canicode-roundtrip <figma-url>` directly — the slash command bypasses model-based routing.
+
 The skills shell out to `npx canicode …` for analyze / gotcha-survey when the canicode MCP server is not installed — both paths produce the same JSON shape. The Figma MCP server is still required for the apply step (Step 4 in `/canicode-roundtrip`); see the prereq note above.
 
 Flags: `--global` installs into `~/.claude/skills/` instead. `--cursor-skills` also installs Cursor copies under `.cursor/skills/`. `--force` overwrites existing skill files without prompting. Run `canicode docs setup` for the full setup guide.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -237,6 +237,8 @@ After editing MCP JSON or running `canicode init`:
 2. Install skills: **`canicode init --token … --cursor-skills`** saves the Figma token and installs everything; or **`canicode init --cursor-skills`** without `--token` installs Claude skills plus Cursor copies — you still need **`canicode init --token …`** (or `FIGMA_TOKEN`) before REST **`analyze`** / **`gotcha-survey`** against a live URL. The shared gotchas answer file lives under `.claude/skills/canicode-gotchas/` when the gotchas skill is installed. Authoring is single-source under `.claude/skills/` in the repo; the npm build writes `skills/cursor/` (gotchas strip `# Collected Gotchas`; other skills are full copies).
 3. In chat, **@-mention** **canicode**, **canicode-gotchas**, or **canicode-roundtrip** when your Cursor setup uses Agent-attached skills. Some teams prefer **slash commands** or rules instead of `@` — use whichever your workspace enables; roundtrip still needs **`use_figma`** from the Figma MCP in that session.
 
+> **Deterministic invocation (both hosts):** the SKILL.md `description` fields advertise TRIGGER conditions so the model auto-routes Figma-URL prompts to the matching skill, but model routing is non-deterministic. When you want guaranteed routing, invoke explicitly — `/canicode <figma-url>`, `/canicode-gotchas <figma-url>`, or `/canicode-roundtrip <figma-url>` (Claude Code), or the equivalent slash-command path in Cursor where supported. Both `@`-mention and slash-command invocation skip the description-based router.
+
 ### Manual test checklist (#407)
 
 - [ ] MCP: Cursor shows `canicode` connected and the tools list includes `gotcha-survey` (and `analyze` if testing roundtrip Step 1).


### PR DESCRIPTION
## Summary

Issue #490 asks to convert the three canicode SKILL.md frontmatter `description` fields from descriptive ("what this is") to triggering ("when to invoke vs. skip") so the model routes Figma-URL prompts to canicode skills instead of falling through to raw MCP tools or freehand answers. The fix is frontmatter-only on three SKILL.md files plus a small docs note documenting the explicit `/canicode*` slash-command path as the deterministic fallback. Verified by `pnpm check:skill-determinism` (which scans SKILL.md but is targeted at body prose / fenced code, not frontmatter — needs a sanity check that the multi-line description block doesn't accidentally match PROSE_PATTERNS).

## Tasks

- Rewrite frontmatter description in canicode/SKILL.md
- Rewrite frontmatter description in canicode-gotchas/SKILL.md
- Rewrite frontmatter description in canicode-roundtrip/SKILL.md
- Document the slash-command invocation fallback in README.md and docs/CUSTOMIZATION.md
- Verify check-skill-determinism still passes

## Self-review

Implementation faithfully executes the planned scope: three SKILL.md frontmatter blocks rewritten as YAML block scalars with TRIGGER/SKIP grammar mirroring the Figma MCP server's WHEN-TO-USE shape, plus terse deterministic-invocation callouts in README.md and docs/CUSTOMIZATION.md. Bodies untouched, `disable-model-invocation: false` preserved on canicode-roundtrip, `pnpm check:skill-determinism` passes (re-verified locally), and the harness in this very session re-rendered the new multi-paragraph descriptions cleanly in its skill list — strong evidence the YAML block scalar parses correctly under Claude Code. Diff is minimal (~50 insertions / 3 deletions across 5 files) and exactly tracks the issue's acceptance criteria.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 3

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #490

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))