### PR TITLE
docs: promote Workflow 1 (component-to-code mapping) to ✅ Available

### DIFF
--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -21,7 +21,7 @@ These workflows compose. A new project typically starts at Workflow 3 (find the 
 
 | Phase | Workflow | Status | Tracking epic |
 |---|---|---|---|
-| 1 | Component-to-code mapping | 🚧 Partial | [#509](https://github.com/let-sunny/canicode/issues/509) |
+| 1 | Component-to-code mapping | ✅ Available | [#509](https://github.com/let-sunny/canicode/issues/509) |
 | 2 | Screen-to-code handoff | ✅ Largely shipped | [#510](https://github.com/let-sunny/canicode/issues/510) |
 | 3 | Bootstrap a design system from screens | 🗺️ Planned | [#508](https://github.com/let-sunny/canicode/issues/508) |
 
@@ -29,7 +29,7 @@ These workflows compose. A new project typically starts at Workflow 3 (find the 
 
 ## Workflow 1 — Component-to-code mapping
 
-> 🚧 Partial — `analyze`, `roundtrip`, and `doctor` ship today. The roundtrip's closing Code Connect mapping step is the next milestone (epic #509, sub-issue #515).
+> ✅ Available — `analyze`, `roundtrip`, `doctor`, and the roundtrip's closing Code Connect mapping step (epic [#509](https://github.com/let-sunny/canicode/issues/509)) all ship in v0.12.0. End-to-end live verification ran 2026-04-28 against a real Figma component on `npx canicode@0.12.0`; all hard-pass items in [#527](https://github.com/let-sunny/canicode/issues/527) Section A landed (Step 1.5 soft-warn, Step 7 satisfaction prompt + `add_code_connect_map` + `send_code_connect_mappings`, screen-level skip, failure case with verbatim error). Follow-ups in [#526](https://github.com/let-sunny/canicode/issues/526) (`unmapped-component` v1.5), [#531](https://github.com/let-sunny/canicode/issues/531) (skill prose: inline use_figma payload), [#532](https://github.com/let-sunny/canicode/issues/532) (doctor: publish-status pre-check), [#533](https://github.com/let-sunny/canicode/issues/533) (ADR-020 installer eval bug), [#534](https://github.com/let-sunny/canicode/issues/534) (Step 7d duplicate `send_*` call) — all polish, none blocking.
 
 **You are**: a designer creating a single component (Button, Card, Input...) on purpose, knowing it should be reused in code.
 


### PR DESCRIPTION
Closes the [#509](https://github.com/let-sunny/canicode/issues/509) promotion gate. End-to-end live verification ran 2026-04-28 on \`canicode@0.12.0\` ([#527](https://github.com/let-sunny/canicode/issues/527) Section A) and all hard-pass items landed.

## Summary

Two-line change in \`docs/WORKFLOWS.md\`:
- Status table row 1: \`🚧 Partial\` → \`✅ Available\`
- Workflow 1 narrative paragraph: rewrite the partial-status note to reflect what shipped + link the verification + polish follow-ups

## Verification evidence (#527 Section A)

| Item | Result |
|---|---|
| Pass A — prereqs missing: Step 1.5 soft-warn + (Y/n) default Y + survey runs + Step 7a \`⏭️ skipped (prereq)\` wrap-up | ✅ |
| Pass B — prereqs present: Step 1.5 silent pass + Step 7b satisfaction prompt + \`get_code_connect_map\` + \`add_code_connect_map\` + \`send_code_connect_mappings\` + \`✅ mapped\` wrap-up | ✅ |
| Pass B — failure case: published component not found surfaced with verbatim error + Steps 1–6 still report success | ✅ |
| Cross-cutting — Step 7 entry condition skips for screen-level node with verbatim message | ✅ |
| Cross-cutting — \`unmapped-component\` rule fires on COMPONENT/COMPONENT_SET when figma.config.json present, never on instances | ✅ |

Bonus validation: a follow-up roundtrip on a screen using the just-mapped Button confirmed \`figma-implement-design\` reused \`src/Button.tsx\` instead of regenerating markup — the core Phase 1 value proposition validated end-to-end on \`npx canicode@0.12.0\`.

## Polish follow-ups (none blocking)

- [#526](https://github.com/let-sunny/canicode/issues/526) — \`unmapped-component\` v1.5 (mapping-declaration parser, opt-out annotation, coverage metric)
- [#531](https://github.com/let-sunny/canicode/issues/531) — skill prose: prefer inline \`use_figma\` payload for small Step 4 apply scripts
- [#532](https://github.com/let-sunny/canicode/issues/532) — \`canicode doctor\`: pre-flight check for Figma component publish status
- [#533](https://github.com/let-sunny/canicode/issues/533) — ADR-020 installer eval doesn't expose CanICodeRoundtrip — fallback fires every batch
- [#534](https://github.com/let-sunny/canicode/issues/534) — Step 7d \`send_code_connect_mappings\` errors as duplicate after \`add_code_connect_map\` already publishes

## Test plan

- [ ] Diff is the 2-line WORKFLOWS.md change only
- [ ] Renders correctly on the doc site

🤖 Generated with [Claude Code](https://claude.com/claude-code)