### PR TITLE
feat(rules): unmapped-component v1.5 — parser + coverage metric (#526)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ fixtures/report.html
 # Stale roundtrip build artifact (pre-outExtension config)
 .claude/skills/canicode-roundtrip/helpers.global.js
 .pnpm-store/
+.claude/scheduled_tasks.lock

--- a/src/cli/commands/analyze.ts
+++ b/src/cli/commands/analyze.ts
@@ -14,8 +14,15 @@ import {
 import {
   getFigmaToken, getReportsDir, ensureReportsDir,
 } from "../../core/engine/config-store.js";
-import { calculateScores, formatScoreSummary, buildResultJson } from "../../core/engine/scoring.js";
+import {
+  calculateScores,
+  formatScoreSummary,
+  buildResultJson,
+  formatCodeConnectCoverageLine,
+  type CodeConnectCoverage,
+} from "../../core/engine/scoring.js";
 import type { Grade } from "../../core/engine/scoring.js";
+import { parseCodeConnectMappings } from "../../core/rules/component/code-connect-mapping-parser.js";
 import { computeDesignKey } from "../../core/contracts/design-key.js";
 import { getConfigsWithPreset, RULE_CONFIGS } from "../../core/rules/rule-config.js";
 import { loadConfigFile, mergeConfigs } from "../../core/rules/config-loader.js";
@@ -38,6 +45,25 @@ const AnalyzeOptionsSchema = z.object({
   readyMinGrade: z.enum(["S", "A+", "A", "B+", "B", "C+", "C", "D", "F"]).optional(),
 });
 
+
+/**
+ * Code Connect coverage = mapped / total components in this Figma file (#526).
+ * Returns undefined when figma.config.json is absent — without Code Connect
+ * setup, the metric isn't meaningful and would just add noise to the report.
+ */
+function computeCodeConnectCoverage(
+  components: Record<string, { key: string; name: string; description: string }>,
+): CodeConnectCoverage | undefined {
+  const result = parseCodeConnectMappings(process.cwd());
+  if (result.skippedReason?.includes("not found")) return undefined;
+  const componentNodeIds = Object.keys(components);
+  const total = componentNodeIds.length;
+  let mapped = 0;
+  for (const nodeId of componentNodeIds) {
+    if (result.mappedNodeIds.has(nodeId)) mapped++;
+  }
+  return { mapped, total };
+}
 
 export function registerAnalyze(cli: CAC): void {
   cli
@@ -179,9 +205,20 @@ export function registerAnalyze(cli: CAC): void {
         // Calculate scores using the same preset-adjusted configs
         const scores = calculateScores(result, configs as Record<RuleId, RuleConfig>);
 
+        // Code Connect coverage (#526 sub-task 3) — only when figma.config.json
+        // is present in cwd, otherwise the metric is meaningless. Computed by
+        // intersecting parsed `figma.connect` declarations with this file's
+        // components map. Parser failures degrade silently (mapped:0 / total:N).
+        const coverage = computeCodeConnectCoverage(file.components);
+
         // JSON output mode — only JSON goes to stdout; exit code still applies
         if (options.json) {
-          console.log(JSON.stringify(buildResultJson(file.name, result, scores, { fileKey: file.fileKey, designKey: computeDesignKey(input), ...(effectiveMinGrade ? { codegenReadyMinGrade: effectiveMinGrade } : {}) }), null, 2));
+          console.log(JSON.stringify(buildResultJson(file.name, result, scores, {
+            fileKey: file.fileKey,
+            designKey: computeDesignKey(input),
+            ...(effectiveMinGrade ? { codegenReadyMinGrade: effectiveMinGrade } : {}),
+            ...(coverage ? { codeConnectCoverage: coverage } : {}),
+          }), null, 2));
           if (scores.overall.grade === "F") {
             process.exitCode = 1;
           }
@@ -191,6 +228,10 @@ export function registerAnalyze(cli: CAC): void {
         // Print summary to terminal
         console.log("\n" + "=".repeat(50));
         console.log(formatScoreSummary(scores));
+        if (coverage) {
+          console.log(""); // blank line for visual separation
+          console.log(formatCodeConnectCoverageLine(coverage));
+        }
         console.log("=".repeat(50));
 
         // Generate HTML report

--- a/src/core/contracts/mcp-response.ts
+++ b/src/core/contracts/mcp-response.ts
@@ -84,6 +84,15 @@ export const McpAnalyzeResponseSchema = z.object({
   issues: z.array(McpIssueSchema),
   summary: z.string(),
   failedRules: z.array(z.string()).optional(),
+  /**
+   * #526 sub-task 3 — Code Connect mapping coverage. Optional: only emitted
+   * when the consuming repo has `figma.config.json`. Numerator = components in
+   * this file with a discovered `figma.connect` declaration; denominator =
+   * total components in the file.
+   */
+  codeConnectCoverage: z
+    .object({ mapped: z.number().int().min(0), total: z.number().int().min(0) })
+    .optional(),
 });
 
 export type McpAnalyzeResponse = z.infer<typeof McpAnalyzeResponseSchema>;

--- a/src/core/engine/scoring.test.ts
+++ b/src/core/engine/scoring.test.ts
@@ -712,6 +712,42 @@ describe("buildResultJson", () => {
     expect(json.acknowledgedCount).toBe(0);
     expect(issues[0]).not.toHaveProperty("acknowledged");
   });
+
+  it("emits codeConnectCoverage in the JSON and appends a coverage line to the summary when the option is provided (#526 sub-task 3)", () => {
+    const result = makeResult([]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores, {
+      codeConnectCoverage: { mapped: 2, total: 5 },
+    });
+    expect(json["codeConnectCoverage"]).toEqual({ mapped: 2, total: 5 });
+    expect(json.summary).toMatch(/Code Connect coverage: 2\/5 components \(40%\) mapped/);
+  });
+
+  it("does not emit codeConnectCoverage when the option is omitted", () => {
+    const result = makeResult([]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores);
+    expect(json["codeConnectCoverage"]).toBeUndefined();
+    expect(json.summary).not.toMatch(/Code Connect coverage/);
+  });
+
+  it("renders 0% coverage cleanly when total is non-zero and mapped is zero (#526)", () => {
+    const result = makeResult([]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores, {
+      codeConnectCoverage: { mapped: 0, total: 4 },
+    });
+    expect(json.summary).toMatch(/0\/4 components \(0%\) mapped/);
+  });
+
+  it("renders 0% (not NaN) when both numerator and denominator are 0 — empty-component file with config present", () => {
+    const result = makeResult([]);
+    const scores = calculateScores(result);
+    const json = buildResultJson("TestFile", result, scores, {
+      codeConnectCoverage: { mapped: 0, total: 0 },
+    });
+    expect(json.summary).toMatch(/0\/0 components \(0%\) mapped/);
+  });
 });
 
 // ─── isReadyForCodeGen helper ─────────────────────────────────────────────────

--- a/src/core/engine/scoring.ts
+++ b/src/core/engine/scoring.ts
@@ -442,6 +442,29 @@ export function getSeverityLabel(severity: Severity): string {
 }
 
 /**
+ * Code Connect mapping coverage metric (#526 sub-task 3). Surfaces how many of
+ * the file's components are already wired to a code path via a `figma.connect`
+ * declaration. Optional — only computed when the consuming repo has Code
+ * Connect set up (figma.config.json present).
+ */
+export interface CodeConnectCoverage {
+  /** Number of components in this file that have a Code Connect mapping. */
+  mapped: number;
+  /** Total components in this file (numerator + unmapped). */
+  total: number;
+}
+
+/**
+ * Format the coverage line that ships in the analyze summary. Kept exported
+ * so consumers (HTML report, MCP wrapper) render the same wording.
+ */
+export function formatCodeConnectCoverageLine(coverage: CodeConnectCoverage): string {
+  const { mapped, total } = coverage;
+  const pct = total === 0 ? 0 : Math.round((mapped / total) * 100);
+  return `Code Connect coverage: ${mapped}/${total} components (${pct}%) mapped`;
+}
+
+/**
  * Build a JSON-serializable analysis result summary.
  * Shared by CLI (--json) and MCP server (analyze tool response).
  */
@@ -449,7 +472,12 @@ export function buildResultJson(
   fileName: string,
   result: AnalysisResult,
   scores: ScoreReport,
-  options?: { fileKey?: string; designKey?: string; codegenReadyMinGrade?: Grade },
+  options?: {
+    fileKey?: string;
+    designKey?: string;
+    codegenReadyMinGrade?: Grade;
+    codeConnectCoverage?: CodeConnectCoverage;
+  },
 ): Record<string, unknown> {
   const issuesByRule: Record<string, number> = {};
   for (const issue of result.issues) {
@@ -506,8 +534,14 @@ export function buildResultJson(
     },
     issuesByRule,
     issues,
-    summary: formatScoreSummary(scores),
+    summary: options?.codeConnectCoverage
+      ? `${formatScoreSummary(scores)}\n\n${formatCodeConnectCoverageLine(options.codeConnectCoverage)}`
+      : formatScoreSummary(scores),
   };
+
+  if (options?.codeConnectCoverage) {
+    json["codeConnectCoverage"] = options.codeConnectCoverage;
+  }
 
   if (result.failedRules.length > 0) {
     json["failedRules"] = result.failedRules;

--- a/src/core/rules/component/code-connect-mapping-parser.test.ts
+++ b/src/core/rules/component/code-connect-mapping-parser.test.ts
@@ -1,0 +1,165 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  extractNodeIdsFromSource,
+  parseCodeConnectMappings,
+} from "./code-connect-mapping-parser.js";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "canicode-cc-parser-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("extractNodeIdsFromSource", () => {
+  it("extracts node-id from a figma.connect URL with `-` separator and normalizes to `:`", () => {
+    const src = `figma.connect(Button, "https://www.figma.com/design/abc/xyz?node-id=3384-3")`;
+    const result = extractNodeIdsFromSource(src);
+    expect(Array.from(result)).toEqual(["3384:3"]);
+  });
+
+  it("extracts node-id from a URL that already uses `:` form", () => {
+    const src = `figma.connect(Card, "https://www.figma.com/design/abc/xyz?node-id=10:42")`;
+    const result = extractNodeIdsFromSource(src);
+    expect(Array.from(result)).toEqual(["10:42"]);
+  });
+
+  it("extracts multiple node-ids from a single file", () => {
+    const src = `
+      figma.connect(Button, "https://www.figma.com/design/abc/xyz?node-id=1-1");
+      figma.connect(Card, "https://www.figma.com/design/abc/xyz?node-id=1-2");
+    `;
+    const result = extractNodeIdsFromSource(src);
+    expect(result.has("1:1")).toBe(true);
+    expect(result.has("1:2")).toBe(true);
+  });
+
+  it("ignores URL fragments without a node-id query param", () => {
+    const src = `const link = "https://www.figma.com/design/abc/xyz";`;
+    const result = extractNodeIdsFromSource(src);
+    expect(result.size).toBe(0);
+  });
+
+  it("decodes URL-encoded node-id values when extracting", () => {
+    const src = `figma.connect(X, "?node-id=1%3A1")`;
+    const result = extractNodeIdsFromSource(src);
+    expect(result.has("1:1")).toBe(true);
+  });
+});
+
+describe("parseCodeConnectMappings", () => {
+  it("returns an empty set with a skippedReason when figma.config.json is absent", () => {
+    const result = parseCodeConnectMappings(tmp);
+    expect(result.mappedNodeIds.size).toBe(0);
+    expect(result.skippedReason).toMatch(/figma\.config\.json not found/);
+  });
+
+  it("returns an empty set with a skippedReason when the config has no include paths", () => {
+    writeFileSync(join(tmp, "figma.config.json"), JSON.stringify({}));
+    const result = parseCodeConnectMappings(tmp);
+    expect(result.mappedNodeIds.size).toBe(0);
+    expect(result.skippedReason).toMatch(/no codeConnect\.include/);
+  });
+
+  it("returns an empty set with a skippedReason when the config is malformed JSON", () => {
+    writeFileSync(join(tmp, "figma.config.json"), "{ broken");
+    const result = parseCodeConnectMappings(tmp);
+    expect(result.mappedNodeIds.size).toBe(0);
+    expect(result.skippedReason).toMatch(/malformed/);
+  });
+
+  it("scans a directory include path and finds node-ids in *.figma.tsx files", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(
+      join(tmp, "src", "Button.figma.tsx"),
+      `figma.connect(Button, "https://www.figma.com/design/abc/xyz?node-id=3384-3")`,
+    );
+    writeFileSync(
+      join(tmp, "src", "NotAConnectFile.tsx"),
+      `figma.connect(Other, "https://www.figma.com/design/abc/xyz?node-id=9999-9")`,
+    );
+    writeFileSync(
+      join(tmp, "figma.config.json"),
+      JSON.stringify({ codeConnect: { include: ["src"] } }),
+    );
+
+    const result = parseCodeConnectMappings(tmp);
+    expect(result.mappedNodeIds.has("3384:3")).toBe(true);
+    expect(result.mappedNodeIds.has("9999:9")).toBe(false);
+  });
+
+  it("supports the legacy flat `include` shape (no `codeConnect` namespace)", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(
+      join(tmp, "src", "Card.figma.tsx"),
+      `figma.connect(Card, "https://figma.com/design/abc?node-id=10-42")`,
+    );
+    writeFileSync(
+      join(tmp, "figma.config.json"),
+      JSON.stringify({ include: ["src"] }),
+    );
+    const result = parseCodeConnectMappings(tmp);
+    expect(result.mappedNodeIds.has("10:42")).toBe(true);
+  });
+
+  it("walks include paths with a glob suffix (** is treated as a recursive walk root)", () => {
+    mkdirSync(join(tmp, "src", "components"), { recursive: true });
+    writeFileSync(
+      join(tmp, "src", "components", "Header.figma.tsx"),
+      `figma.connect(Header, "?node-id=5-5")`,
+    );
+    writeFileSync(
+      join(tmp, "figma.config.json"),
+      JSON.stringify({ codeConnect: { include: ["src/**/*.figma.tsx"] } }),
+    );
+    const result = parseCodeConnectMappings(tmp);
+    expect(result.mappedNodeIds.has("5:5")).toBe(true);
+  });
+
+  it("ignores node_modules and dotfile directories during the walk", () => {
+    mkdirSync(join(tmp, "node_modules", "junk"), { recursive: true });
+    mkdirSync(join(tmp, ".cache"), { recursive: true });
+    mkdirSync(join(tmp, "src"), { recursive: true });
+    writeFileSync(
+      join(tmp, "node_modules", "junk", "Bad.figma.tsx"),
+      `figma.connect(Bad, "?node-id=999-999")`,
+    );
+    writeFileSync(
+      join(tmp, ".cache", "Bad.figma.tsx"),
+      `figma.connect(Bad, "?node-id=888-888")`,
+    );
+    writeFileSync(
+      join(tmp, "src", "Good.figma.tsx"),
+      `figma.connect(Good, "?node-id=1-1")`,
+    );
+    writeFileSync(
+      join(tmp, "figma.config.json"),
+      JSON.stringify({ codeConnect: { include: ["."] } }),
+    );
+    const result = parseCodeConnectMappings(tmp);
+    expect(result.mappedNodeIds.has("1:1")).toBe(true);
+    expect(result.mappedNodeIds.has("999:999")).toBe(false);
+    expect(result.mappedNodeIds.has("888:888")).toBe(false);
+  });
+
+  it("returns scannedFiles for debug visibility", () => {
+    mkdirSync(join(tmp, "src"));
+    const filePath = join(tmp, "src", "X.figma.tsx");
+    writeFileSync(filePath, `figma.connect(X, "?node-id=1-1")`);
+    writeFileSync(
+      join(tmp, "figma.config.json"),
+      JSON.stringify({ codeConnect: { include: ["src"] } }),
+    );
+    const result = parseCodeConnectMappings(tmp);
+    expect(result.scannedFiles.length).toBeGreaterThan(0);
+    expect(result.scannedFiles[0]).toMatch(/X\.figma\.tsx$/);
+  });
+});

--- a/src/core/rules/component/code-connect-mapping-parser.ts
+++ b/src/core/rules/component/code-connect-mapping-parser.ts
@@ -1,0 +1,198 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, resolve, isAbsolute, sep } from "node:path";
+
+/**
+ * Parses Code Connect mapping declarations from a project's `figma.config.json`
+ * `include` paths so the `unmapped-component` rule can skip components that
+ * already carry a mapping (#526 sub-task 1).
+ *
+ * v1.5 contract — light-touch:
+ *   - Source of truth is `figma.config.json` `include` (Code Connect's own
+ *     declared file scope; we don't invent our own include syntax).
+ *   - We scan matched files for the simple `figma.connect(...)` URL form and
+ *     extract the `node-id` query param. That's the canonical pattern Figma
+ *     ships in its docs and what every example in their repo uses.
+ *   - We do NOT resolve component imports, follow re-exports, or evaluate
+ *     anything — purely lexical regex over file text. Cross-file resolution
+ *     and library-mapping support are explicitly out of scope per #526.
+ *
+ * Parsing failures (missing config, malformed JSON, unreadable files) are
+ * non-fatal: the parser returns an empty set so the rule degrades to v1
+ * behaviour (fire on every component) rather than blocking analysis.
+ */
+export interface CodeConnectMappingResult {
+  /** Set of Figma node IDs (canonical `:` form, e.g. `3384:3`) with a mapping declaration found. */
+  mappedNodeIds: Set<string>;
+  /** Files that were scanned. Useful for debugging "nothing matched" cases. */
+  scannedFiles: string[];
+  /** Reason mapping discovery was skipped, if it was. */
+  skippedReason?: string;
+}
+
+const FIGMA_CONFIG_FILENAME = "figma.config.json";
+const FIGMA_CONNECT_FILE_GLOB = /\.figma\.(tsx?|jsx?)$/;
+const NODE_ID_QUERY_RE = /[?&]node-id=([0-9A-Za-z%:\-_]+)/;
+
+interface FigmaConfigShape {
+  codeConnect?: {
+    include?: string[];
+  };
+  // Fallback for projects with the older flat shape.
+  include?: string[];
+}
+
+export function parseCodeConnectMappings(cwd: string): CodeConnectMappingResult {
+  const configPath = join(cwd, FIGMA_CONFIG_FILENAME);
+  if (!existsSync(configPath)) {
+    return {
+      mappedNodeIds: new Set(),
+      scannedFiles: [],
+      skippedReason: `${FIGMA_CONFIG_FILENAME} not found at ${cwd}`,
+    };
+  }
+
+  let config: FigmaConfigShape;
+  try {
+    config = JSON.parse(readFileSync(configPath, "utf-8")) as FigmaConfigShape;
+  } catch (err) {
+    return {
+      mappedNodeIds: new Set(),
+      scannedFiles: [],
+      skippedReason: `malformed ${FIGMA_CONFIG_FILENAME}: ${(err as Error).message}`,
+    };
+  }
+
+  const includes = config.codeConnect?.include ?? config.include ?? [];
+  if (includes.length === 0) {
+    return {
+      mappedNodeIds: new Set(),
+      scannedFiles: [],
+      skippedReason: `${FIGMA_CONFIG_FILENAME} has no codeConnect.include paths`,
+    };
+  }
+
+  const candidateFiles = new Set<string>();
+  for (const includePattern of includes) {
+    for (const file of resolveInclude(cwd, includePattern)) {
+      candidateFiles.add(file);
+    }
+  }
+
+  const mappedNodeIds = new Set<string>();
+  const scannedFiles: string[] = [];
+  for (const file of candidateFiles) {
+    scannedFiles.push(file);
+    let contents: string;
+    try {
+      contents = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    for (const nodeId of extractNodeIdsFromSource(contents)) {
+      mappedNodeIds.add(nodeId);
+    }
+  }
+
+  return { mappedNodeIds, scannedFiles };
+}
+
+/**
+ * Resolve a single `include` entry to a list of files on disk.
+ *
+ * Supports the two patterns Code Connect's own docs use most frequently:
+ *   - A directory path (recursively scanned for `*.figma.tsx?` / `*.figma.jsx?`).
+ *   - A glob with a `**` segment + a trailing `*.figma.{tsx,ts,jsx,js}` filename
+ *     pattern (very common in Code Connect example configs).
+ *
+ * Non-matching globs (e.g. brace expansion, character classes) fall back to
+ * directory-walk semantics rooted at the literal portion of the path. This is
+ * intentionally simple so we don't pull in a glob dependency for what is
+ * meant to be a low-risk lint helper.
+ */
+function resolveInclude(cwd: string, includePattern: string): string[] {
+  const results: string[] = [];
+  const absolute = isAbsolute(includePattern)
+    ? includePattern
+    : resolve(cwd, includePattern);
+
+  // Walk back from the pattern to find the literal root we can walk.
+  // Drop any segment containing `*`, `?`, `{`, or `[`.
+  const segments = absolute.split(sep);
+  let firstGlobIdx = segments.findIndex((s) => /[*?{[]/.test(s));
+  if (firstGlobIdx === -1) {
+    // No glob — could be a file or a directory. Treat both.
+    if (existsSync(absolute)) {
+      const stat = statSync(absolute);
+      if (stat.isFile() && FIGMA_CONNECT_FILE_GLOB.test(absolute)) {
+        results.push(absolute);
+      } else if (stat.isDirectory()) {
+        walkDir(absolute, results);
+      }
+    }
+    return results;
+  }
+
+  const rootSegments = segments.slice(0, firstGlobIdx);
+  const root = rootSegments.length === 0 ? sep : rootSegments.join(sep);
+  if (!existsSync(root)) return results;
+  const rootStat = statSync(root);
+  if (!rootStat.isDirectory()) return results;
+  walkDir(root, results);
+  // Filter to files within the absolute pattern's prefix. We don't enforce the
+  // post-glob portion strictly because the file extension filter does the
+  // heavy lifting — Code Connect declarations only live in `*.figma.{tsx,ts,jsx,js}`.
+  const prefix = rootSegments.join(sep) + sep;
+  return results.filter((f) => f.startsWith(prefix) || rootSegments.length === 0);
+}
+
+function walkDir(dir: string, out: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry === "node_modules" || entry.startsWith(".")) continue;
+    const full = join(dir, entry);
+    let stat;
+    try {
+      stat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      walkDir(full, out);
+    } else if (stat.isFile() && FIGMA_CONNECT_FILE_GLOB.test(full)) {
+      out.push(full);
+    }
+  }
+}
+
+/**
+ * Extract canonical Figma node IDs from `figma.connect(...)` URL arguments.
+ *
+ * Recognises any URL fragment containing `node-id=...` (the Figma URL form
+ * uses `-`, the canonical internal form uses `:`). Returns the canonical
+ * (`:`) form to match the rule's `node.id` comparison.
+ */
+export function extractNodeIdsFromSource(source: string): Set<string> {
+  const nodeIds = new Set<string>();
+  const re = new RegExp(NODE_ID_QUERY_RE, "g");
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    const raw = match[1];
+    if (!raw) continue;
+    const decoded = safeDecode(raw);
+    nodeIds.add(decoded.replace(/-/g, ":"));
+  }
+  return nodeIds;
+}
+
+function safeDecode(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}

