### PR TITLE
fix(plugin): shim node:fs/path so analyzeFile is reachable in Figma sandbox

### DIFF
--- a/app/figma-plugin/src/ui.template.html
+++ b/app/figma-plugin/src/ui.template.html
@@ -71,6 +71,31 @@
     })();
   </script>
 
+  <!--
+    Node-builtin shims for the analysis engine bundle.
+    tsup wraps the IIFE with `(function(exports, fs$1, path){...})({}, fs$1, path);`
+    because rollup externalises `fs`/`path` regardless of the browser
+    platform target. Pre-declaring them here prevents a ReferenceError at
+    the IIFE call site (which would leave `CanICode` as undefined and
+    surface as "Cannot read properties of undefined (reading 'analyzeFile')").
+    Rules that reach these stubs short-circuit at the call site —
+    see src/core/rules/component/index.ts.
+  -->
+  <script>
+    var fs$1 = {
+      existsSync: function () { return false; },
+      readFileSync: function () { return ''; },
+      statSync: function () { throw new Error('statSync not available in Figma plugin sandbox'); },
+      readdirSync: function () { return []; }
+    };
+    var path = {
+      sep: '/',
+      join: function () { return Array.prototype.filter.call(arguments, Boolean).join('/'); },
+      resolve: function () { return Array.prototype.filter.call(arguments, Boolean).join('/'); },
+      isAbsolute: function (p) { return typeof p === 'string' && p.charAt(0) === '/'; }
+    };
+  </script>
+
   <!-- Inline analysis engine (injected at build time) -->
   <script>
     /* __CANICODE_BROWSER_BUNDLE_INJECT__ */

--- a/src/core/rules/component/index.ts
+++ b/src/core/rules/component/index.ts
@@ -475,16 +475,35 @@ const CODE_CONNECT_SETUP_KEY = "unmapped-component:setup-detected";
 const CODE_CONNECT_MAPPINGS_KEY = "unmapped-component:mappings";
 const SEEN_MAIN_IDS_KEY = "unmapped-component:seen-main-ids";
 
+// Browser/plugin environments (Figma plugin sandbox, web app) have no
+// `process` global and no real fs — short-circuit cleanly so the rule
+// degrades to "no Code Connect setup" instead of throwing.
+function browserCwd(): string | null {
+  return typeof process !== "undefined" && typeof process.cwd === "function"
+    ? process.cwd()
+    : null;
+}
+
 function codeConnectIsSetUp(context: RuleContext): boolean {
   return getAnalysisState(context, CODE_CONNECT_SETUP_KEY, () => {
-    return existsSync(join(process.cwd(), "figma.config.json"));
+    const cwd = browserCwd();
+    if (cwd === null) return false;
+    return existsSync(join(cwd, "figma.config.json"));
   });
 }
 
 function codeConnectMappings(context: RuleContext): CodeConnectMappingResult {
-  return getAnalysisState(context, CODE_CONNECT_MAPPINGS_KEY, () =>
-    parseCodeConnectMappings(process.cwd()),
-  );
+  return getAnalysisState(context, CODE_CONNECT_MAPPINGS_KEY, () => {
+    const cwd = browserCwd();
+    if (cwd === null) {
+      return {
+        mappedNodeIds: new Set<string>(),
+        scannedFiles: [],
+        skipReason: "no-config",
+      };
+    }
+    return parseCodeConnectMappings(cwd);
+  });
 }
 
 function seenMainIds(context: RuleContext): Set<string> {

--- a/tsup.browser.config.ts
+++ b/tsup.browser.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from "tsup";
 
+// Browser bundle for the analysis engine. The IIFE that tsup emits depends
+// on Node-only globals (`fs$1`, `path`) because tsup's IIFE wrapper
+// externalises Node built-ins regardless of `platform: "browser"`. Hosts
+// that pre-declare those globals must do so before the bundle executes —
+// see `app/figma-plugin/src/ui.template.html` for the Figma-plugin shim.
+// Rules that touch the stubbed APIs guard at the call site
+// (see `src/core/rules/component/index.ts`).
 export default defineConfig({
   entry: { browser: "src/browser.ts" },
   format: ["iife"],


### PR DESCRIPTION
## Summary

- The Figma plugin failed at runtime with **"Analysis failed: Cannot read properties of undefined (reading 'analyzeFile')"** because the IIFE that wraps the analysis bundle references `fs\$1` and `path` as globals — and the Figma plugin sandbox has neither.
- Root cause: tsup's IIFE wrapper externalises Node built-ins regardless of `platform: "browser"`, leaving the bundle's IIFE call as `(function(exports, fs\$1, path){...})({}, fs\$1, path);`. The ReferenceError on `fs\$1` fires before `CanICode` is assigned, so the global is `undefined` and `CanICode.analyzeFile(...)` throws.
- Fix:
  - Pre-declare `fs\$1` and `path` in `app/figma-plugin/src/ui.template.html` with safe stubs that match the call shape (existsSync→false, readFileSync→"", join/resolve→delimited string).
  - Guard the only `process.cwd()` call that survives into the bundle (Code Connect setup detection in `src/core/rules/component/index.ts`) so the `unmapped-component` rule short-circuits cleanly when no Node `process` global is available.

The web app (`app/web/`) shares the same bundle and would benefit from the same shim — out of scope for this PR; separate follow-up if we ever observe the same failure there.

## Test plan
- [ ] `pnpm lint` passes ✓ (verified locally)
- [ ] `pnpm test:run` — full suite passes locally (1290 tests ✓)
- [ ] Build: `pnpm build:plugin` produces `app/figma-plugin/dist/ui.html` with the shim block immediately before the bundle IIFE
- [ ] Figma → Plugins → Development → Import plugin from manifest → run **Analyze Selection** on a small frame → no "Cannot read properties of undefined" error and report renders
- [ ] Re-run analysis on the same selection — repeat with a frame that contains components to exercise the `unmapped-component` rule short-circuit

🤖 Generated with [Claude Code](https://claude.com/claude-code)