### PR TITLE
feat: Split init into interactive setup + separate token-refresh command

### DIFF
--- a/src/cli/commands/config.test.ts
+++ b/src/cli/commands/config.test.ts
@@ -1,0 +1,195 @@
+import cac from "cac";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const setFigmaToken = vi.hoisted(() => vi.fn());
+const setTelemetryEnabled = vi.hoisted(() => vi.fn());
+const readConfig = vi.hoisted(() => vi.fn(() => ({})));
+const getFigmaToken = vi.hoisted(() => vi.fn(() => undefined as string | undefined));
+const getConfigPath = vi.hoisted(() => vi.fn(() => "/tmp/canicode-test/config.json"));
+const getReportsDir = vi.hoisted(() => vi.fn(() => "/tmp/canicode-test/reports"));
+const trackEvent = vi.hoisted(() => vi.fn());
+const promptForFigmaToken = vi.hoisted(() => vi.fn());
+
+vi.mock("../../core/engine/config-store.js", () => ({
+  setFigmaToken,
+  setTelemetryEnabled,
+  readConfig,
+  getFigmaToken,
+  getConfigPath,
+  getReportsDir,
+}));
+
+vi.mock("../../core/monitoring/index.js", () => ({
+  trackEvent,
+  trackError: vi.fn(),
+  EVENTS: {
+    CLI_CONFIG_SET_TOKEN: "cic_cli_config_set_token",
+  },
+}));
+
+vi.mock("../prompts.js", async () => {
+  class NonInteractiveError extends Error {
+    constructor(message = "Interactive prompt requires a TTY") {
+      super(message);
+      this.name = "NonInteractiveError";
+    }
+  }
+  return {
+    promptForFigmaToken,
+    NonInteractiveError,
+    maskFigmaToken: (t: string | undefined) => {
+      if (!t) return "(empty)";
+      if (t.startsWith("figd_") && t.length > 9) return `figd_••••••••${t.slice(-4)}`;
+      if (t.length >= 4) return `••••••••${t.slice(-4)}`;
+      return "•".repeat(t.length);
+    },
+  };
+});
+
+import { registerConfig } from "./config.js";
+
+let logs: string[] = [];
+let errors: string[] = [];
+let origLog: typeof console.log;
+let origError: typeof console.error;
+let origExitCode: number | string | undefined;
+let origEnvToken: string | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  readConfig.mockReturnValue({});
+  getFigmaToken.mockReturnValue(undefined);
+  promptForFigmaToken.mockImplementation(async () => {
+    const { NonInteractiveError } = await import("../prompts.js");
+    throw new NonInteractiveError();
+  });
+  logs = [];
+  errors = [];
+  origLog = console.log;
+  origError = console.error;
+  origExitCode = process.exitCode;
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map(String).join(" "));
+  };
+  console.error = (...args: unknown[]) => {
+    errors.push(args.map(String).join(" "));
+  };
+  origEnvToken = process.env["FIGMA_TOKEN"];
+  delete process.env["FIGMA_TOKEN"];
+});
+
+afterEach(() => {
+  console.log = origLog;
+  console.error = origError;
+  process.exitCode = origExitCode;
+  if (origEnvToken === undefined) {
+    delete process.env["FIGMA_TOKEN"];
+  } else {
+    process.env["FIGMA_TOKEN"] = origEnvToken;
+  }
+});
+
+async function runConfig(args: string[]): Promise<void> {
+  const cli = cac("canicode");
+  registerConfig(cli);
+  const origArgv = process.argv;
+  process.argv = ["node", "canicode", "config", ...args];
+  try {
+    cli.parse(process.argv, { run: false });
+    await cli.runMatchedCommand();
+  } finally {
+    process.argv = origArgv;
+  }
+}
+
+describe("config set-token", () => {
+  it("with --token writes the token via setFigmaToken and emits telemetry (non-interactive)", async () => {
+    await runConfig(["set-token", "--token", "figd_round_trip"]);
+    expect(setFigmaToken).toHaveBeenCalledWith("figd_round_trip");
+    expect(promptForFigmaToken).not.toHaveBeenCalled();
+    expect(trackEvent).toHaveBeenCalledWith(
+      "cic_cli_config_set_token",
+      expect.objectContaining({ interactive: false }),
+    );
+    expect(logs.join("\n")).toContain("Token saved:");
+  });
+
+  it("without --token in non-TTY exits with code 1 and prints CI hint", async () => {
+    await runConfig(["set-token"]);
+    expect(setFigmaToken).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(errors.join("\n")).toMatch(/--token|FIGMA_TOKEN/);
+  });
+
+  it("with TTY uses the prompt and emits telemetry with interactive: true", async () => {
+    promptForFigmaToken.mockResolvedValueOnce("figd_from_prompt");
+    await runConfig(["set-token"]);
+    expect(setFigmaToken).toHaveBeenCalledWith("figd_from_prompt");
+    expect(trackEvent).toHaveBeenCalledWith(
+      "cic_cli_config_set_token",
+      expect.objectContaining({ interactive: true }),
+    );
+  });
+});
+
+describe("config show", () => {
+  it("masks the stored token and prints config + reports paths", async () => {
+    readConfig.mockReturnValue({ figmaToken: "figd_abcdefgh1234", telemetry: true });
+    getFigmaToken.mockReturnValue("figd_abcdefgh1234");
+    await runConfig(["show"]);
+    const out = logs.join("\n");
+    expect(out).toContain("figd_••••••••1234");
+    expect(out).toContain("/tmp/canicode-test/config.json");
+    expect(out).toContain("/tmp/canicode-test/reports");
+    expect(out).toContain("Telemetry:   enabled");
+  });
+
+  it("annotates env-sourced token with (env: FIGMA_TOKEN)", async () => {
+    process.env["FIGMA_TOKEN"] = "figd_envtoken9999";
+    getFigmaToken.mockReturnValue("figd_envtoken9999");
+    await runConfig(["show"]);
+    const out = logs.join("\n");
+    expect(out).toContain("(env: FIGMA_TOKEN)");
+    expect(out).toContain("figd_••••••••9999");
+  });
+
+  it("shows (empty) when no token is configured", async () => {
+    await runConfig(["show"]);
+    expect(logs.join("\n")).toContain("Figma token: (empty)");
+  });
+});
+
+describe("config path", () => {
+  it("prints exactly the absolute config path", async () => {
+    await runConfig(["path"]);
+    expect(logs).toEqual(["/tmp/canicode-test/config.json"]);
+  });
+});
+
+describe("config (no action)", () => {
+  it("--no-telemetry disables telemetry and does not show config", async () => {
+    await runConfig(["--no-telemetry"]);
+    expect(setTelemetryEnabled).toHaveBeenCalledWith(false);
+    expect(logs.join("\n")).toContain("Telemetry disabled");
+    expect(logs.join("\n")).not.toContain("CANICODE CONFIG");
+  });
+
+  it("--telemetry enables telemetry", async () => {
+    await runConfig(["--telemetry"]);
+    expect(setTelemetryEnabled).toHaveBeenCalledWith(true);
+    expect(logs.join("\n")).toContain("Telemetry enabled");
+  });
+
+  it("no args delegates to show", async () => {
+    await runConfig([]);
+    expect(logs.join("\n")).toContain("CANICODE CONFIG");
+  });
+});
+
+describe("config invalid action", () => {
+  it("prints error and exits 1 for unknown action", async () => {
+    await runConfig(["bogus"]);
+    expect(process.exitCode).toBe(1);
+    expect(errors.join("\n")).toMatch(/Unknown config action/);
+  });
+});

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1,42 +1,127 @@
 import type { CAC } from "cac";
 
 import {
-  getConfigPath, readConfig, setTelemetryEnabled,
+  getConfigPath,
+  getFigmaToken,
+  getReportsDir,
+  readConfig,
+  setFigmaToken,
+  setTelemetryEnabled,
 } from "../../core/engine/config-store.js";
