### PR TITLE
chore: release v0.12.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
   "skills": [
     "./skills/canicode",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.11.5",
+  "version": "0.12.0",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/let-sunny/canicode",
     "source": "github"
   },
-  "version": "0.11.5",
+  "version": "0.12.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "canicode",
-      "version": "0.11.5",
+      "version": "0.12.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Bump v0.11.5 → v0.12.0. Minor signal because this release adds a new CLI subcommand (\`canicode doctor\`), a new analyze rule (\`unmapped-component\`), and a new severity tier (\`note\`) — all user-visible.

## Why minor

| Surface | Change |
|---|---|
| New CLI subcommand | \`canicode doctor\` (Code Connect prereq checks) |
| New analyze rule | \`unmapped-component\` |
| New severity tier | \`note\` (zero-score, annotation-primary) |
| New roundtrip steps | Step 1.5 (soft-warn) + Step 7 (Code Connect close-out) |
| New CLI subcommand split | \`canicode init\` → interactive + \`canicode config\` |

Patch bump (0.11.6) would understate the surface delta.

## Highlights since v0.11.5

- feat: \`canicode doctor\` CLI subcommand for Code Connect prerequisite checks (#512 / #513)
- feat: \`canicode-roundtrip\` Step 1.5 (Code Connect soft-warn pre-check) + Step 7 (hard close-out: doctor recheck → satisfaction prompt → \`add_code_connect_map\` + \`send_code_connect_mappings\`) (#515 / #516)
- feat: zero-score \`note\` severity tier — annotation-primary rules surface in the gotcha survey without distorting the grade; \`missing-prototype\` / \`missing-interaction-state\` / \`missing-size-constraint\` backfilled out of the apologetic \`score: -1\` workaround (#519 / #523)
- feat: \`unmapped-component\` analyze rule using the new \`note\` tier; flags \`COMPONENT\` / \`COMPONENT_SET\` nodes when \`figma.config.json\` is present in cwd (#520 / #524)
- feat: split \`canicode init\` into interactive setup + \`canicode config\` subcommands (#505 / #506)
- docs: WORKFLOWS.md mapping the 3-phase canicode bootstrap roadmap (#511)
- docs: README + ONBOARDING-TEST surface Code Connect close-out (#517 / #518)
- docs: ADR-021 — handoff carriers and conflict resolution between \`canicode-roundtrip\` and \`figma-implement-design\` (#529)

## Why now

This release unblocks #527 — the live verification campaign for Phase 1 ([#509](https://github.com/let-sunny/canicode/issues/509)) Workflow 1 promotion + Phase 2 ([#510](https://github.com/let-sunny/canicode/issues/510)) Workflow 2 audit. Both need \`npx canicode init\` to install the post-v0.11.5 features (\`canicode doctor\`, Step 1.5/7, \`note\` tier, \`unmapped-component\` rule).

## Test plan

- [ ] \`pnpm lint\` clean
- [ ] \`pnpm test:run\` all green (1185/1185)
- [ ] After merge: tag \`v0.12.0\`, push tag, watch CI auto-publish to npm
- [ ] After publish: \`npx canicode@0.12.0 init --token figd_...\` lands all three skills + new doctor subcommand
- [ ] After publish: kick off #527 live verification campaign

🤖 Generated with [Claude Code](https://claude.com/claude-code)