### PR TITLE
fix(rules): narrow Stage 1/Stage 2 frame walks to analysisRoot (#558)

### DIFF
--- a/src/core/rules/component/index.ts
+++ b/src/core/rules/component/index.ts
@@ -201,13 +201,26 @@ const missingComponentCheck: RuleCheckFn = (node, context, options) => {
   // ========================================
   if (node.type === "FRAME") {
     // Stage 1: Component exists but not used — FRAME name matches a component in metadata AND frame is repeated
+    //
+    // `matchingComponent` stays file-wide because `context.file.components`
+    // is the file-global component registry — a published component "exists"
+    // regardless of which subtree the user is currently analyzing.
+    //
+    // `frameNames` (#558): narrowed to `context.analysisRoot` so the
+    // repetition count and `firstFrame` dedup match the user's actual
+    // analysis scope. Pre-#558 this walked the full file, which under a
+    // `--target-node-id` run could let an out-of-scope FRAME claim
+    // `firstFrame` and silently swallow the in-scope hit (same shape as
+    // the Stage 3 scope leak fixed in #557). Falls back to `file.document`
+    // only on the unit-test path where contexts omit `analysisRoot`.
     const components = context.file.components;
     const matchingComponent = Object.values(components).find(
       (c) => c.name.toLowerCase() === node.name.toLowerCase()
     );
 
-    // Collect frame names once for Stage 1 and Stage 2
-    const frameNames = collectFrameNames(context.file.document);
+    // Collect frame names once for Stage 1 and Stage 2 — scope-aware (#558)
+    const scopeRoot = context.analysisRoot ?? context.file.document;
+    const frameNames = collectFrameNames(scopeRoot);
     const sameNameFrames = frameNames.get(node.name);
     const firstFrame = sameNameFrames?.[0];
 

--- a/src/core/rules/component/missing-component.test.ts
+++ b/src/core/rules/component/missing-component.test.ts
@@ -277,6 +277,82 @@ describe("missing-component — Stage 2: Name-based repetition", () => {
     // Stage 1 message pattern
     expect(result!.message).toContain('Component "Card" exists');
   });
+
+  it("Stage 2 name-repetition respects analysisRoot — counts only in-scope occurrences (#558)", () => {
+    // 2 in-scope + 1 out-of-scope FRAME share a name. minRepetitions = 2.
+    // Pre-#558 the count was file-wide (3) AND `firstFrame` could be the
+    // outsider, swallowing the in-scope hit. Post-#558 the count is
+    // in-scope only (2), and the in-scope first frame fires.
+    const inScopeFrameA = makeNode({ id: "in:1", name: "Widget" });
+    const inScopeFrameB = makeNode({ id: "in:2", name: "Widget" });
+    const outsider = makeNode({ id: "out:1", name: "Widget" });
+
+    const subRoot = makeNode({
+      id: "sub:1",
+      name: "InScope",
+      type: "FRAME",
+      children: [inScopeFrameA, inScopeFrameB],
+    });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      // Outsider FIRST in document order — pre-#558 firstFrame would land
+      // on it and the in-scope frames would never see the issue.
+      children: [outsider, subRoot],
+    });
+
+    const ctx = makeContext({
+      file: makeFile({ document: doc }),
+      analysisRoot: subRoot,
+    });
+
+    const result = missingComponent.check(inScopeFrameA, ctx);
+    expect(result).not.toBeNull();
+    expect(result!.subType).toBe("name-repetition");
+    // In-scope count = 2, not 3 (with outsider).
+    expect(result!.message).toContain('"Widget" appears 2 times');
+  });
+
+  it("respects analysisRoot — out-of-scope frame does not steal firstFrame (#558)", () => {
+    // Pre-#558 the frame-name walk hit `file.document` and the
+    // out-of-scope `Card` won as firstFrame, so the in-scope `Card`
+    // never matched as "first" and the issue silently disappeared
+    // under a `--target-node-id` analysis. Same shape as the Stage 3
+    // scope leak fixed in #557.
+    const inScopeFrameA = makeNode({ id: "in:1", name: "Card" });
+    const inScopeFrameB = makeNode({ id: "in:2", name: "Card" });
+    const outsider = makeNode({ id: "out:1", name: "Card" });
+
+    const subRoot = makeNode({
+      id: "sub:1",
+      name: "InScope",
+      type: "FRAME",
+      children: [inScopeFrameA, inScopeFrameB],
+    });
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [outsider, subRoot],
+    });
+
+    const ctx = makeContext({
+      file: makeFile({
+        document: doc,
+        components: {
+          "comp:1": { key: "comp:1", name: "Card", description: "" },
+        },
+      }),
+      analysisRoot: subRoot,
+    });
+
+    const result = missingComponent.check(inScopeFrameA, ctx);
+    expect(result).not.toBeNull();
+    expect(result!.subType).toBe("unused-component");
+    // Count from the in-scope subtree only (2), not 3 (with outsider).
+    expect(result!.message).toContain('"Card" exists but 2 repeated frames');
+  });
 });
 
 // ============================================


### PR DESCRIPTION
## Summary

Closes #558 (follow-up from #557 review). Applies the same scope-aware fix from #557's Stage 3 fix to Stage 1 (\`unused-component\`) and Stage 2 (\`name-repetition\`) — both call \`collectFrameNames(context.file.document)\` and silently misbehave under \`--target-node-id\` analysis the same way Stage 3 did.

## What changed

The single \`collectFrameNames\` call (shared by both stages) now walks \`context.analysisRoot ?? context.file.document\`. Same pattern as #557's \`getStage3Groups\` fix.

\`matchingComponent\` lookup against \`context.file.components\` stays file-wide because the component metadata registry is intentionally global — a published component exists regardless of which subtree is being analyzed. Only the **frame repetition count + \`firstFrame\` dedup** narrow.

## Audit conclusion (the original investigation goal of #558)

Both Stage 1 and Stage 2 had the same scope leak as Stage 3 — the audit confirmed the latent bug was real, not just a documentation gap. Pre-#558 a scoped analysis could:

- silence in-scope hits when an out-of-scope FRAME claimed \`firstFrame\` in document order, OR
- inflate the count past the threshold so a sub-threshold in-scope group fired anyway.

In practice the blast radius is small (\`--target-node-id\` is mostly used by calibration scripts), but the fix is mechanical and the tests now lock in the contract.

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm test:run\` clean (1282 tests pass; 2 new — one per stage)
- [x] \`pnpm build\` clean
- [x] H audit re-run unchanged (Stage 3 base rate still 0/24 — Stage 1/2 fixes don't surface differently on the calibration set since fixtures/done/* analyze full pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)