+import { trackEvent, EVENTS } from "../../core/monitoring/index.js";
+import { maskFigmaToken, NonInteractiveError, promptForFigmaToken } from "../prompts.js";
 
 interface ConfigOptions {
   telemetry?: boolean;
+  token?: string;
+}
+
+const VALID_ACTIONS = ["set-token", "show", "path"] as const;
+type ConfigAction = (typeof VALID_ACTIONS)[number];
+
+function isConfigAction(value: string | undefined): value is ConfigAction {
+  return value !== undefined && (VALID_ACTIONS as readonly string[]).includes(value);
+}
+
+function printConfigShow(): void {
+  const cfg = readConfig();
+  const envToken = process.env["FIGMA_TOKEN"];
+  const effectiveToken = getFigmaToken();
+  const tokenSource = envToken ? " (env: FIGMA_TOKEN)" : "";
+
+  console.log("CANICODE CONFIG\n");
+  console.log(`  Config path: ${getConfigPath()}`);
+  console.log(`  Reports dir: ${getReportsDir()}`);
+  console.log(`  Figma token: ${maskFigmaToken(effectiveToken)}${tokenSource}`);
+  console.log(`  Telemetry:   ${cfg.telemetry !== false ? "enabled" : "disabled"}`);
+  console.log(`\nOptions:`);
+  console.log(`  canicode config set-token         Update saved Figma token (no skill reinstall)`);
+  console.log(`  canicode config show              Show current configuration`);
+  console.log(`  canicode config path              Print absolute config path`);
+  console.log(`  canicode config --no-telemetry    Opt out of anonymous telemetry`);
+  console.log(`  canicode config --telemetry       Opt back in`);
+}
+
+async function handleSetToken(options: ConfigOptions): Promise<void> {
+  let token = options.token;
+  const usedFlag = Boolean(token);
+  if (!token) {
+    try {
+      token = await promptForFigmaToken();
+    } catch (err) {
+      if (err instanceof NonInteractiveError) {
+        console.error(
+          "Run with --token <token> or set FIGMA_TOKEN=… (interactive prompt requires a TTY).",
+        );
+        process.exitCode = 1;
+        return;
+      }
+      throw err;
+    }
+  }
+
+  setFigmaToken(token);
+  console.log(`Token saved: ${getConfigPath()}`);
+  trackEvent(EVENTS.CLI_CONFIG_SET_TOKEN, { interactive: !usedFlag });
 }
 
 export function registerConfig(cli: CAC): void {
+  // cac (v7) does not match space-delimited multi-word command names cleanly
+  // when an overlapping shorter command exists (`config` vs. `config set-token`):
+  // it greedy-matches the shorter one and rejects the inner flag as unknown.
+  // Use a single command with a positional `[action]` and dispatch internally
+  // — the plan in #505 anticipated this fallback.
   cli
-    .command("config", "Manage canicode configuration")
+    .command("config [action]", "Manage canicode configuration (actions: set-token, show, path)")
     .option("--telemetry", "Enable anonymous telemetry")
     .option("--no-telemetry", "Disable anonymous telemetry")
-    .action((options: ConfigOptions) => {
+    .option("--token <token>", "For `config set-token`: set token non-interactively (CI / non-TTY)")
+    .action(async (action: string | undefined, options: ConfigOptions) => {
       try {
-        // CAC maps --no-telemetry to options.telemetry === false
-        if (options.telemetry === false) {
+        if (action !== undefined && !isConfigAction(action)) {
+          console.error(
+            `Unknown config action: ${action}. Available: ${VALID_ACTIONS.join(", ")}`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+
+        if (action === "set-token") {
+          await handleSetToken(options);
+          return;
+        }
+
+        if (action === "path") {
+          console.log(getConfigPath());
+          return;
+        }
+
+        if (action === "show") {
+          printConfigShow();
+          return;
+        }
+
+        // No action — telemetry flags only flip when explicitly passed. cac
+        // defaults `options.telemetry` to `true` whenever `--no-telemetry` is
+        // registered, so checking the parsed value alone would always trip
+        // and shadow the show-config fallback.
+        const argv = process.argv.slice(2);
+        const flippedOff = argv.includes("--no-telemetry");
+        const flippedOn = argv.includes("--telemetry");
+
+        if (flippedOff) {
           setTelemetryEnabled(false);
           console.log("Telemetry disabled. No analytics data will be sent.");
           return;
         }
 
-        if (options.telemetry === true) {
+        if (flippedOn) {
           setTelemetryEnabled(true);
           console.log("Telemetry enabled. Only anonymous usage events are tracked — no design data.");
           return;
         }
 
-        // No flags: show current config
-        const cfg = readConfig();
-        console.log("CANICODE CONFIG\n");
-        console.log(`  Config path: ${getConfigPath()}`);
-        console.log(`  Figma token: ${cfg.figmaToken ? "set" : "not set"}`);
-        console.log(`  Telemetry:   ${cfg.telemetry !== false ? "enabled" : "disabled"}`);
-        console.log(`\nOptions:`);
-        console.log(`  canicode config --no-telemetry    Opt out of anonymous telemetry`);
-        console.log(`  canicode config --telemetry       Opt back in`);
+        printConfigShow();
       } catch (error) {
         console.error(
           "\nError:",

--- a/src/cli/commands/init-skills-only.test.ts
+++ b/src/cli/commands/init-skills-only.test.ts
@@ -9,6 +9,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const installSkills = vi.hoisted(() => vi.fn());
 const installCursorBundledSkills = vi.hoisted(() => vi.fn());
 const trackEvent = vi.hoisted(() => vi.fn());
+const promptForFigmaToken = vi.hoisted(() => vi.fn());
+const initAiready = vi.hoisted(() => vi.fn());
+const getConfigPath = vi.hoisted(() => vi.fn(() => "/tmp/canicode-test/config.json"));
+const getReportsDir = vi.hoisted(() => vi.fn(() => "/tmp/canicode-test/reports"));
 
 vi.mock("../skill-installer.js", () => ({
   installSkills,
@@ -19,6 +23,24 @@ vi.mock("../../core/monitoring/index.js", () => ({
   trackEvent,
   trackError: vi.fn(),
   EVENTS: { CLI_INIT: "cic_cli_init" },
+}));
+
+vi.mock("../prompts.js", async () => {
+  // Keep NonInteractiveError as a real class so `instanceof` checks in init.ts
+  // continue to work against thrown errors from the mocked prompt.
+  class NonInteractiveError extends Error {
+    constructor(message = "Interactive prompt requires a TTY") {
+      super(message);
+      this.name = "NonInteractiveError";
+    }
+  }
+  return { promptForFigmaToken, NonInteractiveError };
+});
+
+vi.mock("../../core/engine/config-store.js", () => ({
+  initAiready,
+  getConfigPath,
+  getReportsDir,
 }));
 
 import { registerInit } from "./init.js";
@@ -42,6 +64,12 @@ beforeEach(() => {
     overwritten: [],
     skipped: [],
     targetDir: join(tempCwd, ".cursor", "skills"),
+  });
+  // Default: prompt rejects as non-interactive (matches vitest's stdin which
+  // is not a TTY). Individual tests can override with mockResolvedValueOnce.
+  promptForFigmaToken.mockImplementation(async () => {
+    const { NonInteractiveError } = await import("../prompts.js");
+    throw new NonInteractiveError();
   });
 });
 
@@ -70,7 +98,7 @@ describe("registerInit skills without token (#461)", () => {
     );
   });
 
-  it("prints setup guide when no token and no skill flags", async () => {
+  it("prints setup guide when no token, no skill flags, and stdin is not a TTY", async () => {
     const logs: string[] = [];
     const origLog = console.log;
     console.log = (...args: unknown[]) => {
@@ -91,5 +119,50 @@ describe("registerInit skills without token (#461)", () => {
     expect(installSkills).not.toHaveBeenCalled();
     expect(installCursorBundledSkills).not.toHaveBeenCalled();
     expect(logs.join("\n")).toContain("CANICODE SETUP");
+  });
+});
+
+describe("registerInit interactive (#505)", () => {
+  it("TTY + no flags: prompts for token, runs initAiready, installs skills", async () => {
+    promptForFigmaToken.mockResolvedValueOnce("figd_interactive_test");
+    const prev = process.cwd();
+    process.chdir(tempCwd);
+    try {
+      const cli = cac("canicode");
+      registerInit(cli);
+      cli.parse(["node", "canicode", "init"], { run: false });
+      await cli.runMatchedCommand();
+    } finally {
+      process.chdir(prev);
+    }
+
+    expect(promptForFigmaToken).toHaveBeenCalledTimes(1);
+    expect(initAiready).toHaveBeenCalledWith("figd_interactive_test");
+    expect(installSkills).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith(
+      "cic_cli_init",
+      expect.objectContaining({ interactive: true, skillStepOk: true }),
+    );
+  });
+
+  it("--token branch: emits telemetry with interactive: false", async () => {
+    const prev = process.cwd();
+    process.chdir(tempCwd);
+    try {
+      const cli = cac("canicode");
+      registerInit(cli);
+      cli.parse(["node", "canicode", "init", "--token", "figd_flag_test"], { run: false });
+      await cli.runMatchedCommand();
+    } finally {
+      process.chdir(prev);
+    }
+
+    expect(promptForFigmaToken).not.toHaveBeenCalled();
+    expect(initAiready).toHaveBeenCalledWith("figd_flag_test");
+    expect(installSkills).toHaveBeenCalledTimes(1);
+    expect(trackEvent).toHaveBeenCalledWith(
+      "cic_cli_init",
+      expect.objectContaining({ interactive: false, skillStepOk: true }),
+    );
   });
 });

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -12,6 +12,7 @@ import {
   installCursorBundledSkills,
 } from "../skill-installer.js";
 import { trackEvent, EVENTS } from "../../core/monitoring/index.js";
+import { promptForFigmaToken, NonInteractiveError } from "../prompts.js";
 
 function figmaEntryInMcpFile(filePath: string): boolean {
   try {
@@ -105,6 +106,60 @@ function wantsSkillInstallWithoutToken(options: InitOptions): boolean {
 }
 
 /**
+ * Save token, install skills, print next steps, emit telemetry. Shared between
+ * the `--token` and interactive (no-flag TTY) branches so they cannot drift.
+ */
+async function runFullInit(
+  token: string,
+  options: InitOptions,
+  interactive: boolean,
+): Promise<void> {
+  initAiready(token);
+
+  console.log(`  Config saved: ${getConfigPath()}`);
+  console.log(`  Reports will be saved to: ${getReportsDir()}/`);
+
+  const { skillStepOk, skillSummary } = await runInitSkillInstallSteps(options);
+
+  trackEvent(EVENTS.CLI_INIT, {
+    skillsRequested: true,
+    cursorSkillsRequested: options.cursorSkills === true,
+    skillStepOk,
+    target: options.global ? "global" : "project",
+    force: options.force ?? false,
+    interactive,
+    ...(skillSummary ?? {}),
+  });
+
+  if (skillStepOk) {
+    console.log(
+      formatNextSteps({
+        figmaMcpPresent: figmaMcpRegistered(),
+        skillsInstalled: true,
+        cursorSkillsInstalled: options.cursorSkills === true,
+      }),
+    );
+  }
+}
+
+function printSetupGuide(): void {
+  console.log(`CANICODE SETUP\n`);
+  console.log(
+    `  Never paste your token into Claude/Cursor chat — use FIGMA_TOKEN=… npx canicode init or this prompt only.\n`,
+  );
+  console.log(`  canicode init --token YOUR_FIGMA_TOKEN`);
+  console.log(`  Get token: figma.com > Settings > Personal access tokens\n`);
+  console.log(`Skills:`);
+  console.log(`  --token also installs three Claude Code skills into ./.claude/skills/`);
+  console.log(`  (canicode, canicode-gotchas, canicode-roundtrip).`);
+  console.log(`  --global       Install to ~/.claude/skills/ instead`);
+  console.log(`  --cursor-skills Install Claude skills under .claude/skills/ plus Cursor copies under .cursor/skills/ (no --token yet — add --token when ready for REST analyze)`);
+  console.log(`  --force        Overwrite existing skill files without prompting\n`);
+  console.log(`After setup:`);
+  console.log(`  canicode analyze "https://www.figma.com/design/..."`);
+}
+
+/**
  * Install Claude skills, optional gotchas-only path, then optional Cursor bundle.
  * Mirrors the `--token` branch so behavior stays aligned (#461).
  */
@@ -190,31 +245,7 @@ export function registerInit(cli: CAC): void {
         const options = parseResult.data;
 
         if (options.token) {
-          initAiready(options.token);
-
-          console.log(`  Config saved: ${getConfigPath()}`);
-          console.log(`  Reports will be saved to: ${getReportsDir()}/`);
-
-          const { skillStepOk, skillSummary } = await runInitSkillInstallSteps(options);
-
-          trackEvent(EVENTS.CLI_INIT, {
-            skillsRequested: true,
-            cursorSkillsRequested: options.cursorSkills === true,
-            skillStepOk,
-            target: options.global ? "global" : "project",
-            force: options.force ?? false,
-            ...(skillSummary ?? {}),
-          });
-
-          if (skillStepOk) {
-            console.log(
-              formatNextSteps({
-                figmaMcpPresent: figmaMcpRegistered(),
-                skillsInstalled: true,
-                cursorSkillsInstalled: options.cursorSkills === true,
-              }),
-            );
-          }
+          await runFullInit(options.token, options, false);
           return;
         }
 
@@ -246,21 +277,20 @@ export function registerInit(cli: CAC): void {
           return;
         }
 
-        // No flags: show setup guide
-        console.log(`CANICODE SETUP\n`);
-        console.log(
-          `  Never paste your token into Claude/Cursor chat — use FIGMA_TOKEN=… npx canicode init or this prompt only.\n`,
-        );
-        console.log(`  canicode init --token YOUR_FIGMA_TOKEN`);
-        console.log(`  Get token: figma.com > Settings > Personal access tokens\n`);
-        console.log(`Skills:`);
-        console.log(`  --token also installs three Claude Code skills into ./.claude/skills/`);
-        console.log(`  (canicode, canicode-gotchas, canicode-roundtrip).`);
-        console.log(`  --global       Install to ~/.claude/skills/ instead`);
-        console.log(`  --cursor-skills Install Claude skills under .claude/skills/ plus Cursor copies under .cursor/skills/ (no --token yet — add --token when ready for REST analyze)`);
-        console.log(`  --force        Overwrite existing skill files without prompting\n`);
-        console.log(`After setup:`);
-        console.log(`  canicode analyze "https://www.figma.com/design/..."`);
+        // No flags + TTY: prompt for token interactively. Non-TTY (CI without
+        // --token) falls through to the existing setup guide so we never hang.
+        try {
+          const token = await promptForFigmaToken();
+          await runFullInit(token, options, true);
+          return;
+        } catch (promptError) {
+          if (!(promptError instanceof NonInteractiveError)) {
+            throw promptError;
+          }
+          // fall through to setup guide
+        }
+
+        printSetupGuide();
       } catch (error) {
         console.error(
           "\nError:",

--- a/src/cli/docs.ts
+++ b/src/cli/docs.ts
@@ -42,12 +42,14 @@ CANICODE SETUP GUIDE
     npm install -g canicode
 
   Setup:
-    canicode init --token figd_xxxxxxxxxxxxx
+    canicode init                              (interactive prompt; TTY)
+    canicode init --token figd_xxxxxxxxxxxxx   (non-TTY / CI)
+    FIGMA_TOKEN=figd_xxx canicode init         (env-driven)
     (saves token + installs Claude Code skills into ./.claude/skills/)
 
   Skills only (no token yet):
     canicode init --cursor-skills
-    (installs Claude skills + Cursor copies; run init --token … before live Figma REST URLs)
+    (installs Claude skills + Cursor copies; run init or init --token … before live Figma REST URLs)
 
   Use:
     canicode analyze "https://www.figma.com/design/ABC123/MyDesign?node-id=1-234"
@@ -69,7 +71,8 @@ CANICODE SETUP GUIDE
   (Same token safety as above — env var or interactive prompt, not chat.)
 
   Setup:
-    canicode init --token figd_xxxxxxxxxxxxx
+    canicode init                              (interactive prompt; TTY)
+    canicode init --token figd_xxxxxxxxxxxxx   (non-TTY / CI)
     (installs three skills into ./.claude/skills/ alongside the token)
 
   Installed skills:
@@ -94,7 +97,8 @@ CANICODE SETUP GUIDE
   (Same token safety as above — env var or interactive prompt, not chat.)
 
   Setup:
-    canicode init --token figd_xxxxxxxxxxxxx --cursor-skills
+    canicode init --cursor-skills                              (interactive prompt; TTY)
+    canicode init --token figd_xxxxxxxxxxxxx --cursor-skills   (non-TTY / CI)
     (installs Cursor copies of the three skills into ./.cursor/skills/)
 
   Installed skills:
@@ -123,6 +127,14 @@ CANICODE SETUP GUIDE
 
   See also: docs/CUSTOMIZATION.md#cursor-mcp-canicode (Figma MCP required for roundtrip
   writes; analyze-only works without it).
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ MANAGE CONFIG
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  canicode config set-token   Rotate Figma token (no skill reinstall)
+  canicode config show        Print masked token + config + reports paths
+  canicode config path        Print absolute config path (script-friendly)
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  TOKEN PRIORITY

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -65,6 +65,15 @@ describe.skipIf(!existsSync(CLI_PATH))("CLI --help", () => {
     expect(taglineIndex).toBeLessThan(usageIndex);
   });
 
+  it("should advertise the interactive `canicode init` and `config set-token` lines in --help", () => {
+    const output = execFileSync("node", [CLI_PATH, "--help"], {
+      encoding: "utf-8",
+    });
+    expect(output).toContain("Interactive setup");
+    expect(output).toContain("canicode init --token <token>");
+    expect(output).toContain("canicode config set-token");
+  });
+
   it("should allow direct invocation of internal commands", () => {
     const output = execFileSync(
       "node",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -125,7 +125,11 @@ cli.help((sections) => {
   sections.push(
     {
       title: "\nSetup",
-      body: `  canicode init --token <token>   Save Figma token to ~/.canicode/`,
+      body: [
+        `  canicode init                   Interactive setup (prompts for token)`,
+        `  canicode init --token <token>   Non-interactive setup (CI / non-TTY)`,
+        `  canicode config set-token       Rotate token without reinstalling skills`,
+      ].join("\n"),
     },
     {
       title: "\nData source",

--- a/src/cli/prompts.test.ts
+++ b/src/cli/prompts.test.ts
@@ -1,0 +1,101 @@
+import { Writable } from "node:stream";
+
+import { vi } from "vitest";
+
+const createInterface = vi.hoisted(() => vi.fn());
+vi.mock("node:readline/promises", () => ({ createInterface }));
+
+import { maskFigmaToken, NonInteractiveError, promptForFigmaToken } from "./prompts.js";
+
+function sinkOutput(): { stream: NodeJS.WritableStream; chunks: string[] } {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  return { stream, chunks };
+}
+
+function makeRl(answers: string[]): { question: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> } {
+  const queue = [...answers];
+  const question = vi.fn().mockImplementation(async () => {
+    if (queue.length === 0) {
+      throw new Error("No more queued answers");
+    }
+    return queue.shift()!;
+  });
+  const close = vi.fn();
+  return { question, close };
+}
+
+beforeEach(() => {
+  createInterface.mockReset();
+});
+
+describe("promptForFigmaToken", () => {
+  it("reads a trimmed token from injected input", async () => {
+    const rl = makeRl(["  figd_abc123  "]);
+    createInterface.mockReturnValue(rl);
+    const { stream: output } = sinkOutput();
+    const token = await promptForFigmaToken({ output, isTTY: true });
+    expect(token).toBe("figd_abc123");
+    expect(rl.close).toHaveBeenCalled();
+  });
+
+  it("re-prompts when input is empty, then returns the next non-empty value", async () => {
+    const rl = makeRl(["", "   ", "figd_ok"]);
+    createInterface.mockReturnValue(rl);
+    const { stream: output, chunks } = sinkOutput();
+    const token = await promptForFigmaToken({ output, isTTY: true, maxAttempts: 3 });
+    expect(token).toBe("figd_ok");
+    expect(chunks.join("")).toContain("Token cannot be empty");
+    expect(rl.question).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws after maxAttempts of empty input", async () => {
+    const rl = makeRl(["", "", ""]);
+    createInterface.mockReturnValue(rl);
+    const { stream: output } = sinkOutput();
+    await expect(
+      promptForFigmaToken({ output, isTTY: true, maxAttempts: 3 }),
+    ).rejects.toThrow(/No token provided/);
+    expect(rl.close).toHaveBeenCalled();
+  });
+
+  it("throws NonInteractiveError when isTTY is false (without opening readline)", async () => {
+    const { stream: output } = sinkOutput();
+    await expect(
+      promptForFigmaToken({ output, isTTY: false }),
+    ).rejects.toBeInstanceOf(NonInteractiveError);
+    expect(createInterface).not.toHaveBeenCalled();
+  });
+});
+
+describe("maskFigmaToken", () => {
+  it("masks a figd_ token preserving prefix and last 4 chars", () => {
+    expect(maskFigmaToken("figd_abcdefgh1234")).toBe("figd_••••••••1234");
+  });
+
+  it("masks a generic long token with last 4 chars", () => {
+    expect(maskFigmaToken("0123456789abcd")).toBe("••••••••abcd");
+  });
+
+  it("returns bullets only for short tokens (< 4 chars)", () => {
+    expect(maskFigmaToken("abc")).toBe("•••");
+  });
+
+  it("returns (empty) for undefined", () => {
+    expect(maskFigmaToken(undefined)).toBe("(empty)");
+  });
+
+  it("returns (empty) for empty string", () => {
+    expect(maskFigmaToken("")).toBe("(empty)");
+  });
+
+  it("masks figd_ token shorter than 10 chars as a generic token (no prefix branch)", () => {
+    // length 6 — fails `> 9` check, falls through to the >= 4 branch
+    expect(maskFigmaToken("figd_x")).toBe("••••••••gd_x");
+  });
+});

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -1,0 +1,75 @@
+import * as readline from "node:readline/promises";
+
+/**
+ * Thrown by `promptForFigmaToken` when stdin is not a TTY.
+ *
+ * Callers pattern-match on this so each command can choose its own non-TTY
+ * fallback (init prints the setup guide; config set-token prints a CI hint).
+ */
+export class NonInteractiveError extends Error {
+  constructor(message = "Interactive prompt requires a TTY") {
+    super(message);
+    this.name = "NonInteractiveError";
+  }
+}
+
+interface PromptOpts {
+  input?: NodeJS.ReadableStream;
+  output?: NodeJS.WritableStream;
+  isTTY?: boolean;
+  maxAttempts?: number;
+}
+
+/**
+ * Read a Figma token interactively from stdin.
+ *
+ * Input is echoed (Node readline does not expose hidden-input cleanly without
+ * a third-party dep). For sensitive workflows use `--token` or `FIGMA_TOKEN=…`.
+ */
+export async function promptForFigmaToken(opts: PromptOpts = {}): Promise<string> {
+  const isTTY = opts.isTTY ?? process.stdin.isTTY ?? false;
+  if (!isTTY) {
+    throw new NonInteractiveError();
+  }
+
+  const input = opts.input ?? process.stdin;
+  const output = opts.output ?? process.stdout;
+  const maxAttempts = opts.maxAttempts ?? 3;
+
+  // Let readline auto-detect terminal mode from output.isTTY — real CLI use
+  // gets line-editing; tests with PassThrough streams parse line-by-line.
+  const rl = readline.createInterface({ input, output });
+  try {
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const answer = (await rl.question("Figma token: ")).trim();
+      if (answer.length > 0) {
+        return answer;
+      }
+      if (attempt < maxAttempts) {
+        output.write("Token cannot be empty. Try again.\n");
+      }
+    }
+    throw new Error(`No token provided after ${maxAttempts} attempts`);
+  } finally {
+    rl.close();
+  }
+}
+
+/**
+ * Mask a Figma token for display: `figd_••••••••1234`.
+ *
+ * Preserves the `figd_` prefix when present so users can tell at a glance the
+ * stored value looks like a Figma personal access token.
+ */
+export function maskFigmaToken(token: string | undefined): string {
+  if (!token) return "(empty)";
+
+  const BULLETS = "••••••••";
+  if (token.startsWith("figd_") && token.length > 9) {
+    return `figd_${BULLETS}${token.slice(-4)}`;
+  }
+  if (token.length >= 4) {
+    return `${BULLETS}${token.slice(-4)}`;
+  }
+  return "•".repeat(token.length);
+}

--- a/src/core/monitoring/events.ts
+++ b/src/core/monitoring/events.ts
@@ -26,6 +26,7 @@ export const EVENTS = {
   // CLI
   CLI_COMMAND: `${EVENT_PREFIX}cli_command`,
   CLI_INIT: `${EVENT_PREFIX}cli_init`,
+  CLI_CONFIG_SET_TOKEN: `${EVENT_PREFIX}cli_config_set_token`,
 
   // Roundtrip (ADR-012)
   // Wiring point for the roundtrip helper's `telemetry` callback. No Node-side

--- a/src/core/monitoring/index.test.ts
+++ b/src/core/monitoring/index.test.ts
@@ -73,6 +73,7 @@ describe("monitoring module", () => {
       expect(EVENTS.MCP_TOOL_CALLED).toBe("cic_mcp_tool_called");
       expect(EVENTS.CLI_COMMAND).toBe("cic_cli_command");
       expect(EVENTS.CLI_INIT).toBe("cic_cli_init");
+      expect(EVENTS.CLI_CONFIG_SET_TOKEN).toBe("cic_cli_config_set_token");
       expect(EVENTS.ROUNDTRIP_DEFINITION_WRITE_SKIPPED).toBe(
         "cic_roundtrip_definition_write_skipped",
       );


### PR DESCRIPTION
## Summary

Issue #505 wants two clean concepts: `canicode init` becomes interactive first-time setup (prompt for token in TTY, fall back to existing setup guide when non-TTY without --token), and a new `canicode config` surface (`set-token`, `show`, `path`) for lightweight config-only operations that do NOT reinstall skills. Today `canicode init` with no flags is a dead-end (prints a guide telling the user to re-run with --token), and the only way to rotate a token is to re-run `init --token` (which also reinstalls all three skills) or hand-edit `~/.canicode/config.json`. The fix: add a small interactive prompt helper + a token-mask helper, wire an interactive branch into the existing `registerInit` action (preserving the non-TTY guide as the fallback), expand the existing `config` command into multiple subcommands while keeping the current telemetry flags on the no-args form, and refresh the docs setup text. Reuses existing helpers in `src/core/engine/config-store.ts` (setFigmaToken, readConfig, getConfigPath, getReportsDir) — no new state, no new dependencies.

## Tasks

- Add token prompt + mask helpers
- Wire interactive token prompt into `canicode init` (no flags, TTY)
- Expand `canicode config` with `set-token`, `show`, `path` subcommands
- Update `canicode docs setup` to reflect the new flow
- Add CLI_CONFIG_SET_TOKEN event + verify lint/tests

## Self-review

Implementation cleanly delivers issue #505: interactive `canicode init`, `config set-token/show/path` subcommands, and updated docs/help. Plan deviations are well-justified (single-command dispatch for cac, argv-based flag detection, tests collocated with the existing init-skills mock harness). All acceptance criteria are met, conventions hold (.js imports, ESM, kebab-case files, co-located *.test.ts), Zod is preserved on the existing init options, and no new runtime deps were added. A handful of minor suggestions only.
- Verdict: approve
- Errors: 0, Warnings: 0, Total: 5

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #505

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))