### PR TITLE
chore: strip internal issue/ADR refs from user-facing surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## How it works
 
-AI can turn Figma designs into code — but the quality depends heavily on **how the design is structured**. CanICode runs a **roundtrip** over your Figma file: analyze the design, surface the gotchas it can't answer on its own, apply fixes back to Figma, re-analyze until the design is clean, then hand off to Figma's `figma-implement-design` skill for code generation. canicode does the design augmentation; code generation lives downstream (see [ADR-013](.claude/docs/ADR.md) for the scope boundary).
+AI can turn Figma designs into code — but the quality depends heavily on **how the design is structured**. CanICode runs a **roundtrip** over your Figma file: analyze the design, surface the gotchas it can't answer on its own, apply fixes back to Figma, re-analyze until the design is clean, then hand off to Figma's `figma-implement-design` skill for code generation. canicode does the design augmentation; code generation lives downstream.
 
 ![Role diagram: gotchas (memo) vs roundtrip (canvas) vs code-gen](docs/images/roles.svg)
 
@@ -46,10 +46,10 @@ Rule scores aren't guesswork. The calibration pipeline converts real Figma desig
 2. **Surface gotchas** — the analyzer emits questions for design information it can't infer (missing states, unclear variants, responsive intent).
 3. **Apply fixes to Figma** — the `/canicode-roundtrip` skill writes answers back via `use_figma`. Each write shows up in the summary with one of three outcome markers:
    - ✅ **scene write succeeded** — the property was written directly to the scene node or instance override.
-   - 📝 **annotated the scene node** — the skill left a structured annotation instead of writing the property. This is the [ADR-012](.claude/docs/ADR.md) default for instance-child layout writes, because propagating a property to the component definition (and therefore every instance of it) is almost never what the user wants. **A summary full of 📝 markers is correct behavior, not failure.**
+   - 📝 **annotated the scene node** — the skill left a structured annotation instead of writing the property. This is the default for instance-child layout writes, because propagating a property to the component definition (and therefore every instance of it) is almost never what the user wants. **A summary full of 📝 markers is correct behavior, not failure.**
    - 🌐 **definition write propagated** — the property was written to the component definition and every instance inherited it. Only happens when the user opted in up front with `allowDefinitionWrite`.
 4. **Re-analyze** — verify gotchas were captured (annotations / acks); repeat step 2 if new gotchas surface.
-5. **Hand off** to `figma-implement-design` — canicode's scope ends here ([ADR-013](.claude/docs/ADR.md)). Figma's official code-generation skill takes the now-clean design and produces code.
+5. **Hand off** to `figma-implement-design` — canicode's scope ends here. Figma's official code-generation skill takes the now-clean design and produces code.
 
 ---
 
@@ -88,7 +88,7 @@ npx canicode analyze "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234
 claude mcp add canicode -- npx --yes --package=canicode canicode-mcp
 ```
 
-Restart Claude Code or reload MCP (Cursor) so canicode tools (`analyze`, `gotcha-survey`, …) load — same cold-session requirement as the Figma MCP (#433).
+Restart Claude Code or reload MCP (Cursor) so canicode tools (`analyze`, `gotcha-survey`, …) load — same cold-session requirement as the Figma MCP.
 
 **Smoke test (no Figma token needed):**
 
@@ -134,7 +134,7 @@ Each issue is classified: **Blocking** > **Risk** > **Missing Info** > **Suggest
 
 ## Installation — pick one
 
-Each row below is a **complete** install. Don't run more than one — they cover overlapping use cases. (#367)
+Each row below is a **complete** install. Don't run more than one — they cover overlapping use cases.
 
 | If you use… | Install |
 |-------------|---------|
@@ -180,15 +180,15 @@ Flags: `--global` installs into `~/.claude/skills/` instead. `--cursor-skills` a
 claude mcp add canicode -- npx --yes --package=canicode canicode-mcp
 ```
 
