### PR TITLE
feat: add Claude Code marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "canicode",
+  "owner": {
+    "name": "let-sunny"
+  },
+  "plugins": [
+    {
+      "name": "canicode",
+      "source": ".",
+      "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add \`.claude-plugin/marketplace.json\` so this repo doubles as its own Claude Code marketplace, pointing at itself. Unblocks plugin install without waiting on Anthropic's official marketplace queue.

After merge, users can install via:

\`\`\`bash
claude plugin marketplace add let-sunny/canicode
claude plugin install canicode
# Restart Claude Code
npx canicode init --token figd_xxxxxxx   # token still needed (see below)
\`\`\`

## Why now

#496 user-flow test found that \`claude plugin install canicode\` failed with "not found in any configured marketplace" because the canicode plugin manifest (#493) wasn't reachable through any registered marketplace. The Anthropic official marketplace submission is pending — turnaround is opaque (form submissions appear to feed an internal staff queue with no public ack), so we ship our own marketplace as the immediate unblocker.

## Why \`source: "."\`

Per Claude Code marketplace spec ([docs](https://code.claude.com/docs/en/plugin-marketplaces)), a marketplace can self-point at the same repo via \`source: "."\`. The marketplace lives in \`.claude-plugin/marketplace.json\` next to the existing \`.claude-plugin/plugin.json\` (#493). One repo serves both roles.

## Token still required

This PR does **not** solve token injection. \`plugin.json#mcpServers\` cannot declare env values per Claude Code's plugin spec, and Anthropic's own GitHub plugin uses the same env-var pattern. After plugin install, users still need either:
- \`npx canicode init --token figd_xxx\` (writes to \`~/.canicode/config.json\`, which canicode-mcp reads first), OR
- \`export FIGMA_TOKEN=figd_xxx\` in shell rc

README rewrite is a follow-up after we verify the marketplace path actually works in a cold Claude Code session (test plan in #496).

## Test plan

- [x] \`pnpm lint\` passes
- [x] \`pnpm check:server-json\` passes
- [ ] **After merge** — verify in cold Claude Code session:
  \`\`\`bash
  claude plugin marketplace add let-sunny/canicode
  claude plugin install canicode
  \`\`\`
  Expected: skills + MCP server registered. If it fails (e.g. \`source: "."\` doesn't resolve correctly, or \`mcpServers.canicode.command: "canicode-mcp"\` isn't on PATH), file follow-up.

## Relation

- Builds on #493 (plugin.json)
- Falsifies branch of #496 (the install-command test)
- Anthropic-marketplace submission remains a parallel track, not a blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)