### PR TITLE
feat(rules): scope-wide cross-parent fingerprint pass (Phase 3 delta 3, #556)

### DIFF
--- a/src/core/contracts/rule.ts
+++ b/src/core/contracts/rule.ts
@@ -71,6 +71,26 @@ export interface RuleContext {
    */
   rootNodeType: string;
   /**
+   * #557: Root node of the current analysis subtree. Set by
+   * `RuleEngine.analyze` to the same node `traverseAndCheck` walks — i.e.
+   * `file.document` for full-file analysis or the resolved subtree when
+   * `targetNodeId` scopes the run.
+   *
+   * Distinct from `file.document`, which is **always** the full file root.
+   * Rules that build scope-wide indices (e.g. Stage 3 fingerprint pass in
+   * `missing-component`) MUST walk `analysisRoot`, not `file.document` —
+   * walking the full file under a scoped run produces silent false
+   * negatives because the index's first-occurrence id may resolve to a
+   * node outside the current scope, and the in-scope duplicate then never
+   * matches as "first" so the issue never surfaces.
+   *
+   * Optional purely so existing rule unit tests that construct
+   * `RuleContext` literals do not have to backfill the field. The engine
+   * always sets it; rule code reading this should default to
+   * `context.file.document` for safety on the unit-test path.
+   */
+  analysisRoot?: AnalysisNode;
+  /**
    * ADR-022: lookup canicode-authored acknowledgments by `(nodeId, ruleId)`.
    * The rule engine builds this from `RuleEngineOptions.acknowledgments` and
    * exposes it to every rule so individual rules can short-circuit (suppress

--- a/src/core/engine/rule-engine.ts
+++ b/src/core/engine/rule-engine.ts
@@ -260,6 +260,7 @@ export class RuleEngine {
       analysisState,
       scope,
       rootNodeType,
+      rootNode,
       undefined,
       undefined
     );
@@ -320,6 +321,7 @@ export class RuleEngine {
     analysisState: Map<string, unknown>,
     scope: AnalysisScope,
     rootNodeType: string,
+    analysisRoot: AnalysisNode,
     parent?: AnalysisNode,
     siblings?: AnalysisNode[]
   ): void {
@@ -351,6 +353,7 @@ export class RuleEngine {
       analysisState,
       scope,
       rootNodeType,
+      analysisRoot,
       findAcknowledgment: (nodeId, ruleId) =>
         acknowledgmentsByKey.get(`${normalizeNodeId(nodeId)}::${ruleId}`),
     };
@@ -414,6 +417,7 @@ export class RuleEngine {
           analysisState,
           scope,
           rootNodeType,
+          analysisRoot,
           node,
           node.children
         );

--- a/src/core/rules/component/index.ts
+++ b/src/core/rules/component/index.ts
@@ -106,6 +106,73 @@ function getSeenStage4(context: RuleContext): Set<string> {
   return getAnalysisState(context, SEEN_STAGE4_KEY, () => new Set<string>());
 }
 
+/**
+ * Phase 3 (#508 / #556) — Stage 3 group lookup table.
+ *
+ * One-time scope-wide pass that maps each fingerprint to the list of
+ * qualifying FRAME ids. Built lazily on the first Stage 3 invocation in an
+ * analysis run and cached on `context.analysisState` so subsequent per-node
+ * calls just look up — O(1) per node instead of re-walking siblings every
+ * time. Cached separately per `maxFingerprintDepth` so the rare per-call
+ * option override stays correct.
+ */
+interface Stage3GroupInfo {
+  /** Document-order id of the first qualifying FRAME in this group. */
+  firstNodeId: string;
+  /** Total qualifying FRAMEs in this group across the entire analysis scope. */
+  count: number;
+}
+
+function stage3GroupsKey(maxDepth: number): string {
+  return `missing-component:stage3Groups:depth=${maxDepth}`;
+}
+
+function nodeQualifiesForStage3(
+  node: AnalysisNode,
+  parent: AnalysisNode | null,
+  insideInstance: boolean
+): boolean {
+  if (insideInstance) return false;
+  if (node.type !== "FRAME") return false;
+  if (parent?.type === "COMPONENT_SET") return false;
+  if (!node.children || node.children.length === 0) return false;
+  return true;
+}
+
+function buildStage3Groups(
+  root: AnalysisNode,
+  maxFingerprintDepth: number
+): Map<string, Stage3GroupInfo> {
+  const groups = new Map<string, Stage3GroupInfo>();
+  const walk = (
+    node: AnalysisNode,
+    parent: AnalysisNode | null,
+    ancestorIsInstance: boolean
+  ): void => {
+    const insideInstance = ancestorIsInstance || node.type === "INSTANCE";
+    if (nodeQualifiesForStage3(node, parent, ancestorIsInstance)) {
+      const fp = buildFingerprint(node, maxFingerprintDepth);
+      const existing = groups.get(fp);
+      if (existing) existing.count++;
+      else groups.set(fp, { firstNodeId: node.id, count: 1 });
+    }
+    if (node.children) {
+      for (const child of node.children) walk(child, node, insideInstance);
+    }
+  };
+  walk(root, null, false);
+  return groups;
+}
+
+function getStage3Groups(
+  context: RuleContext,
+  maxFingerprintDepth: number
+): Map<string, Stage3GroupInfo> {
+  return getAnalysisState(context, stage3GroupsKey(maxFingerprintDepth), () =>
+    buildStage3Groups(context.file.document, maxFingerprintDepth)
+  );
+}
+
 const missingComponentDef: RuleDefinition = {
   id: "missing-component",
   name: "Missing Component",
@@ -168,14 +235,20 @@ const missingComponentCheck: RuleCheckFn = (node, context, options) => {
       }
     }
 
-    // Stage 3: Structure-based repetition (absorbed from repeated-frame-structure)
-    // Skip if node is inside an INSTANCE subtree
+    // Stage 3: scope-wide structure-based repetition (#508 / #556)
+    //
+    // Pre-#556 the check restricted matching to `context.siblings` — same-
+    // parent only. The cross-parent fingerprint pass (delta 3) replaces the
+    // sibling walk with a one-time scope-wide pass cached on
+    // `analysisState`, so duplicates spread across different parents now
+    // land in the same fingerprint group and emit a single issue on the
+    // document-order first qualifying FRAME.
+    //
+    // The per-node guards stay (`isInsideInstance`, `COMPONENT_SET` parent,
+    // empty children) so a cheap reject path short-circuits before any map
+    // lookup.
     if (isInsideInstance(context)) return null;
-
-    // Skip if parent is COMPONENT_SET
     if (context.parent?.type === "COMPONENT_SET") return null;
-
-    // Skip if node has no children
     if (!node.children || node.children.length === 0) return null;
 
     const structureMinRepetitions =
@@ -186,51 +259,20 @@ const missingComponentCheck: RuleCheckFn = (node, context, options) => {
       (options?.["maxFingerprintDepth"] as number | undefined) ??
       getRuleOption("missing-component", "maxFingerprintDepth", 3);
 
-    // Compute fingerprint for this node
+    const groups = getStage3Groups(context, maxFingerprintDepth);
     const fingerprint = buildFingerprint(node, maxFingerprintDepth);
+    const group = groups.get(fingerprint);
+    if (!group) return null;
+    if (group.count < structureMinRepetitions) return null;
+    if (group.firstNodeId !== node.id) return null;
 
-    // Access siblings (may be undefined)
-    const siblings = context.siblings ?? [];
-
-    // Filter siblings to qualifying frames (type === FRAME, not inside INSTANCE, has children)
-    const qualifyingSiblings = siblings.filter(
-      (s) =>
-        s.type === "FRAME" &&
-        s.children !== undefined &&
-        s.children.length > 0
-    );
-
-    // Count siblings (including self) sharing the same fingerprint
-    const matchingNodes = qualifyingSiblings.filter(
-      (s) => buildFingerprint(s, maxFingerprintDepth) === fingerprint
-    );
-
-    // Ensure self is counted (it should be in siblings, but add a guard)
-    const selfIsInSiblings = qualifyingSiblings.some((s) => s.id === node.id);
-    const count = selfIsInSiblings
-      ? matchingNodes.length
-      : matchingNodes.length + 1;
-
-    if (count >= structureMinRepetitions) {
-      // Only emit for the first sibling (by array order) with this fingerprint
-      const firstMatch = qualifyingSiblings.find(
-        (s) => buildFingerprint(s, maxFingerprintDepth) === fingerprint
-      );
-
-      // If self is not in siblings list, treat self as first match when no earlier match exists
-      const firstMatchId = firstMatch?.id ?? node.id;
-      if (firstMatchId === node.id) {
-        return {
-          ruleId: missingComponentDef.id,
-          subType: "structure-repetition" as const,
-          nodeId: node.id,
-          nodePath: context.path.join(" > "),
-          ...missingComponentMsg.structureRepetition(node.name, count - 1),
-        };
-      }
-    }
-
-    return null;
+    return {
+      ruleId: missingComponentDef.id,
+      subType: "structure-repetition" as const,
+      nodeId: node.id,
+      nodePath: context.path.join(" > "),
+      ...missingComponentMsg.structureRepetition(node.name, group.count - 1),
+    };
   }
 
   // ========================================

--- a/src/core/rules/component/index.ts
+++ b/src/core/rules/component/index.ts
@@ -127,6 +127,10 @@ function stage3GroupsKey(maxDepth: number): string {
   return `missing-component:stage3Groups:depth=${maxDepth}`;
 }
 
+// Single source of truth for Stage 3's qualification predicate. Used by
+// both the per-node check (entry point) and the scope-wide walker
+// (`buildStage3Groups`) so the index never holds a node the per-node check
+// would have rejected. Adding a new exclusion here covers both paths.
 function nodeQualifiesForStage3(
   node: AnalysisNode,
   parent: AnalysisNode | null,
@@ -168,8 +172,17 @@ function getStage3Groups(
   context: RuleContext,
   maxFingerprintDepth: number
 ): Map<string, Stage3GroupInfo> {
+  // #557: walk the analysis root (the subtree the engine is actually
+  // checking), not `context.file.document` (always the full file). When
+  // analysis is scoped via `targetNodeId`, the full-file walk would seed
+  // the index with out-of-scope groups whose `firstNodeId` resolves to a
+  // node the engine never visits — the in-scope duplicate then never
+  // matches "first" and the issue silently disappears. Falls back to
+  // `file.document` only on the unit-test path where the test omits
+  // `analysisRoot` from a hand-built context literal.
+  const root = context.analysisRoot ?? context.file.document;
   return getAnalysisState(context, stage3GroupsKey(maxFingerprintDepth), () =>
-    buildStage3Groups(context.file.document, maxFingerprintDepth)
+    buildStage3Groups(root, maxFingerprintDepth)
   );
 }
 
@@ -244,12 +257,15 @@ const missingComponentCheck: RuleCheckFn = (node, context, options) => {
     // land in the same fingerprint group and emit a single issue on the
     // document-order first qualifying FRAME.
     //
-    // The per-node guards stay (`isInsideInstance`, `COMPONENT_SET` parent,
-    // empty children) so a cheap reject path short-circuits before any map
-    // lookup.
-    if (isInsideInstance(context)) return null;
-    if (context.parent?.type === "COMPONENT_SET") return null;
-    if (!node.children || node.children.length === 0) return null;
+    // The per-node check shares `nodeQualifiesForStage3` with the walker so
+    // a cheap reject path short-circuits before any map lookup, and the
+    // qualification logic stays in one place — a future exclusion only
+    // needs to land in `nodeQualifiesForStage3`.
+    if (
+      !nodeQualifiesForStage3(node, context.parent ?? null, isInsideInstance(context))
+    ) {
+      return null;
+    }
 
     const structureMinRepetitions =
       (options?.["structureMinRepetitions"] as number | undefined) ??

--- a/src/core/rules/component/missing-component.test.ts
+++ b/src/core/rules/component/missing-component.test.ts
@@ -554,6 +554,53 @@ describe("missing-component — Stage 3: Structure-based repetition", () => {
     expect(missingComponent.check(frameC, ctxC)).toBeNull();
   });
 
+  it("respects analysisRoot when scoped — out-of-scope frames don't pollute groups (#557)", () => {
+    // Scope is `subRoot` only. `outsiderFrame` lives elsewhere in the file
+    // and shares the fingerprint with the in-scope frames. Pre-#557 the
+    // walker hit `file.document` and folded `outsiderFrame` into the same
+    // group, making it the document-order first match — the in-scope
+    // frames then never fired because their id !== firstNodeId. Now the
+    // walker honours `analysisRoot`, so the outsider is invisible and the
+    // in-scope first frame fires.
+    const childA = makeChildFrame("c:1", "RECTANGLE");
+    const childB = makeChildFrame("c:2", "RECTANGLE");
+    const childOut = makeChildFrame("c:99", "RECTANGLE");
+    const inFrameA = makeNode({ id: "in:1", name: "Card In A", children: [childA] });
+    const inFrameB = makeNode({ id: "in:2", name: "Card In B", children: [childB] });
+    const outsider = makeNode({
+      id: "out:1",
+      name: "Card Out",
+      children: [childOut],
+    });
+
+    const subRoot = makeNode({
+      id: "sub:1",
+      name: "InScope",
+      type: "FRAME",
+      children: [inFrameA, inFrameB],
+    });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      // Document order: outsider FIRST, then subRoot. Pre-#557 outsider
+      // would win as `firstNodeId` and silently swallow the in-scope hits.
+      children: [outsider, subRoot],
+    });
+
+    const ctx = makeContext({
+      file: makeFile({ document: doc }),
+      analysisRoot: subRoot,
+      parent: subRoot,
+      siblings: [inFrameA, inFrameB],
+    });
+
+    const result = missingComponent.check(inFrameA, ctx);
+    expect(result).not.toBeNull();
+    // Group inside the scope has 2 frames → "1 other frame(s)"
+    expect(result!.message).toContain("1 other frame(s)");
+  });
+
   it("caches the scope-wide pass on analysisState (no rebuild between calls)", () => {
     const childA = makeChildFrame("c:1", "RECTANGLE");
     const childB = makeChildFrame("c:2", "RECTANGLE");

--- a/src/core/rules/component/missing-component.test.ts
+++ b/src/core/rules/component/missing-component.test.ts
@@ -294,14 +294,22 @@ describe("missing-component — Stage 3: Structure-based repetition", () => {
     const frameA = makeNode({ id: "f:1", name: "Card A", children: [childA] });
     const frameB = makeNode({ id: "f:2", name: "Card B", children: [childB] });
 
-    const siblings = [frameA, frameB];
-    const ctx = makeContext({ siblings });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [frameA, frameB],
+    });
+    const ctx = makeContext({
+      file: makeFile({ document: doc }),
+      siblings: [frameA, frameB],
+    });
 
     const result = missingComponent.check(frameA, ctx);
     expect(result).not.toBeNull();
     expect(result!.ruleId).toBe("missing-component");
     expect(result!.message).toContain("Card A");
-    expect(result!.message).toContain("1 sibling frame(s)");
+    expect(result!.message).toContain("1 other frame(s)");
     expect(result!.suggestion).toContain("Extract a shared component");
   });
 
@@ -311,10 +319,18 @@ describe("missing-component — Stage 3: Structure-based repetition", () => {
     const frameA = makeNode({ id: "f:1", name: "Card A", children: [childA] });
     const frameB = makeNode({ id: "f:2", name: "Card B", children: [childB] });
 
-    const siblings = [frameA, frameB];
-    const ctxB = makeContext({ siblings });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [frameA, frameB],
+    });
+    const ctx = makeContext({
+      file: makeFile({ document: doc }),
+      siblings: [frameA, frameB],
+    });
 
-    expect(missingComponent.check(frameB, ctxB)).toBeNull();
+    expect(missingComponent.check(frameB, ctx)).toBeNull();
   });
 
   it("skips inside INSTANCE subtree", () => {
@@ -370,8 +386,16 @@ describe("missing-component — Stage 3: Structure-based repetition", () => {
     const frameA = makeNode({ id: "f:1", name: "Card A", children: [childA] });
     const frameB = makeNode({ id: "f:2", name: "Card B", children: [childB] });
 
-    const siblings = [frameA, frameB];
-    const ctx = makeContext({ siblings });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [frameA, frameB],
+    });
+    const ctx = makeContext({
+      file: makeFile({ document: doc }),
+      siblings: [frameA, frameB],
+    });
 
     // Default structureMinRepetitions is 2 — should flag
     const result = missingComponent.check(frameA, ctx);
@@ -420,11 +444,22 @@ describe("missing-component — Stage 3: Structure-based repetition", () => {
     const childRect = makeChildFrame("c:1", "RECTANGLE");
     const childText = makeChildFrame("c:2", "TEXT");
 
-    const frameA = makeNode({ id: "f:1", children: [childRect] });
-    const frameB = makeNode({ id: "f:2", children: [childText] });
+    // Distinct names so Stage 2 (name-repetition, minRepetitions: 2) does
+    // not fire — we want to verify Stage 3 returns null on differing
+    // fingerprints, not have Stage 2 mask it.
+    const frameA = makeNode({ id: "f:1", name: "RectCard", children: [childRect] });
+    const frameB = makeNode({ id: "f:2", name: "TextCard", children: [childText] });
 
-    const siblings = [frameA, frameB];
-    const ctx = makeContext({ siblings });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [frameA, frameB],
+    });
+    const ctx = makeContext({
+      file: makeFile({ document: doc }),
+      siblings: [frameA, frameB],
+    });
 
     expect(missingComponent.check(frameA, ctx)).toBeNull();
   });