-Restart Claude Code or reload MCP (Cursor) so canicode MCP tools appear in a fresh session (#433).
+Restart Claude Code or reload MCP (Cursor) so canicode MCP tools appear in a fresh session.
 
 Then ask: *"Analyze this Figma design: https://www.figma.com/design/..."*
 
-canicode's rule engine analyzes the design data — the AI assistant just orchestrates the calls. The MCP server reads `FIGMA_TOKEN` from `~/.canicode/config.json` (set via `canicode init --token …`) or from the host's environment, so passing `-e FIGMA_TOKEN=…` to `claude mcp add` is **not** required and the current parser rejects it anyway (#364).
+canicode's rule engine analyzes the design data — the AI assistant just orchestrates the calls. The MCP server reads `FIGMA_TOKEN` from `~/.canicode/config.json` (set via `canicode init --token …`) or from the host's environment, so passing `-e FIGMA_TOKEN=…` to `claude mcp add` is **not** required and the current parser rejects it anyway.
 
 If you genuinely need a per-server token without using `canicode init`, export it on the calling shell instead: `export FIGMA_TOKEN=figd_xxxxxxxxxxxxx`.
 
-For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md) — especially [Cursor MCP (canicode)](docs/CUSTOMIZATION.md#cursor-mcp-canicode) and the **Manual test checklist (#407)** for verifying `gotcha-survey` end-to-end.
+For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZATION.md) — especially [Cursor MCP (canicode)](docs/CUSTOMIZATION.md#cursor-mcp-canicode) and the **Manual test checklist** for verifying `gotcha-survey` end-to-end.
 
 </details>
 
@@ -199,7 +199,7 @@ For Cursor / Claude Desktop config, see [`docs/CUSTOMIZATION.md`](docs/CUSTOMIZA
 npx canicode analyze "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234"
 ```
 
-> Pass `--ready-min-grade <S|A+|A|B+|B|C+|C|D|F>` to override the codegen-readiness threshold (default: A; from #483).
+> Pass `--ready-min-grade <S|A+|A|B+|B|C+|C|D|F>` to override the codegen-readiness threshold (default: A).
 
 Setup: `npx canicode init --token figd_xxxxxxxxxxxxx` saves the token and installs the Claude Code skills into `./.claude/skills/`.
 

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -184,7 +184,7 @@ Configure the canicode MCP server so Cursor exposes `analyze`, `gotcha-survey`, 
 
 ### Which MCP file affects which host?
 
-Two different JSON locations are easy to confuse because both can live in a git repo and both use an `mcpServers` object. (See GitHub #436.)
+Two different JSON locations are easy to confuse because both can live in a git repo and both use an `mcpServers` object.
 
 | Path | Read by | Purpose |
 | --- | --- | --- |
@@ -215,14 +215,14 @@ Create or merge into `.cursor/mcp.json` in your repository root:
 
 Use long-form `--package` (short `-p` can confuse some parsers). Set your Figma token once with `npx canicode init --token figd_…` — the MCP server reads `~/.canicode/config.json`; you do not need `FIGMA_TOKEN` in the MCP block unless your team prefers env injection.
 
-### Figma MCP server id and tool names in Cursor (#437)
+### Figma MCP server id and tool names in Cursor
 
 Cursor may show an MCP **server id** in the UI that is **not** literally the key you typed in `mcpServers` (for example a workspace or project prefix). Skills and docs often say “the `figma` MCP” or “call `use_figma`” as shorthand — **your session’s truth is the live tool list** after MCP reload (Cursor: MCP / Tools panel), not the string `figma` or `use_figma` read from a config file alone.
 
 - If roundtrip fails with “cannot find `use_figma`” but Figma MCP shows as connected, open the tool list and note the **exact** tool identifier Cursor exposes (it may be namespaced).
 - Keep the Figma MCP entry in `.cursor/mcp.json` (or `~/.cursor/mcp.json`) per [Figma’s MCP docs](https://developers.figma.com/docs/figma-mcp-server/) — then rely on the host-reported tool name when wiring skills or debugging.
 
-### Post-install checklist (MCP + skills + Figma) (#461)
+### Post-install checklist (MCP + skills + Figma)
 
 After editing MCP JSON or running `canicode init`:
 
@@ -239,7 +239,7 @@ After editing MCP JSON or running `canicode init`:
 
 > **Deterministic invocation (both hosts):** the SKILL.md `description` fields advertise TRIGGER conditions so the model auto-routes Figma-URL prompts to the matching skill, but model routing is non-deterministic. When you want guaranteed routing, invoke explicitly — `/canicode <figma-url>`, `/canicode-gotchas <figma-url>`, or `/canicode-roundtrip <figma-url>` (Claude Code), or the equivalent slash-command path in Cursor where supported. Both `@`-mention and slash-command invocation skip the description-based router.
 
-### Manual test checklist (#407)
+### Manual test checklist
 
 - [ ] MCP: Cursor shows `canicode` connected and the tools list includes `gotcha-survey` (and `analyze` if testing roundtrip Step 1).
 - [ ] Figma MCP: `use_figma` is available when testing **roundtrip** (install + restart host if tools are missing).
@@ -266,7 +266,7 @@ Work through these checks in order before concluding that an MCP server is broke
    See the Step 4 preflight block in [`docs/roundtrip-protocol.md`](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md) and the corresponding preflight check in the `canicode-roundtrip` SKILL.md for the full prepend procedure.
 
 4. **Size / delivery — measure the code string before assuming a server bug.**
-   If the `use_figma` call silently fails, truncates, or the host reports the tool payload is too large, the `helpers.js` bundle combined with the apply script may exceed the host's per-message or per-tool-call limit. Measure with `Buffer.byteLength(code, "utf8")` (Node) or `wc -c` (shell). If the string is too large for the chat/tool input, write it to a file and paste it into the MCP `use_figma` UI directly instead of relying on the model to pass the full string inline. See also the delivery notes in [#462](https://github.com/let-sunny/canicode/issues/462) and [`docs/roundtrip-protocol.md`](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md).
+   If the `use_figma` call silently fails, truncates, or the host reports the tool payload is too large, the `helpers.js` bundle combined with the apply script may exceed the host's per-message or per-tool-call limit. Measure with `Buffer.byteLength(code, "utf8")` (Node) or `wc -c` (shell). If the string is too large for the chat/tool input, write it to a file and paste it into the MCP `use_figma` UI directly instead of relying on the model to pass the full string inline. See also the delivery notes in [`docs/roundtrip-protocol.md`](https://github.com/let-sunny/canicode/blob/main/docs/roundtrip-protocol.md).
 
 5. **Common symptom → likely cause mapping:**
    - `ReferenceError: CanICodeRoundtrip is not defined` → `helpers.js` was not prepended (check 3 above).

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -47,14 +47,14 @@ export function registerAnalyze(cli: CAC): void {
     .option("--token <token>", "Figma API token (or use FIGMA_TOKEN env var)")
     .option(
       "--api",
-      "No-op for Figma URL inputs (file data is always fetched via REST). Accepted for CLI parity with `gotcha-survey` (#461).",
+      "No-op for Figma URL inputs (file data is always fetched via REST). Accepted for CLI parity with `gotcha-survey`.",
     )
     .option("--screenshot", "Include screenshot comparison in report (requires ANTHROPIC_API_KEY)")
     .option("--config <path>", "Path to config JSON file (override rule scores/settings)")
     .option("--no-open", "Don't open report in browser after analysis")
     .option("--json", "Output JSON results to stdout (same format as MCP)")
-    .option("--acknowledgments <path>", "(#371 / ADR-019) Path to JSON acknowledgments from canicode Figma annotations (nodeId, ruleId; optional intent / sceneWriteOutcome / codegenDirective per #444). Matching issues are flagged acknowledged and contribute half weight to density.")
-    .option("--scope <scope>", "(#404) Override analysis scope: `page` (screen/section — container bounds are required) or `component` (standalone reusable unit — root FILL is the design contract). Defaults to auto-detection from the root node type.")
+    .option("--acknowledgments <path>", "Path to JSON acknowledgments from canicode Figma annotations (nodeId, ruleId; optional intent / sceneWriteOutcome / codegenDirective). Matching issues are flagged acknowledged and contribute half weight to density.")
+    .option("--scope <scope>", "Override analysis scope: `page` (screen/section — container bounds are required) or `component` (standalone reusable unit — root FILL is the design contract). Defaults to auto-detection from the root node type.")
     .option("--ready-min-grade <grade>", "Minimum grade for code-gen readiness (S | A+ | A | B+ | B | C+ | C | D | F). Overrides configPath codegenReadyMinGrade. Default: A")
     .example("  canicode analyze https://www.figma.com/design/ABC123/MyDesign")
     .example("  canicode analyze ./fixtures/my-design --output report.html")

--- a/src/cli/commands/gotcha-survey.ts
+++ b/src/cli/commands/gotcha-survey.ts
@@ -88,11 +88,11 @@ export function registerGotchaSurvey(cli: CAC): void {
     .option("--token <token>", "Figma API token (or use FIGMA_TOKEN env var)")
     .option(
       "--api",
-      "No-op for Figma URL inputs (file data is always fetched via REST). Accepted for CLI parity with `analyze` (#461).",
+      "No-op for Figma URL inputs (file data is always fetched via REST). Accepted for CLI parity with `analyze`.",
     )
     .option("--config <path>", "Path to config JSON file (override rule scores/settings)")
     .option("--target-node-id <id>", "Scope analysis to a specific node ID")
-    .option("--scope <scope>", "(#404) Override analysis scope: `page` or `component`. Defaults to auto-detection from the root node type.")
+    .option("--scope <scope>", "Override analysis scope: `page` or `component`. Defaults to auto-detection from the root node type.")
     .option("--json", "Output GotchaSurvey JSON to stdout (same format as MCP)")
     .option("--ready-min-grade <grade>", "Minimum grade for code-gen readiness (S | A+ | A | B+ | B | C+ | C | D | F). Overrides configPath codegenReadyMinGrade. Default: A")
     .example("  canicode gotcha-survey https://www.figma.com/design/ABC123/MyDesign --json")

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -49,7 +49,7 @@ export function formatNextSteps(opts: {
         "  Next:",
         "    1. Restart Cursor or reload MCP (so skills + MCP tools load in a fresh session)",
         "    2. In Agent chat, @ canicode-roundtrip with your Figma URL (or @ canicode-gotchas for survey-only)",
-        "    • Optional — faster canicode MCP than `npx`: add `canicode-mcp` per https://github.com/let-sunny/canicode/blob/main/docs/CUSTOMIZATION.md#cursor-mcp-canicode (project `.cursor/mcp.json`), then reload MCP; otherwise skills keep using `npx canicode …` (#433).",
+        "    • Optional — faster canicode MCP than `npx`: add `canicode-mcp` per https://github.com/let-sunny/canicode/blob/main/docs/CUSTOMIZATION.md#cursor-mcp-canicode (project `.cursor/mcp.json`), then reload MCP; otherwise skills keep using `npx canicode …`.",
       ].join("\n");
     }
     return [
@@ -57,7 +57,7 @@ export function formatNextSteps(opts: {
       "  Next:",
       "    1. Restart Claude Code (the newly installed skills only load on a fresh session)",
       "    2. Run /canicode-roundtrip <figma-url>",
-      "    • Optional — faster canicode MCP than `npx`: `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp`, then restart Claude Code so `analyze` / `gotcha-survey` tools load — otherwise skills shell out to `npx canicode …` (#433).",
+      "    • Optional — faster canicode MCP than `npx`: `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp`, then restart Claude Code so `analyze` / `gotcha-survey` tools load — otherwise skills shell out to `npx canicode …`.",
     ].join("\n");
   }
 
@@ -68,7 +68,7 @@ export function formatNextSteps(opts: {
       "    1. Add Figma MCP to .cursor/mcp.json (see https://github.com/let-sunny/canicode/blob/main/docs/CUSTOMIZATION.md#cursor-mcp-canicode and Figma MCP docs)",
       "    2. Restart Cursor so Figma tools (e.g. use_figma) load",
       "    3. @ canicode-roundtrip with your Figma URL for full roundtrip",
-      "    • Optional — faster canicode MCP than `npx`: add `canicode-mcp` per the Customization guide (`#cursor-mcp-canicode`), then reload MCP; otherwise skills keep using `npx canicode …` (#433).",
+      "    • Optional — faster canicode MCP than `npx`: add `canicode-mcp` per the Customization guide (`#cursor-mcp-canicode`), then reload MCP; otherwise skills keep using `npx canicode …`.",
     ].join("\n");
   }
 
@@ -79,7 +79,7 @@ export function formatNextSteps(opts: {
     "         claude mcp add -s project -t http figma https://mcp.figma.com/mcp",
     "    2. Restart Claude Code (so the new skills + Figma MCP tools both load)",
     "    3. Run /canicode-roundtrip <figma-url>",
-    "    • Optional — faster canicode MCP than `npx`: `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp`, then restart Claude Code so MCP tools load — otherwise skills shell out to `npx canicode …` (#433).",
+    "    • Optional — faster canicode MCP than `npx`: `claude mcp add canicode -- npx --yes --package=canicode canicode-mcp`, then restart Claude Code so MCP tools load — otherwise skills shell out to `npx canicode …`.",
   ].join("\n");
 }
 

--- a/src/cli/commands/upsert-gotcha-section.ts
+++ b/src/cli/commands/upsert-gotcha-section.ts
@@ -76,7 +76,7 @@ const USER_MESSAGES: Record<string, string> = {
   missing:
     "Gotchas SKILL.md not found at the given path. Run `canicode init` first, then re-invoke this skill.",
   clobbered:
-    "Your gotchas SKILL.md is missing the canicode YAML frontmatter (pre-#340 single-design clobber). Run `canicode init --force` to restore the workflow, then re-run this survey.",
+    "Your gotchas SKILL.md is missing the canicode YAML frontmatter. Run `canicode init --force` to restore the workflow, then re-run this survey.",
 };
 
 async function readStdin(): Promise<string> {

--- a/src/cli/docs.ts
+++ b/src/cli/docs.ts
@@ -57,7 +57,7 @@ CANICODE SETUP GUIDE
     --preset strict|relaxed|dev-friendly|ai-ready
     --config ./my-config.json
     --no-open   Don't open report in browser
-    --api       No-op for Figma URLs (REST always); same flag as gotcha-survey (#461)
+    --api       No-op for Figma URLs (REST always); same flag as gotcha-survey
 
   Output:
     ~/.canicode/reports/report-YYYY-MM-DD-HH-mm-<filekey>.html

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -63,9 +63,9 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     preset: z.enum(["relaxed", "dev-friendly", "ai-ready", "strict"]).optional().describe("Analysis preset"),
     targetNodeId: z.string().optional().describe("Scope analysis to a specific node ID"),
     configPath: z.string().optional().describe("Path to config JSON file for rule overrides"),
-    openReport: z.boolean().optional().describe("Open the generated HTML report in the user's browser. Defaults to false — opt in only when a visible report is the explicit user request (#365). The HTML file is always written to disk regardless."),
-    acknowledgments: z.array(AcknowledgmentSchema).optional().describe("(#371 / ADR-019) Pre-resolved acknowledgments from canicode-authored Figma annotations (e.g. via readCanicodeAcknowledgments in a use_figma batch). Each entry includes nodeId and ruleId; newer annotations may also carry intent, sceneWriteOutcome, and codegenDirective from a canicode-json fenced block (#444). Matching issues are flagged acknowledged and contribute half weight to the density score."),
-    scope: z.enum(["page", "component"]).optional().describe("(#404) Override analysis scope — `page` (screen/section where container bounds are required) or `component` (standalone reusable unit where root FILL is the design contract). Defaults to auto-detection from the root node type: `COMPONENT` / `COMPONENT_SET` / `INSTANCE` roots resolve to `component`, everything else to `page`."),
+    openReport: z.boolean().optional().describe("Open the generated HTML report in the user's browser. Defaults to false — opt in only when a visible report is the explicit user request. The HTML file is always written to disk regardless."),
+    acknowledgments: z.array(AcknowledgmentSchema).optional().describe("Pre-resolved acknowledgments from canicode-authored Figma annotations (e.g. via readCanicodeAcknowledgments in a use_figma batch). Each entry includes nodeId and ruleId; newer annotations may also carry intent, sceneWriteOutcome, and codegenDirective from a canicode-json fenced block. Matching issues are flagged acknowledged and contribute half weight to the density score."),
+    scope: z.enum(["page", "component"]).optional().describe("Override analysis scope — `page` (screen/section where container bounds are required) or `component` (standalone reusable unit where root FILL is the design contract). Defaults to auto-detection from the root node type: `COMPONENT` / `COMPONENT_SET` / `INSTANCE` roots resolve to `component`, everything else to `page`."),
     codegenReadyMinGrade: z.enum(["S", "A+", "A", "B+", "B", "C+", "C", "D", "F"]).optional().describe("Minimum grade for code-gen readiness. Overrides the codegenReadyMinGrade field in configPath. Default: A"),
   },
   {
@@ -183,7 +183,7 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
     preset: z.enum(["relaxed", "dev-friendly", "ai-ready", "strict"]).optional().describe("Analysis preset"),
     targetNodeId: z.string().optional().describe("Scope analysis to a specific node ID"),
     configPath: z.string().optional().describe("Path to config JSON file for rule overrides"),
-    scope: z.enum(["page", "component"]).optional().describe("(#404) Override analysis scope — `page` or `component`. Defaults to auto-detection from the root node type."),
+    scope: z.enum(["page", "component"]).optional().describe("Override analysis scope — `page` or `component`. Defaults to auto-detection from the root node type."),
     codegenReadyMinGrade: z.enum(["S", "A+", "A", "B+", "B", "C+", "C", "D", "F"]).optional().describe("Minimum grade for code-gen readiness. Overrides the codegenReadyMinGrade field in configPath. Default: A"),
   },
   {
@@ -375,7 +375,7 @@ Get your token: Figma → Settings → Security → Personal access tokens → G
 claude mcp add canicode -- npx --yes --package=canicode canicode-mcp
 \`\`\`
 
-Requires FIGMA_TOKEN for live Figma URL analysis. The MCP server reads it from \`~/.canicode/config.json\` (set via \`canicode init --token …\`) or from the host's environment, so do **not** pass \`-e FIGMA_TOKEN=…\` to \`claude mcp add\` — \`@anthropic-ai/claude-code\`'s current parser rejects short-form flags placed before \`--\`. (#364, #366)
+Requires FIGMA_TOKEN for live Figma URL analysis. The MCP server reads it from \`~/.canicode/config.json\` (set via \`canicode init --token …\`) or from the host's environment, so do **not** pass \`-e FIGMA_TOKEN=…\` to \`claude mcp add\` — \`@anthropic-ai/claude-code\`'s current parser rejects short-form flags placed before \`--\`.
 
 ## CLI only (no MCP server)
 


### PR DESCRIPTION
## Summary

Removes \`(#NNN)\` and \`[ADR-NNN]\` callouts from places users actually see — they don't need internal traceability.

## Touched (user-facing)

- **README.md** — body prose + ADR-012/ADR-013 link removals (6 sites)
- **docs/CUSTOMIZATION.md** — section headings + inline parens (5 sites)
- **CLI option help** — \`analyze\` (\`--api\`, \`--acknowledgments\`, \`--scope\`), \`gotcha-survey\` (\`--api\`, \`--scope\`), \`docs\` (\`--api\`)
- **CLI console output** — \`init\` next-steps "Optional faster MCP" lines (4 branches)
- **CLI error message** — \`upsert-gotcha-section\` clobbered-state message
- **MCP tool descriptions** — \`analyze\` schema (openReport, acknowledgments, scope), \`gotcha-survey\` schema (scope), and the setup topic prose

## Skipped (intentionally)

- \`*.test.ts\` — issue refs are part of test descriptions
- JSDoc / code comments — developer-facing only
- \`src/cli/commands/internal/*\` — non-user-facing internal commands
- \`SKILL.md\` files — these are LLM orchestration cookbooks where ADR/#NNN refs anchor the recipe (e.g. ADR-016 means "logic lives in bundled code, not skill prose"). Stripping would lose context the LLM needs to behave correctly.

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm test:run\` — 1144 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)