### PR TITLE
feat: Polish `canicode init` path docs (#496 user-flow test follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ claude mcp add canicode -- npx --yes --package=canicode canicode-mcp
 
 Restart Claude Code or reload MCP (Cursor) so canicode tools (`analyze`, `gotcha-survey`, …) load — same cold-session requirement as the Figma MCP (#433).
 
+**Smoke test (no Figma token needed):**
+
+```bash
+git clone https://github.com/let-sunny/canicode.git
+cd canicode && pnpm install && pnpm build
+npx canicode analyze ./fixtures/done/desktop-home-page
+```
+
+Loads a bundled fixture (no Figma API call, no token), opens the HTML report in a browser. Use any directory under `fixtures/done/` — `desktop-*` are screen-scale, `mobile-*` are mobile viewports.
+
 <details>
 <summary><strong>All channels</strong></summary>
 
@@ -128,11 +138,13 @@ Each row below is a **complete** install. Don't run more than one — they cover
 
 | If you use… | Install |
 |-------------|---------|
-| **Claude Code** (recommended for the roundtrip workflow) | `npx canicode init --token figd_xxxxxxxxxxxxx` — saves the token AND drops `/canicode`, `/canicode-gotchas`, `/canicode-roundtrip` skills into `./.claude/skills/`. The skills already know how to call canicode via `npx canicode …`, no MCP install needed. |
+| **Claude Code** (recommended for the roundtrip workflow) | `npx canicode init --token figd_xxxxxxxxxxxxx` — saves the token AND drops `/canicode`, `/canicode-gotchas`, `/canicode-roundtrip` skills into `./.claude/skills/`. The skills already know how to call canicode via `npx canicode …`, so no **canicode** MCP install is needed; the **Figma** MCP is still required for the `/canicode-roundtrip` apply step — see the prereq below. |
 | **Cursor / Claude Desktop / other MCP host** | Add canicode to the host’s MCP config — see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md#cursor-mcp-canicode). Example (Cursor project file): `npx` + `canicode-mcp` via `--package=canicode`. |
 | **Just the CLI** (CI, scripts) | Nothing. `npx canicode analyze "<figma-url>"` works directly. Run `canicode init --token …` once if you want the token persisted to `~/.canicode/config.json`. |
 
-> **Get your token:** Figma → Settings → Security → Personal access tokens → Generate new token
+> **Get your token:** Figma → Settings → Security → Personal access tokens → Generate new token. See [Figma's PAT docs](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens) for screenshots and scope details.
+> - **Scope:** read-only is sufficient for analyze and gotcha-survey. The roundtrip apply step writes via the **Figma MCP plugin** (separate auth), not via this REST token, so no write scope is needed here.
+> - **Expiry:** Figma defaults personal access tokens to **90-day expiry**. Pick a longer window (or note the renewal date) to avoid surprise revocations breaking CI/CD.
 
 > **Roundtrip prerequisite:** the `/canicode-roundtrip` skill calls the Figma MCP server to read and write the design. Install it once with `claude mcp add -s project -t http figma https://mcp.figma.com/mcp` and restart Claude Code so the new MCP tools load.
 
@@ -150,9 +162,11 @@ Drops three skills into `./.claude/skills/`:
 - **canicode-gotchas** — standalone gotcha survey (use `/canicode-gotchas <figma-url>`)
 - **canicode-roundtrip** — full analyze → gotcha → apply roundtrip (use `/canicode-roundtrip <figma-url>`)
 
+> The install copies 7 files total — the three SKILL.md files above plus four canicode-roundtrip helper files (`helpers.js`, `helpers-bootstrap.js`, `helpers-installer.js`, `canicode-roundtrip-helpers.d.ts`) used by the roundtrip Step 4 apply path. The CLI summary's `files installed: 7` reflects this file count.
+
 > **Explicit invocation:** the SKILL.md `description` fields advertise TRIGGER conditions so the model auto-routes Figma-URL prompts to the right skill, but routing is non-deterministic. For deterministic invocation, type `/canicode <figma-url>`, `/canicode-gotchas <figma-url>`, or `/canicode-roundtrip <figma-url>` directly — the slash command bypasses model-based routing.
 
-The skills shell out to `npx canicode …` for analyze / gotcha-survey when the canicode MCP server is not installed — both paths produce the same JSON shape. The Figma MCP server is still required for the apply step (Step 4 in `/canicode-roundtrip`); see the prereq note above.
+The skills shell out to `npx canicode …` for analyze / gotcha-survey, so installing the **canicode** MCP server is optional (both paths produce the same JSON shape). The **Figma** MCP server, however, is required for the apply step (Step 4 in `/canicode-roundtrip`); see the prereq note above.
 
 Flags: `--global` installs into `~/.claude/skills/` instead. `--cursor-skills` also installs Cursor copies under `.cursor/skills/`. `--force` overwrites existing skill files without prompting. Run `canicode docs setup` for the full setup guide.
 
@@ -183,6 +197,8 @@ For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZA
 ```bash
 npx canicode analyze "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234"
 ```
+
+> Pass `--ready-min-grade <S|A+|A|B+|B|C+|C|D|F>` to override the codegen-readiness threshold (default: A; from #483).
 
 Setup: `npx canicode init --token figd_xxxxxxxxxxxxx` saves the token and installs the Claude Code skills into `./.claude/skills/`.
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ Restart Claude Code or reload MCP (Cursor) so canicode tools (`analyze`, `gotcha
 ```bash
 git clone https://github.com/let-sunny/canicode.git
 cd canicode && pnpm install && pnpm build
-npx canicode analyze ./fixtures/done/desktop-home-page
+canicode analyze ./fixtures/done/desktop-home-page
 ```
 
-Loads a bundled fixture (no Figma API call, no token), opens the HTML report in a browser. Use any directory under `fixtures/done/` — `desktop-*` are screen-scale, `mobile-*` are mobile viewports.
+Loads a bundled fixture (no Figma API call, no token), opens the HTML report in a browser (pass `--no-open` to skip auto-launch). Use any directory under `fixtures/done/` — `desktop-*` are screen-scale, `mobile-*` are mobile viewports.
 
 <details>
 <summary><strong>All channels</strong></summary>
@@ -142,9 +142,9 @@ Each row below is a **complete** install. Don't run more than one — they cover
 | **Cursor / Claude Desktop / other MCP host** | Add canicode to the host’s MCP config — see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md#cursor-mcp-canicode). Example (Cursor project file): `npx` + `canicode-mcp` via `--package=canicode`. |
 | **Just the CLI** (CI, scripts) | Nothing. `npx canicode analyze "<figma-url>"` works directly. Run `canicode init --token …` once if you want the token persisted to `~/.canicode/config.json`. |
 
-> **Get your token:** Figma → Settings → Security → Personal access tokens → Generate new token. See [Figma's PAT docs](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens) for screenshots and scope details.
-> - **Scope:** read-only is sufficient for analyze and gotcha-survey. The roundtrip apply step writes via the **Figma MCP plugin** (separate auth), not via this REST token, so no write scope is needed here.
-> - **Expiry:** Figma defaults personal access tokens to **90-day expiry**. Pick a longer window (or note the renewal date) to avoid surprise revocations breaking CI/CD.
+> **Get your token:** Figma → Settings → Security → Personal access tokens → Generate new token. [Figma's PAT docs](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens)
+> **Scope:** Read-only is sufficient for canicode.
+> **Expiry:** Tokens default to 90 days; check the dropdown when generating.
 
 > **Roundtrip prerequisite:** the `/canicode-roundtrip` skill calls the Figma MCP server to read and write the design. Install it once with `claude mcp add -s project -t http figma https://mcp.figma.com/mcp` and restart Claude Code so the new MCP tools load.
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -120,9 +120,9 @@ async function runInitSkillInstallSteps(
       force: options.force ?? false,
     });
     console.log(`\n  Skills installed to: ${summary.targetDir}/`);
-    console.log(`    installed:   ${summary.installed.length}`);
-    console.log(`    overwritten: ${summary.overwritten.length}`);
-    console.log(`    skipped:     ${summary.skipped.length}`);
+    console.log(`    files installed:   ${summary.installed.length}`);
+    console.log(`    files overwritten: ${summary.overwritten.length}`);
+    console.log(`    files skipped:     ${summary.skipped.length}`);
     if (summary.skipped.length > 0) {
       console.log(`  (Re-run with --force to overwrite skipped files.)`);
     }
@@ -145,9 +145,9 @@ async function runInitSkillInstallSteps(
         force: options.force ?? false,
       });
       console.log(`\n  Cursor skills installed to: ${cSummary.targetDir}/`);
-      console.log(`    installed:   ${cSummary.installed.length}`);
-      console.log(`    overwritten: ${cSummary.overwritten.length}`);
-      console.log(`    skipped:     ${cSummary.skipped.length}`);
+      console.log(`    files installed:   ${cSummary.installed.length}`);
+      console.log(`    files overwritten: ${cSummary.overwritten.length}`);
+      console.log(`    files skipped:     ${cSummary.skipped.length}`);
       if (cSummary.skipped.length > 0) {
         console.log(`  (Re-run with --force to overwrite skipped files.)`);
       }


### PR DESCRIPTION
## Summary

Polish 5 documentation gaps in the `canicode init` path identified by the #496 user-flow test. All changes land in a single PR, primarily editing README.md (and one minor wording change in src/cli/commands/init.ts CLI output for fix #2 to match README narrative). No engine, rule, or install-logic changes.

## Tasks

- Document `--ready-min-grade` flag in README analyze section
- Reconcile `installed: 7` vs `three skills` narrative
- Reconcile 'MCP install required vs optional' narrative
- Add a working sample input for first-run smoke test
- Strengthen FIGMA_TOKEN guidance

## Self-review

All 5 documentation gaps from #496 are addressed cleanly in a single PR. README edits are surgical, tightly tied to the diagnosed gaps, and consistent with the existing narrative style. The CLI label change in init.ts is a defensible scope expansion (text-only, no logic touched) that removes the very ambiguity Task 2 set out to fix. No conventions broken, no scope creep, no architecture concerns.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 3

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #498

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))