### PR TITLE
feat: Distribute canicode as a multi-host plugin (Claude Code bundle) instead of per-host `init` flags

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "canicode",
+  "version": "0.11.3",
+  "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
+  "skills": [
+    "./skills/canicode",
+    "./skills/canicode-gotchas",
+    "./skills/canicode-roundtrip"
+  ],
+  "mcpServers": {
+    "canicode": {
+      "command": "canicode-mcp"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "files": [
     "dist",
     "skills",
+    ".claude-plugin",
     "README.md",
     "docs/CUSTOMIZATION.md"
   ],


### PR DESCRIPTION
## Summary

Phase 1 of #489: ship a Claude Code plugin manifest so `claude plugin add canicode` (and OpenClaw via auto-detect) registers all three canicode skills + the canicode-mcp MCP server without requiring `canicode init`. Two-file change: create `.claude-plugin/plugin.json` at the repo root and add `.claude-plugin/` to `package.json#files` so the manifest ships in the npm tarball. Phase 2 (Cursor manifest), Phase 3 (`--skills-dir` flag), and README/CUSTOMIZATION/ADR doc edits are explicitly out of scope per the issue scope note and the parallel #490 work.

## Tasks

- Add .claude-plugin/plugin.json manifest at repo root
- Include .claude-plugin/ in the npm tarball

## Self-review

Minimal, scope-respecting Phase 1 implementation: a new `.claude-plugin/plugin.json` manifest and a one-line `package.json#files` addition. Both changes match the plan's design decisions exactly, the manifest is valid JSON, skill paths resolve to real files in the npm tarball (verified via `pnpm pack --dry-run`), and no out-of-scope files (SKILL.md / README / docs / ADR) were touched, leaving #490's surface clean.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 1

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #489

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))