--- a/src/core/rules/component/index.ts
+++ b/src/core/rules/component/index.ts
@@ -367,27 +367,39 @@ export const variantStructureMismatch = defineRule({
 });
 
 // ============================================
-// unmapped-component (#520)
+// unmapped-component (#520, v1.5: #526)
 // ============================================
 //
 // Fires once per main component (COMPONENT / COMPONENT_SET) when the consuming
 // repo has Code Connect set up at all (figma.config.json present in cwd). The
 // gotcha drives the user to /canicode-roundtrip for actual mapping
-// registration via the Figma MCP tools — analyze does not parse mapping
-// declarations from the user's *.figma.tsx files yet (deferred to v1.5).
+// registration via the Figma MCP tools.
 //
-// v1 limitation: this fires for every main even when already mapped, because
-// canicode does not yet read the actual mapping state. Roundtrip Step 7c
-// (`get_code_connect_map`) does the precise check at registration time. The
-// note severity (score 0) makes this acceptable — false positives do not move
-// the grade, just surface a redundant gotcha that the roundtrip will skip.
+// v1.5 (#526 sub-task 1): we now parse Code Connect mapping declarations from
+// the project's `*.figma.tsx?` files (sourced from `figma.config.json`'s
+// `codeConnect.include` paths) so already-mapped components are skipped. This
+// addresses the v1 false-positive complaint without changing the rule's scope
+// or severity. Parser failures are non-fatal and degrade to v1 behaviour
+// (fire on every main).
+
+import {
+  parseCodeConnectMappings,
+  type CodeConnectMappingResult,
+} from "./code-connect-mapping-parser.js";
 
 const CODE_CONNECT_SETUP_KEY = "unmapped-component:setup-detected";
