### PR TITLE
feat(roundtrip): close canicode-roundtrip with a Code Connect mapping step (#515)

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -466,9 +466,13 @@ Follow the **figma-implement-design** skill workflow to generate code from the F
 
 **If all issues were resolved in Steps 4-5**, no additional gotcha context is needed — the design speaks for itself.
 
-#### Wrap-up message rubric (post-handoff)
+After `figma-implement-design` returns, **proceed to Step 7** (Code Connect close-out). Step 7 also owns the final wrap-up message — do not print the post-handoff wrap-up here. The post-handoff wrap-up rubric below is only used when Step 7 is skipped at its entry condition (see Step 7 — Entry condition).
 
-After `figma-implement-design` returns, summarise the roundtrip in the same shape as the Step 5 / Stop wrap-up — issues-delta first, then code-gen outcome; grade at most one optional footline (#423).
+#### Wrap-up message rubric (post-handoff, fallback only)
+
+Used **only when Step 7 is skipped at its entry condition** (e.g., the user invoked the roundtrip on a screen-level node, not a single component). Otherwise the Step 7 wrap-up below replaces this one.
+
+Summarise the roundtrip in the same shape as the Step 5 / Stop wrap-up — issues-delta first, then code-gen outcome; grade at most one optional footline (#423).
 
 ```
 Roundtrip complete — N issues addressed, code generated:
@@ -489,7 +493,16 @@ Code: <files generated / next-step pointer from figma-implement-design>
 
 ### Step 7: Close out with a Code Connect mapping
 
-After `figma-implement-design` returns, register a Code Connect mapping pointing the roundtrip's Figma component at the just-generated code so future roundtrips on screens containing this component reuse the implementation instead of regenerating markup. **Only run this step when the user invoked the roundtrip on a single Figma component / main component**, not on a screen-level node — multi-component mapping is out of scope for v1 (#515).
+Final step of the roundtrip. Registers a Code Connect mapping pointing the Figma component at the just-generated code so future roundtrips on screens containing this component reuse the implementation instead of regenerating markup. Step 7 owns the final wrap-up — when this step runs (whether it ends in mapped, skipped, or failed), use the wrap-up rubric at the end of this section instead of the Step 6 fallback.
+
+#### Step 7 — Entry condition (single-component scope)
+
+v1 only fires Step 7 when the roundtrip was invoked against a **single Figma main component**. Multi-component mapping for screen-level roundtrips is out of scope (#515 calls this out as v1.5).
+
+To decide: read the analyze response from Step 1 — the top-level node's `type` (or equivalent in `get_design_context`) tells you whether it is `COMPONENT` / `COMPONENT_SET` (single-component scope, run Step 7) versus `FRAME` / `SECTION` / `INSTANCE` containing many descendants (screen-level, skip Step 7).
+
+- **Single-component (COMPONENT / COMPONENT_SET)** — proceed to Step 7a.
+- **Screen-level (anything else)** — print one line: "Roundtrip invoked on a screen-level node — Code Connect mapping is per-component. Re-invoke `/canicode-roundtrip` against an individual main component to register a mapping." Then fall back to the Step 6 post-handoff wrap-up rubric (the fallback rubric immediately above this section). Do not print the Step 7 wrap-up.
 
 #### Step 7a: Re-check prerequisites
 

--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -3,8 +3,10 @@ name: canicode-roundtrip
 description: |
   Run the full design-to-code roundtrip — analyze a Figma design, surface gotchas, write
   designer answers back into the file via the Figma Plugin API (use_figma), re-analyze to
-  confirm the gotchas were captured, then hand off to figma-implement-design. Mutates the
-  Figma file: requires Figma full seat + edit access.
+  confirm the gotchas were captured, hand off to figma-implement-design, then optionally
+  register a Code Connect mapping pointing the Figma component at the just-generated code
+  so future roundtrips reuse the implementation. Mutates the Figma file: requires Figma
+  full seat + edit access.
 
   TRIGGER when: the user shares a figma.com/design/... URL and wants production-quality
   code, or asks for "design-to-code roundtrip", "fix the gotchas", or "annotate the Figma
@@ -83,6 +85,26 @@ Show the user a brief summary:
 ```
 Design grade: **{grade}** ({percentage}%) — {issueCount} issues found.
 ```
+
+### Step 1.5: Code Connect prerequisite pre-check (soft warn)
+
+The closing step (Step 7) registers a Code Connect mapping for the just-implemented design, which requires the user's repo to have `@figma/code-connect` installed and `figma.config.json` present. Surfacing missing prerequisites *now* avoids the "spent 10 minutes on the survey, then found out I can't actually save the mapping" surprise.
+
+Run `canicode doctor` (added in #513). If the host is running the bundled CLI:
+
+```bash
+npx canicode doctor
+```
+
+Branch on exit code:
+
+- **Exit 0 (all checks pass)** — silent. Continue to Step 2.
+- **Exit 1 (any check failed)** — print the doctor's remediation lines verbatim, then prompt:
+  > "Code Connect is not configured in this repo. The roundtrip will still generate code, but the closing mapping step (Step 7) will be skipped. Continue anyway? (Y/n)"
+  - **Y** (default) — proceed to Step 2. Remember the prereq state so Step 7 can short-circuit without re-explaining.
+  - **n** — stop the whole roundtrip cleanly. Tell the user: "Set up Code Connect and re-invoke `/canicode-roundtrip` when ready."
+
+Default is `Y` because many users genuinely just want code generation today and have not chosen to adopt Code Connect yet — the soft warn informs without blocking.
 
 ### Step 2: Surface grade as informational banner
 
@@ -464,6 +486,71 @@ Code: <files generated / next-step pointer from figma-implement-design>
 ```
 
 (Drop the `↳` lines when `V_ack == 0`.)
+
+### Step 7: Close out with a Code Connect mapping
+
+After `figma-implement-design` returns, register a Code Connect mapping pointing the roundtrip's Figma component at the just-generated code so future roundtrips on screens containing this component reuse the implementation instead of regenerating markup. **Only run this step when the user invoked the roundtrip on a single Figma component / main component**, not on a screen-level node — multi-component mapping is out of scope for v1 (#515).
+
+#### Step 7a: Re-check prerequisites
+
+Re-run `canicode doctor`. The pre-check in Step 1.5 may have failed and the user may have set up Code Connect mid-flow, or it may have passed and still pass — either way, this is the source of truth for the close-out branch.
+
+- **Exit 0** — proceed to 7b.
+- **Exit 1** — print the doctor's remediation, then exit cleanly with:
+  > "Roundtrip steps 1–6 succeeded. Code Connect mapping skipped because the prerequisites above are missing — set them up and re-invoke `/canicode-roundtrip` to register the mapping."
+
+This step's failure must not retroactively fail the earlier steps; their output is independently valuable.
+
+#### Step 7b: Confirm satisfaction with the generated code
+
+```
+figma-implement-design generated the code at <path>. Are you satisfied with this implementation? (y/N)
+```
+
+Default is `N` — the inverse of Step 1.5's default — because registering a mapping makes a permanent claim about which code represents this Figma component. Asking the user to opt in deliberately is the safer posture.
+
+- **N or skip** — exit cleanly: "Mapping not registered. You can re-invoke `/canicode-roundtrip` later if you want to map a future revision."
+- **y** — continue to 7c.
+
+If `figma-implement-design`'s output did not surface the generated code path in a structured way, prompt the user for it before proceeding. Do not try to scan for "recently modified files" — too fragile.
+
+#### Step 7c: Check existing mapping
+
+Call `get_code_connect_map` for the Figma component's node-id (from the original input URL).
+
+- If a mapping **exists** for this component, show the user the current mapping target and ask:
+  > "A Code Connect mapping already exists for this component, pointing at `<existing-path>`. Update it to `<new-path>`? (y/N)"
+  - **N** — exit cleanly, leaving the existing mapping intact.
+  - **y** — proceed to 7d.
+- If **no mapping exists**, proceed straight to 7d.
+
+#### Step 7d: Register the mapping
+
+Call `add_code_connect_map` with the Figma node-id + generated code path, then `send_code_connect_mappings` to publish.
+
+On success, print:
+> "Code Connect mapping registered: `<figma-component>` → `<code-path>`. Future roundtrips on screens containing this component will reuse the code."
+
+On failure (Figma MCP returns an error), print the error verbatim and tell the user the rest of the roundtrip succeeded — the mapping can be added later via Figma CLI (`figma connect publish`) or by re-invoking the roundtrip.
+
+#### Wrap-up message rubric (with mapping outcome)
+
+Extend the Step 6 wrap-up block with one final line describing the mapping outcome — `✅ mapped`, `⏭️ skipped (user)`, `⏭️ skipped (prereq)`, or `❌ failed`. Keep grade at most one optional footline (#423).
+
+```
+Roundtrip complete — N issues addressed, code generated, mapping <state>:
+  ✅  X resolved
+  📝  Y annotated on Figma (referenced during code-gen)
+  🌐  Z definition writes propagated
+  ⏭️  W skipped
+  —
+  V issues remaining
+     ↳ V_ack acknowledged via canicode annotations
+     ↳ V_open unaddressed
+
+Code: <files generated / next-step pointer from figma-implement-design>
+Code Connect: <mapping outcome line>
+```
 
 ## Edge cases
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -38,7 +38,7 @@ These workflows compose. A new project typically starts at Workflow 3 (find the 
 **Prerequisites in your code repo**
 - `@figma/code-connect` installed (`pnpm add -D @figma/code-connect`)
 - `figma.config.json` configured at the repo root
-- A code component (or a planned slot) corresponding to the Figma component
+- A code component corresponding to the Figma component (existing — or one that `figma-implement-design` will generate during the roundtrip)
 
 > Run `canicode doctor` to verify the prerequisites in your repo (`@figma/code-connect` install + `figma.config.json` presence). It exits 0 when everything is in place, 1 with a remediation hint otherwise.
 

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -29,7 +29,7 @@ These workflows compose. A new project typically starts at Workflow 3 (find the 
 
 ## Workflow 1 — Component-to-code mapping
 
-> 🚧 Partial — `analyze` and `roundtrip` ship today. Code Connect integration is the next milestone (epic #509).
+> 🚧 Partial — `analyze`, `roundtrip`, and `doctor` ship today. The roundtrip's closing Code Connect mapping step is the next milestone (epic #509, sub-issue #515).
 
 **You are**: a designer creating a single component (Button, Card, Input...) on purpose, knowing it should be reused in code.
 
@@ -44,16 +44,11 @@ These workflows compose. A new project typically starts at Workflow 3 (find the 
 
 **Today's flow**
 1. Finish the Figma main component (with variants if applicable).
-2. Run `canicode analyze <component-url>` to confirm the component itself has no blocking gotchas (missing names, off-grid spacing, etc.).
-3. Apply any answers via `/canicode-roundtrip` (Claude Code) or `@ canicode-roundtrip` (Cursor).
-4. Register the Code Connect mapping **manually** using the Figma CLI today (`figma connect create`, `figma connect publish`).
-
-**Planned flow (when #509 ships)**
-1. Same first three steps.
-2. Invoke `canicode componentize` (or the equivalent skill) on the selected component.
-3. canicode calls `get_code_connect_suggestions` to surface candidate code components, with rationale (name match, prop shape, file path).
-4. You confirm the right candidate (or pick "no match — generate one" → handoff to `figma-implement-design`).
-5. canicode registers the mapping via `add_code_connect_map` / `send_code_connect_mappings`.
+2. Run `canicode doctor` once per repo to confirm `@figma/code-connect` and `figma.config.json` are in place.
+3. Run `/canicode-roundtrip <component-url>` (Claude Code) or `@ canicode-roundtrip <component-url>` (Cursor). The roundtrip walks you through analyze → gotcha survey → apply → re-analyze → handoff to `figma-implement-design`, then closes with a Code Connect mapping prompt:
+   - If prerequisites are missing, the soft warn at the top tells you up front so you can stop and set them up — no time wasted on the survey.
+   - After `figma-implement-design` finishes, you confirm whether the generated code is satisfactory. On `y`, canicode calls `add_code_connect_map` + `send_code_connect_mappings` so the next roundtrip on a screen containing this component reuses the code instead of regenerating markup.
+4. (Optional) For an existing code component you want to map without regenerating, use Figma's CLI directly (`figma connect create`, `figma connect publish`) — canicode's mapping flow is currently scoped to fresh code from a roundtrip.
 
 **Outcome**: every Figma main component has a 1:1 Code Connect mapping. Downstream `figma-implement-design` calls reuse the mapped code component instead of regenerating markup.
 


### PR DESCRIPTION
## Summary

Closes #515. Phase 1 (#509) sub-task 2 — extend `canicode-roundtrip` so successful runs leave a permanent Code Connect mapping behind. Future roundtrips on screens containing this component reuse the just-generated code via the mapping instead of regenerating markup.

## Changes

- `.claude/skills/canicode-roundtrip/SKILL.md`
  - **Step 1.5 (soft warn)** — runs `canicode doctor` right after analyze. If prerequisites are missing, prints the doctor's remediation lines plus a Y/n prompt (default `Y`). Lets users opt out before spending time on the survey when they know they don't have Code Connect set up.
  - **Step 7 (hard close-out)** — runs after `figma-implement-design` returns. Re-checks `canicode doctor` (user may have installed prereqs mid-flow), asks satisfaction with the generated code (default `N` — opt-in to a permanent claim), checks existing mapping via `get_code_connect_map`, prompts update vs keep when one exists, then calls `add_code_connect_map` + `send_code_connect_mappings`.
  - **Wrap-up rubric** extended with a final `Code Connect: <outcome>` line (`✅ mapped` / `⏭️ skipped (user)` / `⏭️ skipped (prereq)` / `❌ failed`).
  - **Frontmatter description** updated to mention the new closing step.
- `docs/WORKFLOWS.md`
  - Workflow 1 status note now points at the close-out as the next milestone (`#515`).
  - \"Today's flow\" rewritten to fold the closing step into `/canicode-roundtrip`. Standalone \"Planned flow\" block removed — the planned flow IS the today's flow now.

## Architecture notes

- Skill-only edit. No new Node code, no new CLI command, no `src/core/` module.
- Bundle script (`pnpm bundle:skills`) auto-propagates the canonical SKILL.md to `skills/canicode-roundtrip/` and `skills/cursor/canicode-roundtrip/`. Verified post-build.
- `add_code_connect_map` / `send_code_connect_mappings` / `get_code_connect_map` are called by the host (Claude Code / Cursor) directly per the skill's instructions — canicode is not a Figma MCP client.
- Failure isolation: any error in Step 7 must not retroactively fail steps 1–6. Each step's output is independently valuable.
- v1 is **single-component scope**. Multi-component mapping for screen-level roundtrips is explicitly out of scope (#515 calls this out as v1.5).

## Test plan

- [x] `pnpm lint` — green
- [x] `pnpm test:run` — 1177 pass (no test changes needed; skill-only edit)
- [x] `pnpm build` — clean; both bundled SKILL.md copies (Claude + Cursor) contain Step 1.5 + Step 7
- [ ] Manual smoke test on a real Figma component → end-to-end Step 1.5 → Step 6 → Step 7 close-out (deferred to onboarding-test follow-up since this requires a live Figma file + Code Connect repo setup)
- [ ] Reviewer to verify: with Code Connect prereqs missing, soft warn appears at Step 1.5 and Step 7 short-circuits cleanly without rolling back steps 1–6.

## Out of scope (per #515)

- Standalone `canicode-componentize` skill (#514, closed — wrong shape).
- `analyze` rule that flags unmapped components (separate optional sub-task in #509).
- Multi-component mapping for screen-level roundtrips (v1.5+).
- Variants / props mapping beyond what `add_code_connect_map` exposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)