### PR TITLE
feat: canicode doctor — Code Connect prerequisite check (#512)

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -40,7 +40,7 @@ These workflows compose. A new project typically starts at Workflow 3 (find the 
 - `figma.config.json` configured at the repo root
 - A code component (or a planned slot) corresponding to the Figma component
 
-> If any of the above is missing, set them up first using Figma's Code Connect docs. canicode will eventually detect and warn about missing prerequisites — until then, this is a manual check.
+> Run `canicode doctor` to verify the prerequisites in your repo (`@figma/code-connect` install + `figma.config.json` presence). It exits 0 when everything is in place, 1 with a remediation hint otherwise.
 
 **Today's flow**
 1. Finish the Figma main component (with variants if applicable).

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -1,0 +1,102 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { formatDoctorReport, runCodeConnectChecks } from "./doctor.js";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "canicode-doctor-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function writePkg(deps: Record<string, string> = {}, devDeps: Record<string, string> = {}): void {
+  writeFileSync(
+    join(tmp, "package.json"),
+    JSON.stringify({ name: "fixture", dependencies: deps, devDependencies: devDeps }),
+  );
+}
+
+describe("runCodeConnectChecks", () => {
+  it("flags both checks failed when neither package.json nor figma.config.json exist", () => {
+    const results = runCodeConnectChecks(tmp);
+    expect(results).toHaveLength(2);
+    expect(results.every(r => !r.pass)).toBe(true);
+    expect(results[0]?.remediation).toMatch(/No package\.json/);
+  });
+
+  it("passes when @figma/code-connect is in devDependencies and figma.config.json exists", () => {
+    writePkg({}, { "@figma/code-connect": "^1.2.3" });
+    writeFileSync(join(tmp, "figma.config.json"), "{}");
+    const results = runCodeConnectChecks(tmp);
+    expect(results.every(r => r.pass)).toBe(true);
+    expect(results[0]?.detail).toBe("^1.2.3");
+  });
+
+  it("detects code-connect in dependencies (not just devDependencies)", () => {
+    writePkg({ "@figma/code-connect": "1.0.0" });
+    const results = runCodeConnectChecks(tmp);
+    expect(results[0]?.pass).toBe(true);
+    expect(results[0]?.detail).toBe("1.0.0");
+  });
+
+  it("recommends pnpm install when package.json exists but code-connect is missing", () => {
+    writePkg({}, { vitest: "^1.0.0" });
+    const results = runCodeConnectChecks(tmp);
+    expect(results[0]?.pass).toBe(false);
+    expect(results[0]?.remediation).toMatch(/pnpm add -D @figma\/code-connect/);
+  });
+
+  it("links the Code Connect docs when figma.config.json is missing", () => {
+    writePkg({}, { "@figma/code-connect": "^1.0.0" });
+    const results = runCodeConnectChecks(tmp);
+    expect(results[1]?.pass).toBe(false);
+    expect(results[1]?.remediation).toMatch(/figma\.com\/code-connect-docs/);
+  });
+
+  it("survives a malformed package.json without throwing", () => {
+    writeFileSync(join(tmp, "package.json"), "{ this is not json");
+    const results = runCodeConnectChecks(tmp);
+    expect(results[0]?.pass).toBe(false);
+  });
+});
+
+describe("formatDoctorReport", () => {
+  it("renders ✅/❌ with detail and remediation lines", () => {
+    const out = formatDoctorReport([
+      { name: "@figma/code-connect installed", pass: true, detail: "1.0.0" },
+      {
+        name: "figma.config.json not found at repo root",
+        pass: false,
+        remediation: "see https://www.figma.com/code-connect-docs/",
+      },
+    ]);
+    expect(out).toContain("✅ @figma/code-connect installed (1.0.0)");
+    expect(out).toContain("❌ figma.config.json not found at repo root");
+    expect(out).toContain("→ see https://www.figma.com/code-connect-docs/");
+    expect(out).toContain("Some checks failed");
+  });
+
+  it("ends with all-pass summary when every check passes", () => {
+    const out = formatDoctorReport([
+      { name: "a", pass: true },
+      { name: "b", pass: true },
+    ]);
+    expect(out).toContain("All checks passed.");
+    expect(out).not.toContain("Some checks failed");
+  });
+});
+
+describe("doctor command", () => {
+  it("creates an empty fixture directory and verifies isolation", () => {
+    mkdirSync(join(tmp, "subdir"));
+    const results = runCodeConnectChecks(join(tmp, "subdir"));
+    expect(results.every(r => !r.pass)).toBe(true);
+  });
+});

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,0 +1,121 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { CAC } from "cac";
+
+import { trackEvent, EVENTS } from "../../core/monitoring/index.js";
+
+interface DoctorCheckResult {
+  name: string;
+  pass: boolean;
+  detail?: string;
+  remediation?: string;
+}
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+const CODE_CONNECT_PKG = "@figma/code-connect";
+const CODE_CONNECT_DOCS = "https://www.figma.com/code-connect-docs/";
+
+function readPackageJson(cwd: string): PackageJson | undefined {
+  const pkgPath = join(cwd, "package.json");
+  if (!existsSync(pkgPath)) return undefined;
+  try {
+    return JSON.parse(readFileSync(pkgPath, "utf-8")) as PackageJson;
+  } catch {
+    return undefined;
+  }
+}
+
+function findCodeConnectVersion(pkg: PackageJson | undefined): string | undefined {
+  if (!pkg) return undefined;
+  return pkg.dependencies?.[CODE_CONNECT_PKG] ?? pkg.devDependencies?.[CODE_CONNECT_PKG];
+}
+
+export function runCodeConnectChecks(cwd: string): DoctorCheckResult[] {
+  const pkg = readPackageJson(cwd);
+  const ccVersion = findCodeConnectVersion(pkg);
+  const figmaConfigExists = existsSync(join(cwd, "figma.config.json"));
+
+  const results: DoctorCheckResult[] = [];
+
+  if (ccVersion) {
+    results.push({
+      name: `${CODE_CONNECT_PKG} installed`,
+      pass: true,
+      detail: ccVersion,
+    });
+  } else {
+    results.push({
+      name: `${CODE_CONNECT_PKG} not installed`,
+      pass: false,
+      remediation: pkg
+        ? `pnpm add -D ${CODE_CONNECT_PKG}  (or npm/yarn equivalent)`
+        : `No package.json found at ${cwd} — run from your project root, or initialise one first.`,
+    });
+  }
+
+  if (figmaConfigExists) {
+    results.push({
+      name: "figma.config.json found at repo root",
+      pass: true,
+    });
+  } else {
+    results.push({
+      name: "figma.config.json not found at repo root",
+      pass: false,
+      remediation: `see ${CODE_CONNECT_DOCS}`,
+    });
+  }
+
+  return results;
+}
+
+export function formatDoctorReport(results: DoctorCheckResult[]): string {
+  const lines: string[] = ["Code Connect"];
+  for (const result of results) {
+    const icon = result.pass ? "✅" : "❌";
+    const detail = result.detail ? ` (${result.detail})` : "";
+    lines.push(`  ${icon} ${result.name}${detail}`);
+    if (!result.pass && result.remediation) {
+      lines.push(`     → ${result.remediation}`);
+    }
+  }
+  lines.push("");
+  const allPass = results.every(r => r.pass);
+  lines.push(
+    allPass
+      ? "All checks passed."
+      : "Some checks failed. Fix the items above before running the Code Connect flow.",
+  );
+  return lines.join("\n");
+}
+
+export function registerDoctor(cli: CAC): void {
+  cli
+    .command(
+      "doctor",
+      "Diagnose Code Connect prerequisites (`@figma/code-connect`, `figma.config.json`)",
+    )
+    .action(() => {
+      const cwd = process.cwd();
+      const results = runCodeConnectChecks(cwd);
+      console.log(formatDoctorReport(results));
+
+      const passed = results.filter(r => r.pass).length;
+      const failed = results.length - passed;
+
+      trackEvent(EVENTS.CLI_DOCTOR, {
+        passed,
+        failed,
+        total: results.length,
+      });
+
+      if (failed > 0) {
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import { registerDesignTree } from "./commands/design-tree.js";
 import { registerVisualCompare } from "./commands/visual-compare.js";
 import { registerInit } from "./commands/init.js";
 import { registerConfig } from "./commands/config.js";
+import { registerDoctor } from "./commands/doctor.js";
 import { registerListRules } from "./commands/list-rules.js";
 import { registerRoundtripTally } from "./commands/roundtrip-tally.js";
 
@@ -77,6 +78,7 @@ registerDesignTree(cli);
 registerVisualCompare(cli);
 registerInit(cli);
 registerConfig(cli);
+registerDoctor(cli);
 registerListRules(cli);
 registerRoundtripTally(cli);
 

--- a/src/core/monitoring/events.ts
+++ b/src/core/monitoring/events.ts
@@ -27,6 +27,7 @@ export const EVENTS = {
   CLI_COMMAND: `${EVENT_PREFIX}cli_command`,
   CLI_INIT: `${EVENT_PREFIX}cli_init`,
   CLI_CONFIG_SET_TOKEN: `${EVENT_PREFIX}cli_config_set_token`,
+  CLI_DOCTOR: `${EVENT_PREFIX}cli_doctor`,
 
   // Roundtrip (ADR-012)
   // Wiring point for the roundtrip helper's `telemetry` callback. No Node-side


### PR DESCRIPTION
## Summary

Phase 1 sub-task 1 of #509 — adds a new `canicode doctor` CLI command that diagnoses whether the consuming repo has the Code Connect prerequisites in place (`@figma/code-connect` installed, `figma.config.json` present at root).

Why this is needed: every later Phase 1 step (MCP wrapper, invoke surface, match-confirmation UX) silently dead-ends with a confusing Figma MCP error if these prerequisites are missing. `canicode doctor` surfaces them up front with one-line remediation.

Closes #512.

## Behavior

```
$ canicode doctor

Code Connect
  ❌ @figma/code-connect not installed
     → pnpm add -D @figma/code-connect  (or npm/yarn equivalent)
  ❌ figma.config.json not found at repo root
     → see https://www.figma.com/code-connect-docs/

Some checks failed. Fix the items above before running the Code Connect flow.
```

- Exit code: 0 when all checks pass, 1 otherwise.
- Output is plain CLI text — humans and LLMs (when invoked from a skill) both read it. No `--json` flag (out of scope per #512).
- v1 only diagnoses Code Connect prerequisites; FIGMA_TOKEN / skill-install / MCP-registration checks are explicit follow-ups, not part of this PR.

## Implementation notes

- `runCodeConnectChecks(cwd)` and `formatDoctorReport(results)` are pure helpers, fully unit-tested with a tmp-dir fixture per case.
- `figma.config.json` contents are **not** parsed — file presence only. The Figma CLI validates contents at `figma connect publish` time, so duplicating that here adds false-positive risk for no real signal.
- Telemetry: new `cic_cli_doctor` event records `passed` / `failed` / `total` counts only. No file paths, no contents.
- WORKFLOWS.md Workflow 1 prerequisites note now points at `canicode doctor`.

## Test plan

- [x] `pnpm lint` — green
- [x] `pnpm test:run` — 1177 pass (9 new doctor tests)
- [x] `pnpm build` — clean
- [x] Smoke test: empty dir → both fail, exit 1
- [x] Smoke test: dir with package.json (devDeps) + figma.config.json → both pass, exit 0
- [ ] Reviewer to verify: `canicode --help` lists `doctor` after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)