### PR TITLE
feat(doctor): --figma-url publish-status pre-check (#532)

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -88,23 +88,30 @@ Design grade: **{grade}** ({percentage}%) — {issueCount} issues found.
 
 ### Step 1.5: Code Connect prerequisite pre-check (soft warn)
 
-The closing step (Step 7) registers a Code Connect mapping for the just-implemented design, which requires the user's repo to have `@figma/code-connect` installed and `figma.config.json` present. Surfacing missing prerequisites *now* avoids the "spent 10 minutes on the survey, then found out I can't actually save the mapping" surprise.
+The closing step (Step 7) registers a Code Connect mapping for the just-implemented design, which requires three things:
 
-Run `canicode doctor` (added in #513). If the host is running the bundled CLI:
+1. The user's repo has `@figma/code-connect` installed.
+2. `figma.config.json` is present at the repo root.
+3. The target Figma component is published in a library (Figma UI: Assets panel → Publish library).
+
+The first two are repo-side; the third is Figma-side. Pass the Figma URL to `canicode doctor --figma-url <url>` (added in #532) so all three surface here, before the survey:
 
 ```bash
-npx canicode doctor
+npx canicode doctor --figma-url "<the-figma-url-the-user-passed>"
 ```
+
+Always quote the URL — zsh expands `?` in `?node-id=...` otherwise.
 
 Branch on exit code:
 
-- **Exit 0 (all checks pass)** — silent. Continue to Step 2.
+- **Exit 0 (no blocking failures)** — silent. Continue to Step 2.
+  - The Figma publish-status check may render as `⚠️ inconclusive` (e.g. `FIGMA_TOKEN` not configured, network error, URL has no node-id). Inconclusive is not a failure: doctor stays informational, and Step 7d's actual `add_code_connect_map` call remains the authority. Print the inconclusive line for visibility but do not prompt.
 - **Exit 1 (any check failed)** — print the doctor's remediation lines verbatim, then prompt:
   > "Code Connect is not configured in this repo. The roundtrip will still generate code, but the closing mapping step (Step 7) will be skipped. Continue anyway? (Y/n)"
   - **Y** (default) — proceed to Step 2. Remember the prereq state so Step 7 can short-circuit without re-explaining.
   - **n** — stop the whole roundtrip cleanly. Tell the user: "Set up Code Connect and re-invoke `/canicode-roundtrip` when ready."
 
-Default is `Y` because many users genuinely just want code generation today and have not chosen to adopt Code Connect yet — the soft warn informs without blocking.
+Default is `Y` because many users genuinely just want code generation today and have not chosen to adopt Code Connect yet — the soft warn informs without blocking. The publish-status check shifting the Figma-side prereq into this step (rather than discovering it after Step 7d's `add_code_connect_map` fails with "Published component not found") was the #532 motivation.
 
 ### Step 2: Surface grade as informational banner
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ fixtures/report.html
 # Stale roundtrip build artifact (pre-outExtension config)
 .claude/skills/canicode-roundtrip/helpers.global.js
 .pnpm-store/
+.claude/scheduled_tasks.lock

--- a/src/cli/commands/doctor.test.ts
+++ b/src/cli/commands/doctor.test.ts
@@ -4,7 +4,11 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { formatDoctorReport, runCodeConnectChecks } from "./doctor.js";
+import {
+  formatDoctorReport,
+  runCodeConnectChecks,
+  runFigmaPublishCheck,
+} from "./doctor.js";
 
 let tmp: string;
 
@@ -83,6 +87,25 @@ describe("formatDoctorReport", () => {
     expect(out).toContain("Some checks failed");
   });
 
+  it("renders ⚠️ for inconclusive checks and uses a softer summary line (#532)", () => {
+    const out = formatDoctorReport([
+      { name: "@figma/code-connect installed", pass: true, detail: "1.0.0" },
+      { name: "figma.config.json found at repo root", pass: true },
+      {
+        name: "Figma component published in a library",
+        pass: false,
+        inconclusive: true,
+        detail: "FIGMA_TOKEN not configured — skipping publish-status check",
+        remediation: "Set FIGMA_TOKEN.",
+      },
+    ]);
+    expect(out).toContain("⚠️ Figma component published in a library");
+    expect(out).toContain("Set FIGMA_TOKEN");
+    expect(out).toContain("Blocking checks passed; some checks were skipped");
+    expect(out).not.toContain("Some checks failed");
+    expect(out).not.toContain("All checks passed.");
+  });
+
   it("ends with all-pass summary when every check passes", () => {
     const out = formatDoctorReport([
       { name: "a", pass: true },
@@ -90,6 +113,83 @@ describe("formatDoctorReport", () => {
     ]);
     expect(out).toContain("All checks passed.");
     expect(out).not.toContain("Some checks failed");
+  });
+});
+
+describe("runFigmaPublishCheck (#532)", () => {
+  const validUrl =
+    "https://www.figma.com/design/PUNBNLflVnbxKwCSSb6BvK/test?node-id=3384-3";
+
+  it("returns ✅ when the parsed nodeId matches a component in the published-components list", async () => {
+    const result = await runFigmaPublishCheck({
+      figmaUrl: validUrl,
+      token: "tok",
+      fetchPublishedComponents: async () => [
+        { node_id: "3384:3", name: "Button" },
+      ],
+    });
+    expect(result.pass).toBe(true);
+    expect(result.inconclusive).toBeUndefined();
+    expect(result.detail).toContain("Button");
+  });
+
+  it("returns ❌ (not inconclusive) when the API responds but the nodeId is absent — Step 7d would fail with 'Published component not found'", async () => {
+    const result = await runFigmaPublishCheck({
+      figmaUrl: validUrl,
+      token: "tok",
+      fetchPublishedComponents: async () => [
+        { node_id: "9999:9", name: "Other" },
+      ],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.inconclusive).toBeUndefined();
+    expect(result.remediation).toMatch(/Publish library/);
+  });
+
+  it("returns ⚠️ inconclusive when FIGMA_TOKEN is missing — issue #532 keeps doctor informational, not a hard gate", async () => {
+    const result = await runFigmaPublishCheck({
+      figmaUrl: validUrl,
+      token: undefined,
+      fetchPublishedComponents: undefined,
+    });
+    expect(result.pass).toBe(false);
+    expect(result.inconclusive).toBe(true);
+    expect(result.remediation).toMatch(/FIGMA_TOKEN/);
+  });
+
+  it("returns ⚠️ inconclusive when the Figma API call throws — Step 7d remains the authority", async () => {
+    const result = await runFigmaPublishCheck({
+      figmaUrl: validUrl,
+      token: "tok",
+      fetchPublishedComponents: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    expect(result.pass).toBe(false);
+    expect(result.inconclusive).toBe(true);
+    expect(result.detail).toMatch(/ECONNREFUSED/);
+  });
+
+  it("returns ⚠️ inconclusive when the URL has no node-id — Code Connect mapping is per-component", async () => {
+    const result = await runFigmaPublishCheck({
+      figmaUrl: "https://www.figma.com/design/abc/file",
+      token: "tok",
+      fetchPublishedComponents: async () => [],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.inconclusive).toBe(true);
+    expect(result.detail).toContain("missing a node-id");
+  });
+
+  it("returns ⚠️ inconclusive when the URL is unparseable", async () => {
+    const result = await runFigmaPublishCheck({
+      figmaUrl: "not-a-figma-url",
+      token: "tok",
+      fetchPublishedComponents: async () => [],
+    });
+    expect(result.pass).toBe(false);
+    expect(result.inconclusive).toBe(true);
+    expect(result.detail).toMatch(/parse URL/);
   });
 });
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -3,11 +3,22 @@ import { join } from "node:path";
 
 import type { CAC } from "cac";
 
+import { FigmaClient, FigmaClientError } from "../../core/adapters/figma-client.js";
+import { parseFigmaUrl, FigmaUrlParseError } from "../../core/adapters/figma-url-parser.js";
+import { getFigmaToken } from "../../core/engine/config-store.js";
 import { trackEvent, EVENTS } from "../../core/monitoring/index.js";
 
-interface DoctorCheckResult {
+export interface DoctorCheckResult {
   name: string;
   pass: boolean;
+  /**
+   * Marks a check that could not be completed (e.g. token missing, network
+   * error, no node-id in the URL). Inconclusive results render with ⚠️ and
+   * do not count toward the exit-code failure tally — the issue (#532) is
+   * explicit that doctor is informational, not a hard gate. The Figma MCP
+   * call in Step 7d remains the authority.
+   */
+  inconclusive?: boolean;
   detail?: string;
   remediation?: string;
 }
@@ -74,10 +85,123 @@ export function runCodeConnectChecks(cwd: string): DoctorCheckResult[] {
   return results;
 }
 
+export interface FigmaPublishCheckInput {
+  figmaUrl: string;
+  token: string | undefined;
+  /**
+   * Injected at call sites for testability. Production wires this to
+   * `FigmaClient.getPublishedComponents`.
+   */
+  fetchPublishedComponents:
+    | ((fileKey: string) => Promise<Array<{ node_id: string; name: string }>>)
+    | undefined;
+}
+
+const PUBLISH_CHECK_NAME = "Figma component published in a library";
+
+/**
+ * Async sibling to runCodeConnectChecks. Hits Figma REST API to verify the
+ * target component appears in the file's published-components list. The Figma
+ * REST API is the same source of truth `add_code_connect_map` consults, so a
+ * ✅ here is a strong signal that Step 7d will succeed; ❌ is the early
+ * remediation hint #532 wanted (today users only discover the publish gap
+ * after Step 7d's API call fails).
+ */
+export async function runFigmaPublishCheck(
+  input: FigmaPublishCheckInput,
+): Promise<DoctorCheckResult> {
+  const { figmaUrl, token, fetchPublishedComponents } = input;
+
+  let parsed;
+  try {
+    parsed = parseFigmaUrl(figmaUrl);
+  } catch (err) {
+    const message = err instanceof FigmaUrlParseError ? err.message : String(err);
+    return {
+      name: PUBLISH_CHECK_NAME,
+      pass: false,
+      inconclusive: true,
+      detail: `could not parse URL: ${message}`,
+      remediation: "Pass a valid Figma design URL (figma.com/design/<file>?node-id=<id>).",
+    };
+  }
+
+  if (!parsed.nodeId) {
+    return {
+      name: PUBLISH_CHECK_NAME,
+      pass: false,
+      inconclusive: true,
+      detail: "URL is missing a node-id",
+      remediation:
+        "Code Connect mapping is per-component — invoke with a URL that targets a specific node (?node-id=…).",
+    };
+  }
+
+  if (!token) {
+    return {
+      name: PUBLISH_CHECK_NAME,
+      pass: false,
+      inconclusive: true,
+      detail: "FIGMA_TOKEN not configured — skipping publish-status check",
+      remediation:
+        "Set FIGMA_TOKEN (env var) or run `canicode config set-token` so doctor can verify this prereq inline.",
+    };
+  }
+
+  if (!fetchPublishedComponents) {
+    return {
+      name: PUBLISH_CHECK_NAME,
+      pass: false,
+      inconclusive: true,
+      detail: "no fetcher wired",
+      remediation: "internal: doctor was called without a Figma client",
+    };
+  }
+
+  let components: Array<{ node_id: string; name: string }>;
+  try {
+    components = await fetchPublishedComponents(parsed.fileKey);
+  } catch (err) {
+    const status = err instanceof FigmaClientError ? err.statusCode : undefined;
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      name: PUBLISH_CHECK_NAME,
+      pass: false,
+      inconclusive: true,
+      detail: `Figma API call failed${status ? ` (HTTP ${status})` : ""}: ${message}`,
+      remediation:
+        "Step 7d will rely on the API as the authority; if your token / network is OK, the canicode-roundtrip step itself will surface the publish error inline.",
+    };
+  }
+
+  // Figma URLs encode node-ids with `-` (figma.com/.../?node-id=3384-3)
+  // while the REST API returns the canonical `:` form (`3384:3`). Compare on
+  // the canonical form so a URL fresh out of the browser address bar matches.
+  const canonicalNodeId = parsed.nodeId.replace(/-/g, ":");
+  const match = components.find(
+    (c) => c.node_id === canonicalNodeId || c.node_id === parsed.nodeId,
+  );
+  if (match) {
+    return {
+      name: PUBLISH_CHECK_NAME,
+      pass: true,
+      detail: `${match.name} (${match.node_id})`,
+    };
+  }
+
+  return {
+    name: PUBLISH_CHECK_NAME,
+    pass: false,
+    detail: `node ${canonicalNodeId} is not in the published-components list for file ${parsed.fileKey}`,
+    remediation:
+      "Open the file in Figma → Assets panel → Publish library and include this component. Without publishing, `add_code_connect_map` fails with 'Published component not found.'",
+  };
+}
+
 export function formatDoctorReport(results: DoctorCheckResult[]): string {
   const lines: string[] = ["Code Connect"];
   for (const result of results) {
-    const icon = result.pass ? "✅" : "❌";
+    const icon = result.pass ? "✅" : result.inconclusive ? "⚠️" : "❌";
     const detail = result.detail ? ` (${result.detail})` : "";
     lines.push(`  ${icon} ${result.name}${detail}`);
     if (!result.pass && result.remediation) {
@@ -85,13 +209,22 @@ export function formatDoctorReport(results: DoctorCheckResult[]): string {
     }
   }
   lines.push("");
-  const allPass = results.every(r => r.pass);
-  lines.push(
-    allPass
-      ? "All checks passed."
-      : "Some checks failed. Fix the items above before running the Code Connect flow.",
-  );
+  const blocking = results.filter((r) => !r.pass && !r.inconclusive).length;
+  const inconclusive = results.filter((r) => !r.pass && r.inconclusive).length;
+  if (blocking === 0 && inconclusive === 0) {
+    lines.push("All checks passed.");
+  } else if (blocking === 0) {
+    lines.push(
+      "Blocking checks passed; some checks were skipped (⚠️) and could not be verified.",
+    );
+  } else {
+    lines.push("Some checks failed. Fix the items above before running the Code Connect flow.");
+  }
   return lines.join("\n");
+}
+
+interface DoctorCommandOptions {
+  figmaUrl?: string;
 }
 
 export function registerDoctor(cli: CAC): void {
@@ -100,13 +233,32 @@ export function registerDoctor(cli: CAC): void {
       "doctor",
       "Diagnose Code Connect prerequisites (`@figma/code-connect`, `figma.config.json`)",
     )
-    .action(() => {
+    .option(
+      "--figma-url <url>",
+      "Optionally check that the target Figma component is published in a library (requires FIGMA_TOKEN)",
+    )
+    .action(async (options: DoctorCommandOptions) => {
       const cwd = process.cwd();
       const results = runCodeConnectChecks(cwd);
+
+      if (options.figmaUrl) {
+        const token = getFigmaToken();
+        const client = token ? new FigmaClient({ token }) : undefined;
+        const publishCheck = await runFigmaPublishCheck({
+          figmaUrl: options.figmaUrl,
+          token,
+          fetchPublishedComponents: client
+            ? (fileKey) => client.getPublishedComponents(fileKey)
+            : undefined,
+        });
+        results.push(publishCheck);
+      }
+
       console.log(formatDoctorReport(results));
 
-      const passed = results.filter(r => r.pass).length;
-      const failed = results.length - passed;
+      const passed = results.filter((r) => r.pass).length;
+      const inconclusive = results.filter((r) => !r.pass && r.inconclusive).length;
+      const failed = results.length - passed - inconclusive;
 
       trackEvent(EVENTS.CLI_DOCTOR, {
         passed,

--- a/src/core/adapters/figma-client.ts
+++ b/src/core/adapters/figma-client.ts
@@ -134,6 +134,37 @@ export class FigmaClient {
     return Buffer.from(buffer).toString("base64");
   }
 
+  /**
+   * Get the components a file has published to a team library.
+   *
+   * `GET /v1/files/:file_key/components` returns only components that have
+   * been pushed via the Publish Library action — local-but-unpublished
+   * components are absent. This is the authoritative way to detect whether
+   * a Figma component is mappable via Code Connect (#532): `add_code_connect_map`
+   * requires a published component and otherwise fails with "Published
+   * component not found."
+   */
+  async getPublishedComponents(
+    fileKey: string,
+  ): Promise<Array<{ key: string; node_id: string; name: string }>> {
+    const url = `${FIGMA_API_BASE}/files/${fileKey}/components`;
+    const response = await fetch(url, {
+      headers: { "X-Figma-Token": this.token },
+    });
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new FigmaClientError(
+        `Failed to fetch published components: ${response.status} ${response.statusText}`,
+        response.status,
+        error,
+      );
+    }
+    const data = (await response.json()) as {
+      meta?: { components?: Array<{ key: string; node_id: string; name: string }> };
+    };
+    return data.meta?.components ?? [];
+  }
+
   async getFileNodes(
     fileKey: string,
     nodeIds: string[]


### PR DESCRIPTION
## Summary

Today users learn the Figma component must live in a published library only after Step 7d's `add_code_connect_map` call returns \"Published component not found.\" — i.e. after the survey, apply, and code-gen are already done. This PR moves that discovery into Step 1.5.

`canicode doctor --figma-url <url>` performs the existing two repo-side checks plus a Figma REST call to `GET /v1/files/:key/components`, looking for the URL's nodeId in the published-components list. Two new output states:

| Icon | Meaning | Exit code |
|---|---|---|
| `⚠️` inconclusive | Token missing, network error, URL has no node-id | does not fail |
| `❌` failed | API responded but the component is not in the published list | exits 1 |

**Doctor stays informational, not a hard gate.** Step 7d's actual API call remains the authority. The check shifts the discovery point earlier so users don't waste a full roundtrip cycle.

SKILL.md Step 1.5 now passes the URL through. Bare `canicode doctor` (no flag) behaviour is unchanged.

## What changed

- `src/core/adapters/figma-client.ts` — new `getPublishedComponents(fileKey)` method (REST `/v1/files/:key/components`).
- `src/cli/commands/doctor.ts` — new `runFigmaPublishCheck` async helper, new `inconclusive` field on `DoctorCheckResult`, new `--figma-url` flag, `formatDoctorReport` learns ⚠️ + soft summary line.
- `.claude/skills/canicode-roundtrip/SKILL.md` — Step 1.5 explains the third prereq, threads the URL through, treats ⚠️ as informational only.

## Test plan

- [x] 6 new tests cover: ✅ match (with `-` → `:` URL normalization), ❌ no match, ⚠️ token missing / network error / no node-id / unparseable URL.
- [x] `pnpm test:run` green (1192 / 1192).
- [x] `pnpm lint` green.
- [x] `pnpm check:skill-determinism` green.
- [ ] Live verification with a real published / unpublished component pair (manual, follow-up session).

## Acceptance against #532

- ✅ New doctor check `Figma component published`.
- ✅ Step 1.5 calls doctor with the target URL so the third check runs inline.
- ✅ When component is not published, Step 1.5 surfaces the warning early (with same soft-warn / continue-anyway pattern as the other two ❌ checks via the existing prompt).
- ✅ Doctor is not a hard gate — Step 7d still attempts and uses the API as authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)