### PR TITLE
feat(rules): unmapped-component analyze rule (#520)

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -108,7 +108,7 @@ Override score, severity, or enable/disable individual rules:
 | `fixed-size-in-auto-layout` | -6 | risk |
 | `missing-size-constraint` | 0 | note |
 
-**Code Quality (4 rules)**
+**Code Quality (5 rules)**
 
 | Rule ID | Default Score | Default Severity |
 |---------|--------------|-----------------|
@@ -116,6 +116,7 @@ Override score, severity, or enable/disable individual rules:
 | `missing-component` | -7 | risk |
 | `detached-instance` | -4 | risk |
 | `variant-structure-mismatch` | -6 | risk |
+| `unmapped-component` | 0 | note |
 
 **Token Management (2 rules)**
 

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.let-sunny/canicode",
-  "description": "Analyze Figma designs for dev & AI readiness. 16 rules, scoring, HTML reports.",
+  "description": "Analyze Figma designs for dev & AI readiness. 17 rules, scoring, HTML reports.",
   "repository": {
     "url": "https://github.com/let-sunny/canicode",
     "source": "github"

--- a/src/core/contracts/rule.ts
+++ b/src/core/contracts/rule.ts
@@ -138,6 +138,7 @@ export type RuleId =
   | "detached-instance"
   | "variant-structure-mismatch"
   | "deep-nesting"
+  | "unmapped-component"
   // Token Management — raw values without design tokens
   | "raw-value"
   | "irregular-spacing"

--- a/src/core/gotcha/apply-context.ts
+++ b/src/core/gotcha/apply-context.ts
@@ -59,6 +59,7 @@ const STRATEGY_BY_RULE: Record<RuleId, RuleApplyStrategy> = {
   // Strategy C — annotation only
   "absolute-position-in-auto-layout": "annotation",
   "variant-structure-mismatch": "annotation",
+  "unmapped-component": "annotation",
   // Strategy D — auto-fix lower-severity issues from analyze output
   "non-standard-naming": "auto-fix",
   "inconsistent-naming-convention": "auto-fix",
@@ -116,6 +117,7 @@ function resolveTargetProperty(
     case "raw-value":
     case "missing-interaction-state":
     case "missing-prototype":
+    case "unmapped-component":
       return undefined;
   }
 }

--- a/src/core/rules/component/index.ts
+++ b/src/core/rules/component/index.ts
@@ -1,9 +1,12 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
 import type { RuleCheckFn, RuleDefinition, RuleContext } from "../../contracts/rule.js";
 import { getAnalysisState } from "../../contracts/rule.js";
 import type { AnalysisNode } from "../../contracts/figma-node.js";
 import { defineRule } from "../rule-registry.js";
 import { getRuleOption } from "../rule-config.js";
-import { missingComponentMsg, detachedInstanceMsg, variantStructureMismatchMsg } from "../rule-messages.js";
+import { missingComponentMsg, detachedInstanceMsg, variantStructureMismatchMsg, unmappedComponentMsg } from "../rule-messages.js";
 
 // ============================================
 // Helper functions
@@ -363,3 +366,53 @@ export const variantStructureMismatch = defineRule({
   check: variantStructureMismatchCheck,
 });
 
+// ============================================
+// unmapped-component (#520)
+// ============================================
+//
+// Fires once per main component (COMPONENT / COMPONENT_SET) when the consuming
+// repo has Code Connect set up at all (figma.config.json present in cwd). The
+// gotcha drives the user to /canicode-roundtrip for actual mapping
+// registration via the Figma MCP tools — analyze does not parse mapping
+// declarations from the user's *.figma.tsx files yet (deferred to v1.5).
+//
+// v1 limitation: this fires for every main even when already mapped, because
+// canicode does not yet read the actual mapping state. Roundtrip Step 7c
+// (`get_code_connect_map`) does the precise check at registration time. The
+// note severity (score 0) makes this acceptable — false positives do not move
+// the grade, just surface a redundant gotcha that the roundtrip will skip.
+
+const CODE_CONNECT_SETUP_KEY = "unmapped-component:setup-detected";
+
+function codeConnectIsSetUp(context: RuleContext): boolean {
+  return getAnalysisState(context, CODE_CONNECT_SETUP_KEY, () => {
+    return existsSync(join(process.cwd(), "figma.config.json"));
+  });
+}
+
+const unmappedComponentDef: RuleDefinition = {
+  id: "unmapped-component",
+  name: "Unmapped Component",
+  category: "code-quality",
+  why: "Without a Code Connect mapping, figma-implement-design regenerates the same markup every time this component appears in a screen — wasting tokens and risking drift.",
+  impact: "Future roundtrips on screens containing this component cannot reuse your existing code; they regenerate markup that may not match the canonical implementation.",
+  fix: "Run /canicode-roundtrip on this component to register a mapping. Figma's get_code_connect_map will skip if a mapping already exists.",
+};
+
+const unmappedComponentCheck: RuleCheckFn = (node, context) => {
+  if (node.type !== "COMPONENT" && node.type !== "COMPONENT_SET") return null;
+  if (isInsideInstance(context)) return null;
+  if (!codeConnectIsSetUp(context)) return null;
+
+  return {
+    ruleId: unmappedComponentDef.id,
+    nodeId: node.id,
+    nodePath: context.path.join(" > "),
+    ...unmappedComponentMsg(node.name),
+  };
+};
+
+export const unmappedComponent = defineRule({
+  definition: unmappedComponentDef,
+  check: unmappedComponentCheck,
+});

--- a/src/core/rules/component/unmapped-component.test.ts
+++ b/src/core/rules/component/unmapped-component.test.ts
@@ -1,0 +1,110 @@
+import type { RuleContext } from "../../contracts/rule.js";
+import type { AnalysisFile, AnalysisNode } from "../../contracts/figma-node.js";
+import { unmappedComponent } from "./index.js";
+
+function makeNode(overrides?: Partial<AnalysisNode>): AnalysisNode {
+  return {
+    id: "1:1",
+    name: "Button",
+    type: "COMPONENT",
+    visible: true,
+    ...overrides,
+  };
+}
+
+function makeFile(overrides?: Partial<AnalysisFile>): AnalysisFile {
+  return {
+    fileKey: "test-file",
+    name: "Test File",
+    lastModified: "2026-01-01T00:00:00Z",
+    version: "1",
+    document: makeNode({ id: "0:1", name: "Document", type: "DOCUMENT" }),
+    components: {},
+    styles: {},
+    ...overrides,
+  };
+}
+
+let analysisState: Map<string, unknown>;
+
+function makeContext(
+  setupDetected: boolean,
+  overrides?: Partial<RuleContext>,
+): RuleContext {
+  // Pre-seed the analysis state cache so the rule does not actually touch the
+  // filesystem during the test. The cached value short-circuits the existsSync
+  // check inside `codeConnectIsSetUp`.
+  analysisState.set("unmapped-component:setup-detected", setupDetected);
+  return {
+    file: makeFile(),
+    depth: 1,
+    componentDepth: 0,
+    maxDepth: 10,
+    path: ["Page", "Components"],
+    ancestorTypes: [],
+    analysisState,
+    scope: "page",
+    rootNodeType: "FRAME",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  analysisState = new Map();
+});
+
+describe("unmapped-component", () => {
+  it("fires for a COMPONENT when Code Connect is set up", () => {
+    const node = makeNode({ id: "10:1", name: "Button", type: "COMPONENT" });
+    const result = unmappedComponent.check(node, makeContext(true));
+    expect(result).not.toBeNull();
+    expect(result?.ruleId).toBe("unmapped-component");
+    expect(result?.nodeId).toBe("10:1");
+    expect(result?.message).toContain("Button");
+    expect(result?.suggestion).toMatch(/canicode-roundtrip/);
+  });
+
+  it("fires for a COMPONENT_SET when Code Connect is set up", () => {
+    const node = makeNode({ id: "10:2", name: "ButtonVariants", type: "COMPONENT_SET" });
+    const result = unmappedComponent.check(node, makeContext(true));
+    expect(result).not.toBeNull();
+    expect(result?.message).toContain("ButtonVariants");
+  });
+
+  it("does NOT fire when Code Connect is not set up (no figma.config.json)", () => {
+    const node = makeNode({ id: "10:3", type: "COMPONENT" });
+    const result = unmappedComponent.check(node, makeContext(false));
+    expect(result).toBeNull();
+  });
+
+  it("does NOT fire on FRAME / INSTANCE / other node types", () => {
+    for (const type of ["FRAME", "INSTANCE", "RECTANGLE", "TEXT"] as const) {
+      const node = makeNode({ id: `20:${type}`, type });
+      const result = unmappedComponent.check(node, makeContext(true));
+      expect(result, `expected null for type ${type}`).toBeNull();
+    }
+  });
+
+  it("does NOT fire for a COMPONENT nested inside an INSTANCE", () => {
+    const node = makeNode({ id: "30:1", type: "COMPONENT" });
+    const ctx = makeContext(true, { ancestorTypes: ["FRAME", "INSTANCE"] });
+    const result = unmappedComponent.check(node, ctx);
+    expect(result).toBeNull();
+  });
+
+  it("caches the setup detection across calls within one analysis", () => {
+    // First call seeds the cache (true). Second call should reuse the cached
+    // value even if we mutate the underlying world — proves the per-analysis
+    // cache key is honoured rather than re-statting on every node.
+    const node = makeNode({ id: "40:1", type: "COMPONENT" });
+    const ctx = makeContext(true);
+    const first = unmappedComponent.check(node, ctx);
+    expect(first).not.toBeNull();
+
+    // Flip the cached value to false; the rule must now skip — proving it
+    // reads from `analysisState`, not from a fresh filesystem check.
+    ctx.analysisState.set("unmapped-component:setup-detected", false);
+    const second = unmappedComponent.check(node, ctx);
+    expect(second).toBeNull();
+  });
+});

--- a/src/core/rules/gotcha-questions.ts
+++ b/src/core/rules/gotcha-questions.ts
@@ -87,6 +87,12 @@ const GOTCHA_QUESTION_CONTENT: Record<RuleId, GotchaQuestionContent> = {
     hint: "Describe which variant has the correct structure, or if they should all match",
     example: "Default variant is canonical — other variants should toggle child visibility instead of adding/removing elements",
   },
+  "unmapped-component": {
+    ruleId: "unmapped-component",
+    question: '"{nodeName}" has no Code Connect mapping yet. Should we register one so figma-implement-design reuses your code?',
+    hint: "Skip if this component is intentionally unmapped (e.g. marketing-only banner). Otherwise run /canicode-roundtrip on the component to walk through registration.",
+    example: "Yes — map to src/components/Button.tsx so future screens reuse the existing implementation",
+  },
   "deep-nesting": {
     ruleId: "deep-nesting",
     question: '"{nodeName}" is deeply nested. Can some intermediate layers be flattened or extracted?',

--- a/src/core/rules/rule-config.test.ts
+++ b/src/core/rules/rule-config.test.ts
@@ -159,11 +159,12 @@ describe("rule-config sync", () => {
       expect(RULE_PURPOSE["missing-size-constraint"]).toBe("info-collection");
     });
 
-    it("keeps all other non-interaction rules as violation", () => {
+    it("keeps all other non-info-collection rules as violation", () => {
       const infoCollectionRules = new Set([
         "missing-prototype",
         "missing-interaction-state",
         "missing-size-constraint",
+        "unmapped-component", // #520
       ]);
       for (const [id, purpose] of Object.entries(RULE_PURPOSE)) {
         if (infoCollectionRules.has(id)) continue;

--- a/src/core/rules/rule-config.ts
+++ b/src/core/rules/rule-config.ts
@@ -25,6 +25,7 @@ export const RULE_ID_CATEGORY: Record<RuleId, Category> = {
   "detached-instance": "code-quality",
   "variant-structure-mismatch": "code-quality",
   "deep-nesting": "code-quality",
+  "unmapped-component": "code-quality",
   // Token Management
   "raw-value": "token-management",
   "irregular-spacing": "token-management",
@@ -71,6 +72,12 @@ export const RULE_PURPOSE: Record<RuleId, RulePurpose> = {
   "detached-instance": "violation",
   "variant-structure-mismatch": "violation",
   "deep-nesting": "violation",
+  // #520: unmapped-component is annotation-primary. Fires only when the
+  // user has Code Connect set up at all (figma.config.json present in cwd).
+  // The gotcha drives the user to /canicode-roundtrip for actual mapping
+  // registration via the Figma MCP tools — analyze itself does not parse
+  // mapping declarations (deferred to v1.5).
+  "unmapped-component": "info-collection",
   // Token Management
   "raw-value": "violation",
   "irregular-spacing": "violation",
@@ -174,6 +181,16 @@ export const RULE_CONFIGS: Record<RuleId, RuleConfig> = {
     options: {
       maxDepth: 5,
     },
+  },
+  "unmapped-component": {
+    // #520 / #519: zero-impact tier. Fires per main component when Code
+    // Connect is set up in the consuming repo (figma.config.json at cwd).
+    // Score is 0 because the rule's value is the gotcha + roundtrip handoff,
+    // not the grade signal — designers who deliberately do not map (e.g.
+    // marketing-only banners) are not punished.
+    severity: "note",
+    score: 0,
+    enabled: true,
   },
 
   // ── Token Management ──

--- a/src/core/rules/rule-messages.ts
+++ b/src/core/rules/rule-messages.ts
@@ -174,6 +174,13 @@ export const missingComponentMsg = {
   }),
 };
 
+// ── unmapped-component (#520) ────────────────────────────────────────────────
+
+export const unmappedComponentMsg = (componentName: string): ViolationMsg => ({
+  message: `"${componentName}" has no Code Connect mapping`,
+  suggestion: `Run /canicode-roundtrip on this component to register a mapping so figma-implement-design reuses your code instead of regenerating markup. Skip if intentionally unmapped.`,
+});
+
 // ── detached-instance ────────────────────────────────────────────────────────
 
 export const detachedInstanceMsg = (name: string, componentName: string): ViolationMsg => ({


### PR DESCRIPTION
Closes #520. Phase 1 (#509) sub-task 3.

## Summary

Adds a new `unmapped-component` rule that surfaces during normal `canicode analyze` runs to flag Figma main components without a Code Connect mapping. Drives the user toward `/canicode-roundtrip`, which now closes with mapping registration (#516).

Uses the zero-score `note` severity (#519) — the rule's value is the gotcha + handoff to the roundtrip, not a grade signal. Designers who deliberately leave components unmapped (marketing banners, library deps, future-mapping) are not punished.

## Behavior

- Fires once per `COMPONENT` / `COMPONENT_SET` node.
- Only fires when the consuming repo has Code Connect set up at all (`figma.config.json` present at `process.cwd()`). Without it, no actionable signal — the rule stays silent.
- Skips when nested inside an `INSTANCE` subtree (library components live there; double-firing would be noise).
- Existence check cached per-analysis via `analysisState` — runs once, not per node.

## Severity / score

- Severity: `note` (#519's zero-impact tier)
- Score: `0`
- Purpose: `info-collection` — surfaces in the gotcha survey through the existing `purpose === info-collection` filter branch added in #523.

## Strategy / gotcha

- `applyStrategy: annotation` — analyze raises awareness; the actual mapping registration belongs to canicode-roundtrip Step 7 (`add_code_connect_map` + `send_code_connect_mappings`).
- Gotcha question explicitly mentions skipping when intentionally unmapped, plus the `/canicode-roundtrip` action pointer.

## v1 limitations (deferred to v1.5)

- **Mapping declarations not parsed**: the rule fires for every main even if already mapped. Roundtrip Step 7c calls `get_code_connect_map` at registration time, so false positives are caught precisely there. False positives are benign (score 0) but slightly noisy in the gotcha list.
- **No `canicode:intentionally-unmapped` annotation opt-out**: annotation reading is not surfaced in `AnalysisNode` yet. Workaround: user picks `skip` on the gotcha. Real opt-out is a follow-up.

## Tests

- 6 unit tests in `unmapped-component.test.ts` covering: COMPONENT fires, COMPONENT_SET fires, no figma.config.json → silent, non-component types ignored, INSTANCE ancestor → silent, analysisState cache honoured across calls.
- Cache is pre-seeded in tests via `analysisState.set(...)` so no real filesystem dependency.
- `rule-config.test.ts` `infoCollectionRules` set extended to include `unmapped-component`.

## Test plan

- [x] `pnpm lint` — green
- [x] `pnpm test:run` — 1185 pass (6 new)
- [x] `pnpm tsx scripts/sync-rule-docs.ts` — docs/CUSTOMIZATION.md + Wiki Rule-Reference auto-regenerated, both reflect `unmapped-component` / score 0 / note
- [x] `pnpm build` — clean
- [ ] Reviewer to verify: in a fresh dir without `figma.config.json`, `canicode analyze` on a file with main components emits **no** `unmapped-component` findings; in a dir with `figma.config.json`, the same analyze emits the new finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)