@@ -449,11 +484,99 @@ describe("missing-component — Stage 3: Structure-based repetition", () => {
       children: [childC],
     };
 
-    const siblings = [frameA, textNode, groupNode];
-    const ctx = makeContext({ siblings });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [frameA, textNode, groupNode],
+    });
+    const ctx = makeContext({
+      file: makeFile({ document: doc }),
+      siblings: [frameA, textNode, groupNode],
+    });
 
-    // Only one qualifying FRAME sibling — below threshold
+    // Only one qualifying FRAME — below threshold
     expect(missingComponent.check(frameA, ctx)).toBeNull();
+  });
+
+  // ============================================
+  // Stage 3 — cross-parent fingerprint pass (#508 / #556 / delta 3)
+  // ============================================
+
+  it("detects cross-parent identical structure (#556)", () => {
+    const childA = makeChildFrame("c:1", "RECTANGLE");
+    const childB = makeChildFrame("c:2", "RECTANGLE");
+    const childC = makeChildFrame("c:3", "RECTANGLE");
+    const frameA = makeNode({ id: "f:1", name: "Card A", children: [childA] });
+    const frameB = makeNode({ id: "f:2", name: "Card B", children: [childB] });
+    const frameC = makeNode({ id: "f:3", name: "Card C", children: [childC] });
+
+    const sectionA = makeNode({
+      id: "s:a",
+      name: "Section A",
+      type: "FRAME",
+      children: [frameA, frameB],
+    });
+    const sectionB = makeNode({
+      id: "s:b",
+      name: "Section B",
+      type: "FRAME",
+      children: [frameC],
+    });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [sectionA, sectionB],
+    });
+
+    const ctxA = makeContext({
+      file: makeFile({ document: doc }),
+      parent: sectionA,
+      siblings: [frameA, frameB],
+    });
+    const result = missingComponent.check(frameA, ctxA);
+    expect(result).not.toBeNull();
+    expect(result!.subType).toBe("structure-repetition");
+    // Group spans 3 FRAMEs across two parents → "and 2 other frame(s)"
+    expect(result!.message).toContain("2 other frame(s)");
+
+    // frameC lives under a DIFFERENT parent but shares the fingerprint —
+    // pre-#556 this would have been missed. Post-#556 it folds into the same
+    // group; only the document-order first emits, so frameC returns null.
+    const ctxC = makeContext({
+      file: makeFile({ document: doc }),
+      parent: sectionB,
+      siblings: [frameC],
+    });
+    // Reuse the cached scope-wide pass via the same analysisState to mirror
+    // a real analysis run.
+    expect(missingComponent.check(frameC, ctxC)).toBeNull();
+  });
+
+  it("caches the scope-wide pass on analysisState (no rebuild between calls)", () => {
+    const childA = makeChildFrame("c:1", "RECTANGLE");
+    const childB = makeChildFrame("c:2", "RECTANGLE");
+    const frameA = makeNode({ id: "f:1", name: "Card A", children: [childA] });
+    const frameB = makeNode({ id: "f:2", name: "Card B", children: [childB] });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [frameA, frameB],
+    });
+    const ctx = makeContext({
+      file: makeFile({ document: doc }),
+      siblings: [frameA, frameB],
+    });
+
+    expect(missingComponent.check(frameA, ctx)).not.toBeNull();
+    // Cached map should now live on analysisState — at least one key with
+    // the depth-keyed prefix.
+    const keys = Array.from(ctx.analysisState.keys());
+    expect(
+      keys.some((k) => k.startsWith("missing-component:stage3Groups:depth="))
+    ).toBe(true);
   });
 });
 

