### PR TITLE
feat(rules,gotcha): groupMembers on RuleViolation + question shape (Phase 3 delta 4a, #560)

### DIFF
--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -101,7 +101,11 @@ export const GotchaSurveyQuestionSchema = z.object({
    * group-shaped violation that never became N separate issues. The apply
    * step distinguishes by which field is set.
    */
-  groupMembers: z.array(z.string()).optional(),
+  // `.min(2)` locks the contract: a group-shaped emit always carries at
+  // least 2 members (Stage 3 short-circuits below `structureMinRepetitions`
+  // = 2). A future rule emitting `[]` or `[oneId]` is a programming error,
+  // not a runtime case to handle gracefully.
+  groupMembers: z.array(z.string()).min(2).optional(),
 });
 
 export type GotchaSurveyQuestion = z.infer<typeof GotchaSurveyQuestionSchema>;

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -88,6 +88,20 @@ export const GotchaSurveyQuestionSchema = z.object({
   // Single-instance questions omit both fields.
   replicas: z.number().int().min(2).optional(),
   replicaNodeIds: z.array(z.string()).optional(),
+  /**
+   * Phase 3 (#508 / #560 / delta 4a): every node id in the rule's emitted
+   * group, including `nodeId`. Currently only populated for
+   * `missing-component:structure-repetition` (Stage 3) — one question per
+   * fingerprint group, the apply step (delta 4b) iterates this list to
+   * componentize the first member and swap the rest.
+   *
+   * Distinct from `replicas` / `replicaNodeIds`: those collapse N
+   * instance-child questions that pre-existed as separate violations into
+   * one. `groupMembers` carries N original group members from a single
+   * group-shaped violation that never became N separate issues. The apply
+   * step distinguishes by which field is set.
+   */
+  groupMembers: z.array(z.string()).optional(),
 });
 
 export type GotchaSurveyQuestion = z.infer<typeof GotchaSurveyQuestionSchema>;

--- a/src/core/contracts/rule.ts
+++ b/src/core/contracts/rule.ts
@@ -138,6 +138,19 @@ export interface RuleViolation {
    * string keeps lowercase prose.
    */
   suggestedName?: string;
+  /**
+   * Phase 3 (#508 / #560): when a rule emits a single issue that represents
+   * a group of N nodes (e.g. `missing-component:structure-repetition` —
+   * one issue per fingerprint group covering N qualifying FRAMEs), this
+   * lists every node id in the group **including** `nodeId`. Document
+   * order, scope-aware. Apply primitives (componentize + replace-with-
+   * instance) iterate this list to drive the full componentize+swap loop
+   * from a single user answer.
+   *
+   * Optional: rules that emit one issue per node (the typical path) leave
+   * this undefined.
+   */
+  groupMembers?: string[];
 }
 
 /**

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -46,10 +46,12 @@ function makeIssue(opts: {
   score?: number;
   subType?: string;
   suggestedName?: string;
+  groupMembers?: string[];
 }): AnalysisIssue {
   const extra: Partial<RuleViolation> = {};
   if (opts.subType !== undefined) extra.subType = opts.subType;
   if (opts.suggestedName !== undefined) extra.suggestedName = opts.suggestedName;
+  if (opts.groupMembers !== undefined) extra.groupMembers = opts.groupMembers;
   return {
     violation: makeViolation(
       opts.ruleId,
@@ -1504,6 +1506,48 @@ describe("generateGotchaSurvey", () => {
       expect(typeof survey.suggestedDefaultApply).toBe("boolean");
       const result = GotchaSurveySchema.safeParse(survey);
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe("groupMembers (#560 / Phase 3 delta 4a)", () => {
+    it("threads groupMembers from violation onto the question", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-component",
+          category: "code-quality",
+          severity: "risk",
+          nodeId: "fA",
+          nodePath: "Root > A",
+          subType: "structure-repetition",
+          groupMembers: ["fA", "fB", "fC"],
+        }),
+      ];
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("C"),
+      );
+      expect(survey.questions).toHaveLength(1);
+      expect(survey.questions[0]?.groupMembers).toEqual(["fA", "fB", "fC"]);
+      // Schema validation — `groupMembers: z.array(z.string()).optional()`
+      const parsed = GotchaSurveySchema.safeParse(survey);
+      expect(parsed.success).toBe(true);
+    });
+
+    it("omits groupMembers when the violation does not carry one (non-group rules)", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "no-auto-layout",
+          category: "pixel-critical",
+          severity: "blocking",
+          nodeId: "1:1",
+        }),
+      ];
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("C"),
+      );
+      expect(survey.questions).toHaveLength(1);
+      expect(survey.questions[0]?.groupMembers).toBeUndefined();
     });
   });
 });

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -226,6 +226,12 @@ function mapToQuestion(
     ...(applyContext.sourceChildId !== undefined
       ? { sourceChildId: applyContext.sourceChildId }
       : {}),
+    // #560 / Phase 3 delta 4a: thread groupMembers through from the
+    // violation. Currently only populated by `missing-component`
+    // Stage 3; non-group rules pass undefined and the field is omitted.
+    ...(issue.violation.groupMembers !== undefined
+      ? { groupMembers: issue.violation.groupMembers }
+      : {}),
   };
 }
 

--- a/src/core/rules/component/index.ts
+++ b/src/core/rules/component/index.ts
@@ -117,10 +117,14 @@ function getSeenStage4(context: RuleContext): Set<string> {
  * option override stays correct.
  */
 interface Stage3GroupInfo {
-  /** Document-order id of the first qualifying FRAME in this group. */
-  firstNodeId: string;
-  /** Total qualifying FRAMEs in this group across the entire analysis scope. */
-  count: number;
+  /**
+   * Document-order ids of every qualifying FRAME in this group (across the
+   * entire analysis scope). Used both for the per-node "first emitter" check
+   * (`memberIds[0] === node.id`) and for `groupMembers` on the emitted
+   * `RuleViolation` so the apply step (#560 / delta 4) can drive the full
+   * componentize+swap loop from a single user answer.
+   */
+  memberIds: string[];
 }
 
 function stage3GroupsKey(maxDepth: number): string {
@@ -157,8 +161,8 @@ function buildStage3Groups(
     if (nodeQualifiesForStage3(node, parent, ancestorIsInstance)) {
       const fp = buildFingerprint(node, maxFingerprintDepth);
       const existing = groups.get(fp);
-      if (existing) existing.count++;
-      else groups.set(fp, { firstNodeId: node.id, count: 1 });
+      if (existing) existing.memberIds.push(node.id);
+      else groups.set(fp, { memberIds: [node.id] });
     }
     if (node.children) {
       for (const child of node.children) walk(child, node, insideInstance);
@@ -292,15 +296,23 @@ const missingComponentCheck: RuleCheckFn = (node, context, options) => {
     const fingerprint = buildFingerprint(node, maxFingerprintDepth);
     const group = groups.get(fingerprint);
     if (!group) return null;
-    if (group.count < structureMinRepetitions) return null;
-    if (group.firstNodeId !== node.id) return null;
+    if (group.memberIds.length < structureMinRepetitions) return null;
+    if (group.memberIds[0] !== node.id) return null;
 
     return {
       ruleId: missingComponentDef.id,
       subType: "structure-repetition" as const,
       nodeId: node.id,
       nodePath: context.path.join(" > "),
-      ...missingComponentMsg.structureRepetition(node.name, group.count - 1),
+      ...missingComponentMsg.structureRepetition(
+        node.name,
+        group.memberIds.length - 1
+      ),
+      // #560 / delta 4a: surface the full group so the apply step can drive
+      // the componentize+swap loop from a single user answer. `nodeId` is
+      // the document-order first member; the rest are siblings or cross-
+      // parent matches found by the scope-wide pass (#557).
+      groupMembers: [...group.memberIds],
     };
   }
 

--- a/src/core/rules/component/missing-component.test.ts
+++ b/src/core/rules/component/missing-component.test.ts
@@ -616,6 +616,10 @@ describe("missing-component — Stage 3: Structure-based repetition", () => {
     expect(result!.subType).toBe("structure-repetition");
     // Group spans 3 FRAMEs across two parents → "and 2 other frame(s)"
     expect(result!.message).toContain("2 other frame(s)");
+    // #560 / delta 4a: groupMembers carries every node id in the group,
+    // document-order, including the emitting `nodeId`. The apply step
+    // (delta 4b) iterates this list to drive the componentize+swap loop.
+    expect(result!.groupMembers).toEqual(["f:1", "f:2", "f:3"]);
 
     // frameC lives under a DIFFERENT parent but shares the fingerprint —
     // pre-#556 this would have been missed. Post-#556 it folds into the same
@@ -700,6 +704,38 @@ describe("missing-component — Stage 3: Structure-based repetition", () => {
     expect(
       keys.some((k) => k.startsWith("missing-component:stage3Groups:depth="))
     ).toBe(true);
+  });
+
+  it("emits groupMembers in document order including the emitting nodeId (#560)", () => {
+    // 4 sibling FRAMEs with identical fingerprint. Pre-emit: groupMembers
+    // should list all four ids in document order, with the first one
+    // matching the result's `nodeId`. Apply step iterates this list to
+    // componentize the first member and swap the rest.
+    const childA = makeChildFrame("c:1", "RECTANGLE");
+    const childB = makeChildFrame("c:2", "RECTANGLE");
+    const childC = makeChildFrame("c:3", "RECTANGLE");
+    const childD = makeChildFrame("c:4", "RECTANGLE");
+    const frameA = makeNode({ id: "fA", name: "A", children: [childA] });
+    const frameB = makeNode({ id: "fB", name: "B", children: [childB] });
+    const frameC = makeNode({ id: "fC", name: "C", children: [childC] });
+    const frameD = makeNode({ id: "fD", name: "D", children: [childD] });
+
+    const doc = makeNode({
+      id: "0:1",
+      name: "Document",
+      type: "DOCUMENT",
+      children: [frameA, frameB, frameC, frameD],
+    });
+    const ctx = makeContext({
+      file: makeFile({ document: doc }),
+      siblings: [frameA, frameB, frameC, frameD],
+    });
+
+    const result = missingComponent.check(frameA, ctx);
+    expect(result).not.toBeNull();
+    expect(result!.nodeId).toBe("fA");
+    expect(result!.groupMembers).toEqual(["fA", "fB", "fC", "fD"]);
+    expect(result!.groupMembers?.[0]).toBe(result!.nodeId);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #560. First half of Phase 3 delta 4 — **data-shape only**. Adds the group member list to the rule violation contract and threads it through the gotcha-survey question schema so the apply orchestration (delta 4b — separate PR) can drive componentize+swap from a single user answer.

## What changed

| Layer | Change |
|---|---|
| `RuleViolation` | `+ groupMembers?: string[]` — optional, populated when one issue covers a group of nodes |
| `Stage3GroupInfo` | `{ firstNodeId, count }` → `{ memberIds }` — single source of truth for both dedup ordering and emission payload |
| `missing-component:structure-repetition` | emits `groupMembers: [...memberIds]` (document-order, scope-aware via #557) |
| `GotchaSurveyQuestionSchema` | `+ groupMembers: z.array(z.string()).optional()` |
| `survey-generator` | threads field from violation to question |

Additive — existing question consumers ignore the new field. The delta 4b apply step (`canicode-roundtrip` SKILL Step 4 prose) will branch on its presence to call `applyComponentize` + `applyReplaceWithInstance` for the group.

## Distinct from #356 `replicas` / `replicaNodeIds`

| Field | When |
|---|---|
| `replicas` / `replicaNodeIds` (#356) | N pre-existing instance-child **violations** collapsed into one question because they share `(sourceComponentId, sourceNodeId, ruleId)` |
| `groupMembers` (#560, this PR) | N **members of a single group-shaped violation** that never became N separate issues — Stage 3 emits ONE issue per fingerprint group |

Apply step distinguishes by which field is set.

## Out of scope (delta 4b territory)

- SKILL.md Step 4 prose changes (the "componentize this group?" question rendering)
- Apply orchestration calling `applyComponentize` + `applyReplaceWithInstance`
- `componentizeMode: "componentize-new" | "use-existing"` field for Stage 1 reverse handling
- Code Connect handoff (delta 5)

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test:run` clean (1285 tests pass; +3 new)
- [x] `pnpm build` clean
- [ ] User-visible behavior unchanged — apply path doesn't read the field yet (delta 4b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)