### PR TITLE
docs: "Other agents" install guide for non-Claude/Cursor hosts (manual skill copy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Each row below is a **complete** install. Don't run more than one — they cover
 |-------------|---------|
 | **Claude Code** (recommended for the roundtrip workflow) | `npx canicode init --token figd_xxxxxxxxxxxxx` — saves the token AND drops `/canicode`, `/canicode-gotchas`, `/canicode-roundtrip` skills into `./.claude/skills/`. The skills already know how to call canicode via `npx canicode …`, so no **canicode** MCP install is needed; the **Figma** MCP is still required for the `/canicode-roundtrip` apply step — see the prereq below. |
 | **Cursor / Claude Desktop / other MCP host** | Add canicode to the host’s MCP config — see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md#cursor-mcp-canicode). Example (Cursor project file): `npx` + `canicode-mcp` via `--package=canicode`. |
+| **OpenClaw / other AgentSkills-compatible host** | Manual skill copy — see [Other agents (manual install)](docs/CUSTOMIZATION.md#other-agents-manual-install). Best-effort docs, not a support commitment. |
 | **Just the CLI** (CI, scripts) | Nothing. `npx canicode analyze "<figma-url>"` works directly. Run `canicode init --token …` once if you want the token persisted to `~/.canicode/config.json`. |
 
 > **Get your token:** Figma → Settings → Security → Personal access tokens → Generate new token. [Figma's PAT docs](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens)

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -276,6 +276,47 @@ Work through these checks in order before concluding that an MCP server is broke
 
 ---
 
+## Other agents (manual install)
+
+CanICode ships three [AgentSkills](https://agentskills.io)-compatible skills via the npm package. For Claude Code and Cursor, `npx canicode init` (or `--cursor-skills`) handles install automatically. For other AgentSkills-compatible hosts, copy the skill folders into a directory your host scans.
+
+This is best-effort documentation, not a support commitment — hosts named below are listed by their published scan paths, not because canicode is tested against them.
+
+### What ships in the npm package
+
+After `npm install canicode` (or via `npx canicode`), the skill files live under `node_modules/canicode/skills/`:
+
+- `skills/canicode/SKILL.md`
+- `skills/canicode-gotchas/SKILL.md`
+- `skills/canicode-roundtrip/SKILL.md`
+- `skills/canicode-roundtrip/helpers.js`
+- `skills/canicode-roundtrip/helpers-bootstrap.js`
+- `skills/canicode-roundtrip/helpers-installer.js`
+- `skills/canicode-roundtrip/canicode-roundtrip-helpers.d.ts`
+
+These are produced by `pnpm bundle:skills` (`scripts/bundle-skills.sh`) and ship as part of the npm tarball via `package.json` `files`. The four `helpers-*` files in `canicode-roundtrip/` are required for the Step 4 Plugin API write path — copy the whole folder, don't cherry-pick.
+
+The package also contains a `skills/cursor/` subtree, which is a Cursor-specific variant (gotchas SKILL.md is stripped via `strip-cursor-gotcha-skill.mjs`). Use the canonical `skills/canicode*` folders above for non-Cursor manual installs — `skills/cursor/canicode-gotchas/SKILL.md` is missing the gotchas section by design.
+
+### Install into any AgentSkills-compatible host
+
+Copy each of the three skill folders (`canicode/`, `canicode-gotchas/`, `canicode-roundtrip/`) into a directory your host scans for skills.
+
+| Host | Workspace path | User path |
+| --- | --- | --- |
+| Claude Code | `.claude/skills/` | `~/.claude/skills/` |
+| Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
+| OpenClaw ([scan-path doc](https://github.com/openclaw/openclaw/blob/main/docs/tools/skills.md)) | `./skills/` or `./.agents/skills/` | `~/.agents/skills/` or `~/.openclaw/skills/` |
+| Generic AgentSkills runtime | see your host's docs | see your host's docs |
+
+> **Pro tip:** for Claude Code or Cursor specifically, run `npx canicode init` (Claude Code) or `npx canicode init --cursor-skills` (Cursor) instead — those flows handle the copy plus token setup, and you avoid having two copies of the skill folders side by side.
+
+### MCP server registration
+
+Most AgentSkills-compatible hosts also need the canicode MCP server registered through their own MCP config. The [Cursor MCP (canicode)](#cursor-mcp-canicode) section above shows the `mcpServers` JSON shape — most runtimes accept the same shape in a different config file (consult your host's docs for the exact path). The skills can call `npx canicode …` directly without MCP registration, but `analyze` / `gotcha-survey` invoked as MCP tools need the server entry.
+
+---
+
 ## Telemetry
 
 CanICode collects anonymous usage analytics via [PostHog](https://posthog.com) and error tracking via [Sentry](https://sentry.io). This helps improve the tool by understanding which features are used and catching errors early.

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -278,7 +278,7 @@ Work through these checks in order before concluding that an MCP server is broke
 
 ## Other agents (manual install)
 
-CanICode ships three [AgentSkills](https://agentskills.io)-compatible skills via the npm package. For Claude Code and Cursor, `npx canicode init` (or `--cursor-skills`) handles install automatically. For other AgentSkills-compatible hosts, copy the skill folders into a directory your host scans.
+CanICode ships three AgentSkills-compatible skills via the npm package. For Claude Code and Cursor, `npx canicode init` (or `--cursor-skills`) handles install automatically. For other AgentSkills-compatible hosts, copy the skill folders into a directory your host scans.
 
 This is best-effort documentation, not a support commitment — hosts named below are listed by their published scan paths, not because canicode is tested against them.
 


### PR DESCRIPTION
## Summary

Pure docs PR. Add an 'Other agents (manual install)' section to docs/CUSTOMIZATION.md documenting where the npm package puts the three skill folders and how to copy them into any AgentSkills-compatible host (Claude Code, Cursor, OpenClaw, generic) — plus a one-line README pointer in the install matrix area. Replaces the rejected --skills-dir flag from #500: instead of building a flag, we document the manual copy. No src/ or skill content changes; aligned with the Claude-first decision in project_init_vs_plugin.md (no plugin/host code abstractions).

## Tasks

- Verify bundled skill paths and OpenClaw scan paths
- Add 'Other agents (manual install)' section to docs/CUSTOMIZATION.md
- Add README pointer in the install matrix

## Self-review

Pure docs PR is well-scoped, structurally matches the plan, hits the four acceptance bullets (CUSTOMIZATION.md section + README pointer + OpenClaw paths + no src changes), and uses the right non-normative framing. One concrete issue: the intro adds an unverified outbound link to https://agentskills.io that was not in the issue or plan and is not referenced anywhere else in the repo. That risks broken-link rot in user-facing docs and conflicts with the project rule against guessing URLs. Two minor follow-ups around the README slug verification and a small phrasing tightening.
- Verdict: request-changes
- Errors: 0, Warnings: 1, Total: 3

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #501

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))