### PR TITLE
feat(scoring): add zero-score `note` severity tier + backfill info-collection rules (#519)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,8 +188,9 @@ Rules are classified into 4 severity levels:
 - **risk**: Implementable now but will break or increase cost later.
 - **missing-info**: Information is absent, forcing developers to guess.
 - **suggestion**: Not immediately problematic, but improves systemization.
+- **note** (#519): Zero-impact tier. Surfaces in the report and (when `purpose === "info-collection"`) feeds the gotcha survey, but never moves the grade. Use for annotation-primary rules whose value is the nudge, not the score (e.g. `missing-prototype`, `missing-interaction-state`, `missing-size-constraint`, `unmapped-component`).
 
-Severity labels describe user impact, while rule purpose may differ (ADR-017): rules perform rule-based best-practice detection, and gotcha is annotation output from that detection pass. Violation rules remain score-primary best-practice checks; info-collection rules are annotation-primary checks for context Figma cannot encode. In practice, info-collection rules should usually stay in low-penalty ranges (commonly `missing-info` or `suggestion` severity, depending on implementation risk).
+Severity labels describe user impact, while rule purpose may differ (ADR-017): rules perform rule-based best-practice detection, and gotcha is annotation output from that detection pass. Violation rules remain score-primary best-practice checks; info-collection rules are annotation-primary checks for context Figma cannot encode. The canonical home for info-collection rules is `note` (zero-score) so the gotcha can fire without distorting the grade; older rules may still sit at `missing-info` or `suggestion` until backfilled.
 
 ## Adjustable Rule Config
 

--- a/app/shared/styles.css
+++ b/app/shared/styles.css
@@ -57,6 +57,7 @@ body {
 .sev-risk { background: var(--amber); }
 .sev-missing { background: #a1a1aa; }
 .sev-suggestion { background: var(--green); }
+.sev-note { background: #d4d4d8; }
 
 /* ---- Print ---- */
 @media print {
@@ -453,6 +454,7 @@ body {
 .rpt-issue-score.sev-risk     { background: var(--amber-bg); color: #d97706; border-color: rgba(245,158,11,0.2); }
 .rpt-issue-score.sev-missing  { background: #f4f4f5; color: #71717a; border-color: rgba(113,113,122,0.2); }
 .rpt-issue-score.sev-suggestion { background: var(--green-bg); color: #16a34a; border-color: rgba(34,197,94,0.2); }
+.rpt-issue-score.sev-note     { background: #f4f4f5; color: #71717a; border-color: rgba(113,113,122,0.2); }
 
 .rpt-issue-body {
   padding: 12px;

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -106,7 +106,7 @@ Override score, severity, or enable/disable individual rules:
 | Rule ID | Default Score | Default Severity |
 |---------|--------------|-----------------|
 | `fixed-size-in-auto-layout` | -6 | risk |
-| `missing-size-constraint` | -1 | missing-info |
+| `missing-size-constraint` | 0 | note |
 
 **Code Quality (4 rules)**
 
@@ -136,8 +136,8 @@ Override score, severity, or enable/disable individual rules:
 
 | Rule ID | Default Score | Default Severity |
 |---------|--------------|-----------------|
-| `missing-interaction-state` | -1 | missing-info |
-| `missing-prototype` | -1 | missing-info |
+| `missing-interaction-state` | 0 | note |
+| `missing-prototype` | 0 | note |
 <!-- RULE_TABLE_END -->
 
 ### Example Configs

--- a/src/core/contracts/mcp-response.ts
+++ b/src/core/contracts/mcp-response.ts
@@ -26,6 +26,7 @@ const CategoryScoreResultSchema = z.object({
     risk: z.number().int().min(0),
     "missing-info": z.number().int().min(0),
     suggestion: z.number().int().min(0),
+    note: z.number().int().min(0),
   }),
 });
 

--- a/src/core/contracts/severity.ts
+++ b/src/core/contracts/severity.ts
@@ -5,6 +5,13 @@ export const SeveritySchema = z.enum([
   "risk",
   "missing-info",
   "suggestion",
+  /**
+   * `note` is the zero-impact tier (#519): findings render in the report but
+   * never move the grade. Used for annotation-primary rules whose value is the
+   * nudge, not the score (e.g. unmapped Code Connect components, info-collection
+   * rules whose answers belong in figma-implement-design context, not in linting).
+   */
+  "note",
 ]);
 
 export type Severity = z.infer<typeof SeveritySchema>;
@@ -14,6 +21,7 @@ export const SEVERITY_WEIGHT: Record<Severity, number> = {
   risk: 5,
   "missing-info": 2,
   suggestion: 1,
+  note: 0,
 };
 
 export const SEVERITY_LABELS: Record<Severity, string> = {
@@ -21,4 +29,5 @@ export const SEVERITY_LABELS: Record<Severity, string> = {
   risk: "Risk",
   "missing-info": "Missing Info",
   suggestion: "Suggestion",
+  note: "Note",
 };

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -40,6 +40,7 @@ export interface ScoreReport {
     risk: number;
     missingInfo: number;
     suggestion: number;
+    note: number;
     nodeCount: number;
     /**
      * Number of issues marked `acknowledged` by an upstream
@@ -316,6 +317,7 @@ export function calculateScores(
     risk: 0,
     missingInfo: 0,
     suggestion: 0,
+    note: 0,
     nodeCount,
     acknowledgedCount: 0,
   };
@@ -333,6 +335,9 @@ export function calculateScores(
         break;
       case "suggestion":
         summary.suggestion++;
+        break;
+      case "note":
+        summary.note++;
         break;
     }
     if (issue.acknowledged === true) summary.acknowledgedCount++;
@@ -372,6 +377,7 @@ function initializeCategoryScores(): Record<Category, CategoryScoreResult> {
         risk: 0,
         "missing-info": 0,
         suggestion: 0,
+        note: 0,
       },
     };
   }
@@ -400,6 +406,7 @@ export function formatScoreSummary(report: ScoreReport): string {
   lines.push(`  Risk: ${report.summary.risk}`);
   lines.push(`  Missing Info: ${report.summary.missingInfo}`);
   lines.push(`  Suggestion: ${report.summary.suggestion}`);
+  lines.push(`  Note: ${report.summary.note}`);
   if (report.summary.acknowledgedCount > 0) {
     const unaddressed =
       report.summary.totalIssues - report.summary.acknowledgedCount;
@@ -429,6 +436,7 @@ export function getSeverityLabel(severity: Severity): string {
     risk: "Risk",
     "missing-info": "Missing Info",
     suggestion: "Suggestion",
+    note: "Note",
   };
   return labels[severity];
 }

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -38,19 +38,18 @@ export function generateGotchaSurvey(
   // Step 1: Filter to gotcha-relevant issues.
   // - `blocking` + `risk`: violation rules where the user needs to describe
   //   how to resolve the violation (existing behavior).
-  // - `missing-info` + purpose `info-collection` (#406): annotation-primary
+  // - any severity + purpose `info-collection` (#406, #519): annotation-primary
   //   rules like `missing-prototype` / `missing-interaction-state` where the
-  //   gotcha IS the output. Without this, info-collection rules would never
-  //   reach the survey because their penalty is intentionally minimal.
-  // `suggestion` severity still stays out — it's prose-level advice, not an
-  // implementation gap Figma can't encode.
+  //   gotcha IS the output. The severity tier is incidental — what matters is
+  //   `purpose`. After #519 the canonical home for these rules is `note`
+  //   (zero-score) but earlier versions placed them in `missing-info`; both
+  //   should keep surfacing as gotchas.
+  // `suggestion` severity stays out by default — it's prose-level advice, not
+  // an implementation gap Figma can't encode.
   const relevantIssues = result.issues.filter((issue) => {
     const severity = issue.config.severity;
     if (severity === "blocking" || severity === "risk") return true;
-    if (severity === "missing-info") {
-      return getRulePurpose(issue.violation.ruleId) === "info-collection";
-    }
-    return false;
+    return getRulePurpose(issue.violation.ruleId) === "info-collection";
   });
 
   // Step 2: Deduplicate — same ruleId on siblings (same parent path) → keep first

--- a/src/core/report-html/render.ts
+++ b/src/core/report-html/render.ts
@@ -95,6 +95,7 @@ ${CATEGORIES.map((cat) => {
         ${renderSummaryDot("sev-risk", scores.summary.risk, "Risk")}
         ${renderSummaryDot("sev-missing", scores.summary.missingInfo, "Missing Info")}
         ${renderSummaryDot("sev-suggestion", scores.summary.suggestion, "Suggestion")}
+        ${renderSummaryDot("sev-note", scores.summary.note, "Note")}
         <div class="rpt-summary-total">
           <span class="rpt-summary-count">${scores.summary.totalIssues}</span>
           <span class="rpt-summary-label">Total</span>
@@ -346,7 +347,7 @@ function groupIssuesByRule(issues: AnalysisIssue[]): RuleGroup[] {
     group.totalScore += issue.calculatedScore;
   }
 
-  const SEVERITY_RANK: Record<string, number> = { blocking: 0, risk: 1, "missing-info": 2, suggestion: 3 };
+  const SEVERITY_RANK: Record<string, number> = { blocking: 0, risk: 1, "missing-info": 2, suggestion: 3, note: 4 };
   return [...byRule.values()].sort((a, b) => {
     const sevDiff = (SEVERITY_RANK[a.severity] ?? 4) - (SEVERITY_RANK[b.severity] ?? 4);
     return sevDiff !== 0 ? sevDiff : a.totalScore - b.totalScore;

--- a/src/core/rules/rule-config.test.ts
+++ b/src/core/rules/rule-config.test.ts
@@ -171,14 +171,14 @@ describe("rule-config sync", () => {
       }
     });
 
-    it("info-collection rules are enabled and use missing-info severity", () => {
+    it("info-collection rules are enabled and use the zero-impact `note` severity (#519)", () => {
       for (const [id, purpose] of Object.entries(RULE_PURPOSE)) {
         if (purpose !== "info-collection") continue;
         const config = RULE_CONFIGS[id as RuleId];
         expect(config.enabled).toBe(true);
-        expect(config.severity).toBe("missing-info");
-        // Score kept minimal — annotation is primary output, not score penalty.
-        expect(config.score).toBeGreaterThanOrEqual(-1);
+        // Annotation is the primary output, so the rule must not move the grade.
+        expect(config.severity).toBe("note");
+        expect(config.score).toBe(0);
       }
     });
 

--- a/src/core/rules/rule-config.ts
+++ b/src/core/rules/rule-config.ts
@@ -137,12 +137,12 @@ export const RULE_CONFIGS: Record<RuleId, RuleConfig> = {
     enabled: true,
   },
   "missing-size-constraint": {
-    // #403: severity downgraded `risk → missing-info` and score from
-    // -8 → -1 to match the new info-collection purpose. Keeping the
-    // rule enabled (not disabled) so its gotchas still surface in the
-    // survey — see RULE_PURPOSE entry above for the full rationale.
-    severity: "missing-info",
-    score: -1,
+    // #403 → #519: info-collection rule. Score is 0 (severity `note`):
+    // its value is the gotcha annotation, not the grade impact. Survey-
+    // generator includes this rule via the `purpose === "info-collection"`
+    // branch so the gotcha keeps surfacing.
+    severity: "note",
+    score: 0,
     enabled: true,
   },
 
@@ -198,13 +198,13 @@ export const RULE_CONFIGS: Record<RuleId, RuleConfig> = {
   // is minimal. Score stays at -1 so re-enabling `missing-prototype` on
   // fixtures that lack `interactionDestinations` (#139) cannot swing grades.
   "missing-interaction-state": {
-    severity: "missing-info",
-    score: -1, // uncalibrated: no metric to validate score (#210), kept at -1 to preserve category visibility
+    severity: "note", // #519: info-collection rule, zero-score tier
+    score: 0,
     enabled: true,
   },
   "missing-prototype": {
-    severity: "missing-info",
-    score: -1, // #406: info-collection — annotation is primary output; score kept minimal so #139 fixtures don't skew calibration
+    severity: "note", // #519: info-collection — annotation is primary output, no grade impact
+    score: 0,
     enabled: true,
   },
 

--- a/src/core/ui-constants.ts
+++ b/src/core/ui-constants.ts
@@ -31,4 +31,5 @@ export const SEVERITY_ORDER: Severity[] = [
   "risk",
   "missing-info",
   "suggestion",
+  "note",
 ];

--- a/src/core/ui-helpers.ts
+++ b/src/core/ui-helpers.ts
@@ -36,6 +36,7 @@ export function severityDot(sev: Severity): string {
     risk: "sev-risk",
     "missing-info": "sev-missing",
     suggestion: "sev-suggestion",
+    note: "sev-note",
   };
   return map[sev];
 }
@@ -47,6 +48,7 @@ export function severityBadge(sev: Severity): string {
     risk: "sev-risk",
     "missing-info": "sev-missing",
     suggestion: "sev-suggestion",
+    note: "sev-note",
   };
   return map[sev];
 }


### PR DESCRIPTION
Closes #519.

## Why

Today's lowest tier is `suggestion` with scores -1 to -3. Rules whose output is annotation-primary (info-collection per ADR-017) want zero score impact, but the model has no zero-score option. The visible workaround in the codebase is `score: -1` plus an apologetic comment ("kept minimal so fixtures don't skew calibration").

User confirmed live in the web app today (2026-04-27) that `missing-prototype` is currently deducting points despite being annotation-only — exactly the misframing this PR closes.

## What changed

### New severity tier
- `note` (label "Note", weight 0). Score is **always 0 by convention**. Sits below `suggestion` in `SEVERITY_ORDER` and `SEVERITY_RANK`.
- Wired through `Severity` schema + type, `SEVERITY_WEIGHT`, `SEVERITY_LABELS`, MCP response `bySeverity` schema, `ScoreReport.summary.note`, scoring switch, `bySeverity` init, `getSeverityLabel`, CLI text formatter, HTML report `renderSummaryDot` + sort.

### Survey-generator filter rewrite
- Old: `missing-info + info-collection` was the only path into the gotcha survey besides `blocking` / `risk`.
- New: any severity + `info-collection` purpose surfaces, so backfilled rules keep generating gotchas after the tier migration. Severity tier is incidental — what matters is purpose.

### Rule backfill
- `missing-prototype`, `missing-interaction-state`, `missing-size-constraint`: severity `missing-info` → `note`, score `-1` → `0`. Apologetic comments stripped — the new tier IS the home, no workaround needed.
- `rule-config.test.ts` assertion updated: info-collection rules must use `note` + score 0.

### CSS + report
- `app/shared/styles.css`: added `.sev-note` (neutral grey, matches the `.sev-missing` pattern).
- `docs/CUSTOMIZATION.md` auto-regenerated by `pnpm tsx scripts/sync-rule-docs.ts`.
- CLAUDE.md severity table extended with the `note` row.

## Calibration impact

Fixtures that triggered any of the three backfilled rules will report slightly higher grades — each rule contributed `-1` before and `0` now. Calibration baselines are **not** part of the unit-test suite (separate pipeline driven by `/calibrate`), so the test pass does not capture this drift.

**Operator action after merge**: re-run `/calibrate --all` to re-snapshot baselines. The drift should be small and uniformly positive — anything else is a regression.

## Follow-ups (tracked, not in this PR)

- **#520** — `unmapped-component` analyze rule that consumes the new tier (#509 sub-task 3).
- **#521** — UX discussion: how should `note` findings surface in the report (separate context section, collapsed, or status quo)? Live evidence motivating this issue is captured in its body.
- **#522** — wiki + ancillary docs sweep after this PR lands.

## Test plan

- [x] `pnpm lint` — green
- [x] `pnpm test:run` — 1177 pass (1 test updated to match new contract)
- [x] `pnpm tsx scripts/sync-rule-docs.ts` — `docs/CUSTOMIZATION.md` + Wiki Rule-Reference auto-regenerated, both reflect `note` / 0 for the three backfilled rules
- [ ] Reviewer to verify HTML report renders the new tier dot (the `.sev-note` CSS), and that survey-generator still emits gotchas for `missing-prototype` / `missing-interaction-state` / `missing-size-constraint` after the severity migration
- [ ] Operator to run `/calibrate --all` post-merge and confirm baseline drift is small + positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)