### PR TITLE
chore: release v0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/let-sunny/canicode",
     "source": "github"
   },
-  "version": "0.12.0",
+  "version": "0.12.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "canicode",
-      "version": "0.12.0",
+      "version": "0.12.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Patch release rolling up v0.12.0 → v0.12.1.

### Features
- `unmapped-component` v1.5 — Code Connect mapping-declaration parser + coverage metric (#526, #539)
- `canicode doctor --figma-url` publish-status pre-check (#532, #538)
- ADR-022 unmapped-component opt-out write path + SKILL Step 4 docs (#542, #543)

### Fixes
- Roundtrip: bridge `CanICodeRoundtrip` onto `globalThis` inside eval (#533, #537)

### Docs
- ADR-022 — opt-out via ack channel + REST private-beta gating (#540)
- SKILL Step 4 inline staging + Step 7d single-mapping path (#531, #534, #536)
- Promote Workflow 1 (component-to-code mapping) to ✅ Available (#535)

## Release process
1. Merge this PR (squash) to main
2. Tag merged commit on main: `git tag v0.12.1 && git push origin v0.12.1`
3. GitHub CI auto-publishes to npm