+const CODE_CONNECT_MAPPINGS_KEY = "unmapped-component:mappings";
 
 function codeConnectIsSetUp(context: RuleContext): boolean {
   return getAnalysisState(context, CODE_CONNECT_SETUP_KEY, () => {
     return existsSync(join(process.cwd(), "figma.config.json"));
   });
+}
+
+function codeConnectMappings(context: RuleContext): CodeConnectMappingResult {
+  return getAnalysisState(context, CODE_CONNECT_MAPPINGS_KEY, () =>
+    parseCodeConnectMappings(process.cwd()),
+  );
 }
 
 const unmappedComponentDef: RuleDefinition = {
@@ -403,6 +415,13 @@ const unmappedComponentCheck: RuleCheckFn = (node, context) => {
   if (node.type !== "COMPONENT" && node.type !== "COMPONENT_SET") return null;
   if (isInsideInstance(context)) return null;
   if (!codeConnectIsSetUp(context)) return null;
+
+  // v1.5 (#526 sub-task 1): consult parsed Code Connect declarations and
+  // skip components that already carry a mapping. Parser failures return an
+  // empty set, in which case this short-circuit is a no-op and the rule
+  // fires v1-style on every main.
+  const mappings = codeConnectMappings(context);
+  if (mappings.mappedNodeIds.has(node.id)) return null;
 
   return {
     ruleId: unmappedComponentDef.id,

--- a/src/core/rules/component/unmapped-component.test.ts
+++ b/src/core/rules/component/unmapped-component.test.ts
@@ -30,11 +30,18 @@ let analysisState: Map<string, unknown>;
 function makeContext(
   setupDetected: boolean,
   overrides?: Partial<RuleContext>,
+  mappedNodeIds: string[] = [],
 ): RuleContext {
   // Pre-seed the analysis state cache so the rule does not actually touch the
   // filesystem during the test. The cached value short-circuits the existsSync
   // check inside `codeConnectIsSetUp`.
   analysisState.set("unmapped-component:setup-detected", setupDetected);
+  // v1.5 (#526 sub-task 1): pre-seed the mapping-parser cache too so the rule
+  // sees the test's chosen mapped-node-id set without invoking the parser.
+  analysisState.set("unmapped-component:mappings", {
+    mappedNodeIds: new Set(mappedNodeIds),
+    scannedFiles: [],
+  });
   return {
     file: makeFile(),
     depth: 1,
@@ -90,6 +97,32 @@ describe("unmapped-component", () => {
     const ctx = makeContext(true, { ancestorTypes: ["FRAME", "INSTANCE"] });
     const result = unmappedComponent.check(node, ctx);
     expect(result).toBeNull();
+  });
+
+  it("does NOT fire for a COMPONENT whose nodeId is in the parsed mapping set (#526 sub-task 1)", () => {
+    const node = makeNode({ id: "100:1", name: "Button", type: "COMPONENT" });
+    const result = unmappedComponent.check(
+      node,
+      makeContext(true, undefined, ["100:1"]),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("still fires for a COMPONENT whose nodeId is NOT in the parsed mapping set (#526)", () => {
+    const node = makeNode({ id: "100:2", name: "Card", type: "COMPONENT" });
+    const result = unmappedComponent.check(
+      node,
+      makeContext(true, undefined, ["100:1"]),
+    );
+    expect(result).not.toBeNull();
+    expect(result?.nodeId).toBe("100:2");
+  });
+
+  it("falls back to v1 behaviour when the parser returns an empty mapping set (degraded mode)", () => {
+    const node = makeNode({ id: "100:3", name: "EmptyParse", type: "COMPONENT" });
+    const result = unmappedComponent.check(node, makeContext(true, undefined, []));
+    expect(result).not.toBeNull();
+    expect(result?.nodeId).toBe("100:3");
   });
 
   it("caches the setup detection across calls within one analysis", () => {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,7 +8,8 @@ import { writeFile } from "node:fs";
 import { exec } from "node:child_process";
 import { analyzeFile } from "../core/engine/rule-engine.js";
 import { loadFile, isJsonFile, isFixtureDir } from "../core/engine/loader.js";
-import { calculateScores, buildResultJson } from "../core/engine/scoring.js";
+import { calculateScores, buildResultJson, type CodeConnectCoverage } from "../core/engine/scoring.js";
+import { parseCodeConnectMappings } from "../core/rules/component/code-connect-mapping-parser.js";
 import type { Grade } from "../core/engine/scoring.js";
 import { generateGotchaSurvey } from "../core/gotcha/survey-generator.js";
 import { generateHtmlReport } from "../core/report-html/index.js";
@@ -140,11 +141,18 @@ Provide a Figma URL or fixture path via the input parameter. Requires FIGMA_TOKE
         source: isJsonFile(input) || isFixtureDir(input) ? "fixture" : "figma",
       });
 
+      const coverage = computeMcpCodeConnectCoverage(file.components);
+
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(buildResultJson(file.name, result, scores, { fileKey: file.fileKey, designKey: computeDesignKey(input), ...(effectiveMinGrade ? { codegenReadyMinGrade: effectiveMinGrade } : {}) }), null, 2),
+            text: JSON.stringify(buildResultJson(file.name, result, scores, {
+              fileKey: file.fileKey,
+              designKey: computeDesignKey(input),
+              ...(effectiveMinGrade ? { codegenReadyMinGrade: effectiveMinGrade } : {}),
+              ...(coverage ? { codeConnectCoverage: coverage } : {}),
+            }), null, 2),
           },
         ],
       };
@@ -612,6 +620,23 @@ Requires: Playwright with Chromium installed, Figma API token.`,
     }
   },
 );
+
+/**
+ * Same intent as analyze CLI's `computeCodeConnectCoverage` (#526 sub-task 3).
+ * Returns undefined when figma.config.json is absent in cwd.
+ */
+function computeMcpCodeConnectCoverage(
+  components: Record<string, { key: string; name: string; description: string }>,
+): CodeConnectCoverage | undefined {
+  const result = parseCodeConnectMappings(process.cwd());
+  if (result.skippedReason?.includes("not found")) return undefined;
+  const componentNodeIds = Object.keys(components);
+  let mapped = 0;
+  for (const nodeId of componentNodeIds) {
+    if (result.mappedNodeIds.has(nodeId)) mapped++;
+  }
+  return { mapped, total: componentNodeIds.length };
+}
 
 async function main() {
   const monitoringConfig: Parameters<typeof initMonitoring>[0] = {


### PR DESCRIPTION
## Summary

Lands two of three #526 sub-tasks. Sub-task 2 (annotation opt-out) remains open as a follow-up because it needs a source-of-truth decision (annotation vs config vs ack channel) and some Step 5a expansion to round-trip through REST analyze — keeping it separate makes that scope reviewable on its own.

### Sub-task 1 — Code Connect mapping-declaration parser ✅

`figma.config.json`'s `codeConnect.include` paths are now scanned for `figma.connect(..., \"?node-id=X\")` calls. Discovered node IDs are canonicalized (`-` → `:`) and skipped by the unmapped-component check so already-mapped components no longer fire. Resolves the v1 false-positive reported during #525 verification (rule fires for every COMPONENT regardless of mapping state).

Parsing is intentionally **lexical** — no AST, no import resolution, no glob lib dependency. Missing config, malformed JSON, unreadable files, or zero include paths all degrade silently to v1 behaviour. `node_modules` and dotfile directories are skipped during the walk.

### Sub-task 3 — Code Connect coverage metric ✅

CLI summary, JSON response, and MCP response now surface:

```
Code Connect coverage: 2/5 components (40%) mapped
```

Only emitted when `figma.config.json` is present (otherwise the metric is meaningless). `N` = count of `file.components` whose nodeId is in the parsed mappings; `M` = total components in this file.

### Sub-task 2 — annotation opt-out (deferred to follow-up)

`canicode:intentionally-unmapped` annotation suppression isn't trivial because annotations don't appear in REST API responses — only Plugin API. The cleanest path forwards is one of:

- Extend Step 5a / `readCanicodeAcknowledgments` to recognize an opt-out marker, and pass that through analyze's existing `acknowledgments` channel as a *suppression* signal (today acks just mark issues, they don't suppress emission).
- Add a config-based pre-cursor (`figma.config.json` → `canicode.intentionallyUnmapped: [\"3384:3\"]`).

Both worth a small standalone PR. #526 stays open with this checkbox unticked.

## Files

- `src/core/rules/component/code-connect-mapping-parser.ts` (+test, 13 tests)
- `src/core/rules/component/index.ts` — rule consults parsed mapping set
- `src/core/rules/component/unmapped-component.test.ts` — 3 new mapped-skip tests
- `src/core/engine/scoring.ts` — `CodeConnectCoverage` type, `formatCodeConnectCoverageLine`, `buildResultJson` accepts coverage option
- `src/core/engine/scoring.test.ts` — 4 new coverage tests
- `src/core/contracts/mcp-response.ts` — optional `codeConnectCoverage` field
- `src/cli/commands/analyze.ts` + `src/mcp/server.ts` — compute + thread coverage

## Test plan

- [x] `pnpm test:run` — full suite green (1205 / 1205, +18 new tests).
- [x] `pnpm lint` — green.
- [x] `pnpm sync-docs` — no drift.
- [ ] Live verification on a project with a mix of mapped/unmapped components — should see false-positive count drop, coverage line in summary (manual, follow-up session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)