--- a/src/core/rules/rule-messages.ts
+++ b/src/core/rules/rule-messages.ts
@@ -164,8 +164,8 @@ export const missingComponentMsg = {
     message: `"${name}" appears ${count} times`,
     suggestion: `Extract as a reusable component`,
   }),
-  structureRepetition: (name: string, siblingCount: number): ViolationMsg => ({
-    message: `"${name}" and ${siblingCount} sibling frame(s) share the same internal structure`,
+  structureRepetition: (name: string, matchCount: number): ViolationMsg => ({
+    message: `"${name}" and ${matchCount} other frame(s) share the same internal structure`,
     suggestion: `Extract a shared component from the repeated structure`,
   }),
   styleOverride: (componentName: string, overrides: string[]): ViolationMsg => ({


### PR DESCRIPTION
## Summary

Third of five deltas needed to ship **Phase 3 — Bootstrap a design system from screens** (Workflow 3 epic, #508). Closes #556. Builds on delta 1 (#553) and delta 2 (#555). Pure rule-engine change — no new apply primitives, no SKILL prose.

`missing-component` Stage 3 previously restricted fingerprint matching to `context.siblings` (same-parent only). After this PR, a duplicate FRAME structure that lives under a different parent in the same analysis scope joins the same fingerprint group and surfaces the same issue.

## Before / after

```
Page
├── Section A
│   ├── Card  ← shape X
│   └── Card  ← shape X  ← Stage 3 fired here (sibling match)
└── Section B
    ├── Card  ← shape X  ← MISSED pre-#556
    └── Other
```

After #556: all three Cards land in one fingerprint group; Stage 3 emits a single issue on the document-order first qualifying FRAME with `"Card" and 2 other frame(s) share the same internal structure`.

## How

- One-time scope-wide walk over `context.file.document` builds `Map<fingerprint, { firstNodeId, count }>`. Cached on `analysisState` per `maxFingerprintDepth` so subsequent per-node lookups are O(1).
- Per-node guards (`isInsideInstance`, `COMPONENT_SET` parent, empty children) stay as a cheap reject path before the lookup. Walker applies the same qualification predicate.
- Message: `structureRepetition` drops "sibling" from the string since cross-parent matches are now expected.

## Behavior preserved

- Subtype stays `structure-repetition` — downstream gotcha-question generator and apply primitives need no change.
- Per-rule score impact unchanged (`-7` for `missing-component`).
- Stage 1 / Stage 2 / Stage 4 untouched.
- Existing acknowledgment density-half-weight semantic (#371) still applies — designers who acked "intentional duplicate" keep visibility (point cost halved), so opinion shifts later remain visible. Discussed during planning; intentionally NOT short-circuiting like ADR-022's `unmapped-component` opt-out.

## H audit re-run

24-fixture calibration set after the change: **0/24 firings**, unchanged from delta-1 baseline. `fixtures/done/*` is heavily componentized (e.g. desktop-home-page = 16,163 COMPONENT vs 38 FRAME) so no cross-parent group surfaces even with the expansion. **No grade shifts on the calibration set.**

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test:run` clean (1279 tests pass; 2 new in `missing-component.test.ts` for cross-parent + cache verification)
- [x] `pnpm build` clean
- [x] H audit re-run: 0/24 firings (no change from baseline)
- [ ] Live verification deferred until delta 4 wires SKILL Step 4 to the componentize+swap loop

## Out of scope

- Batched gotcha question shape carrying the D `mode` field (delta 4 — separate sub-issue)
- Code Connect handoff (delta 5)
- Acknowledgment-based opt-out for `missing-component` — discussed and **rejected**: density-half-weight is correct here because "intentional duplicate" intent can change as design evolves; permanent suppression would deafen designers to a re-evaluation opportunity (ADR-022's pattern is fine for stable opt-outs like "this is an internal wrapper", but not for shape-evolving cases like duplicate detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)