### PR TITLE
fix(plugin): handle malformed component sets and surface skipped nodes

### DIFF
--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -6,6 +6,30 @@
 
 figma.showUI(__html__, { width: 420, height: 600 });
 
+// ---- Skipped-node tracking ----
+// Some Figma getters throw when the underlying node is healthy but its
+// parent component set has structural errors. We swallow the throw so the
+// rest of the analysis can run, but we record the skip so the UI can
+// surface it — silent skips would make scores look mysterious.
+
+type SkippedNodeInfo = {
+  id: string;
+  name: string;
+  reason:
+    | "componentProperties"
+    | "componentPropertyDefinitions"
+    | "getMainComponent";
+};
+
+let skippedNodes: SkippedNodeInfo[] = [];
+
+function recordSkip(
+  node: SceneNode,
+  reason: SkippedNodeInfo["reason"],
+): void {
+  skippedNodes.push({ id: node.id, name: node.name, reason });
+}
+
 // ---- Type guards ----
 
 function hasAutoLayout(
@@ -323,7 +347,8 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
   // Component properties — every Figma getter touched here can throw when
   // the underlying component set has structural errors (duplicate variants,
   // missing axes). Failures must not abort the whole analysis pass —
-  // skip the field and keep the node.
+  // skip the field, keep the node, and record the skip so the UI can
+  // surface it (`recordSkip`).
   if (node.type === "INSTANCE") {
     try {
       const mainComp = await (node as InstanceNode).getMainComponentAsync();
@@ -331,7 +356,7 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
         result.componentId = mainComp.id;
       }
     } catch {
-      // Main component lookup failed (deleted / malformed set).
+      recordSkip(node, "getMainComponent");
     }
     try {
       if (
@@ -345,6 +370,7 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
     } catch {
       // Figma throws "Component set for node has existing errors" on
       // `componentProperties` access when the parent set is malformed.
+      recordSkip(node, "componentProperties");
     }
   }
   if (node.type === "COMPONENT" || node.type === "COMPONENT_SET") {
@@ -357,7 +383,8 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
         ) as Record<string, unknown>;
       }
     } catch {
-      // Variant components throw when accessing componentPropertyDefinitions
+      // Variant components throw when accessing componentPropertyDefinitions.
+      recordSkip(node, "componentPropertyDefinitions");
     }
   }
 
@@ -387,6 +414,8 @@ async function buildAnalysisFile(
   rootNode: SceneNode,
   pageName: string
 ): Promise<AnalysisFile> {
+  // Reset per-run accumulator so previous skips don't leak into this run.
+  skippedNodes = [];
   const doc = await transformPluginNode(rootNode);
 
   // Collect component metadata
@@ -461,6 +490,7 @@ figma.ui.onmessage = async (msg: { type: string }) => {
       type: "result",
       data: file,
       nodeCount,
+      skipped: skippedNodes,
     });
   }
 

--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -320,19 +320,31 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
     };
   }
 
-  // Component properties
+  // Component properties — every Figma getter touched here can throw when
+  // the underlying component set has structural errors (duplicate variants,
+  // missing axes). Failures must not abort the whole analysis pass —
+  // skip the field and keep the node.
   if (node.type === "INSTANCE") {
-    const mainComp = await (node as InstanceNode).getMainComponentAsync();
-    if (mainComp) {
-      result.componentId = mainComp.id;
+    try {
+      const mainComp = await (node as InstanceNode).getMainComponentAsync();
+      if (mainComp) {
+        result.componentId = mainComp.id;
+      }
+    } catch {
+      // Main component lookup failed (deleted / malformed set).
     }
-    if (
-      "componentProperties" in node &&
-      node.componentProperties
-    ) {
-      result.componentProperties = JSON.parse(
-        JSON.stringify(node.componentProperties)
-      ) as Record<string, unknown>;
+    try {
+      if (
+        "componentProperties" in node &&
+        node.componentProperties
+      ) {
+        result.componentProperties = JSON.parse(
+          JSON.stringify(node.componentProperties)
+        ) as Record<string, unknown>;
+      }
+    } catch {
+      // Figma throws "Component set for node has existing errors" on
+      // `componentProperties` access when the parent set is malformed.
     }
   }
   if (node.type === "COMPONENT" || node.type === "COMPONENT_SET") {

--- a/app/figma-plugin/src/ui.template.html
+++ b/app/figma-plugin/src/ui.template.html
@@ -130,13 +130,14 @@
     }
 
     // ---- Render results via shared renderReportBody() ----
-    function showResults(file, result, scores) {
+    function showResults(file, result, scores, skipped) {
       document.getElementById('empty-state').style.display = 'none';
       document.getElementById('loading').style.display = 'none';
       document.getElementById('error').style.display = 'none';
 
       var el = document.getElementById('results');
-      el.innerHTML = CanICode.renderReportBody({
+      var bannerHtml = renderSkippedBanner(skipped);
+      el.innerHTML = bannerHtml + CanICode.renderReportBody({
         fileName: file.name,
         fileKey: file.fileKey,
         scores: scores,
@@ -146,6 +147,22 @@
       });
       el.className = 'visible';
       CanICode.initReportInteractions(el);
+    }
+
+    // ---- Render banner for nodes skipped during plugin-side extraction ----
+    // (Component sets with errors in Figma cause certain getters to throw —
+    // we surface the count + names so users know related rule scores may
+    // be incomplete and can fix the source set in Figma.)
+    function renderSkippedBanner(skipped) {
+      if (!skipped || skipped.length === 0) return '';
+      var esc = CanICode.escapeHtml;
+      var items = skipped.map(function (s) {
+        return '<li><a href="#" data-node-id="' + esc(s.id) + '">' + esc(s.name) + '</a> <span style="opacity:0.7">(' + esc(s.reason) + ')</span></li>';
+      }).join('');
+      return '<div class="warning-msg">' +
+        '<strong>' + skipped.length + ' node(s) skipped</strong> — their parent component sets have errors in Figma. Related rule scores may be incomplete.' +
+        '<details><summary>Show list</summary><ul>' + items + '</ul></details>' +
+        '</div>';
     }
 
     // ---- Focus node in Figma — intercept all [data-node-id] clicks ----
@@ -176,13 +193,14 @@
           var file = msg.data;
           var result = CanICode.analyzeFile(file);
           var scores = CanICode.calculateScores(result);
-          showResults(file, result, scores);
+          showResults(file, result, scores, msg.skipped);
 
           window._trackEvent('cic_analysis_completed', {
             nodeCount: result.nodeCount,
             issueCount: result.issues.length,
             grade: scores.overall.grade,
             percentage: scores.overall.percentage,
+            skippedCount: (msg.skipped && msg.skipped.length) || 0,
             duration: Date.now() - analysisStart
           });
 

--- a/app/shared/styles.css
+++ b/app/shared/styles.css
@@ -645,6 +645,22 @@ body {
   border: 1px solid rgba(239,68,68,0.15);
 }
 
+/* ---- Warning (skipped nodes, etc.) ---- */
+.warning-msg {
+  background: var(--amber-bg);
+  color: #92400e;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  margin-bottom: 16px;
+  border: 1px solid rgba(245,158,11,0.2);
+}
+.warning-msg details { margin-top: 8px; }
+.warning-msg summary { cursor: pointer; font-weight: 500; }
+.warning-msg ul { margin: 8px 0 0 16px; padding: 0; }
+.warning-msg li { margin: 4px 0; }
+.warning-msg a { color: inherit; text-decoration: underline; }
+
 /* ---- Layout (plugin) ---- */
 .container { padding: 16px; }
 .header {


### PR DESCRIPTION
## Summary

Follow-up to #571. Two bundled changes:

### 1. Don't crash on malformed component sets (commit 1)

The plugin still aborted when the selection contained an INSTANCE whose main COMPONENT_SET has structural errors (duplicate variants, missing axes). The error surfaced in the plugin UI as:

> in get_componentProperties: Component set for node has existing errors

Root cause: \`node.componentProperties\` access at \`app/figma-plugin/src/main.ts\` was not wrapped in try/catch. The same call shape a few lines below (\`componentPropertyDefinitions\` on a COMPONENT/COMPONENT_SET) was already guarded — this fix mirrors the pattern.

Wrapped \`getMainComponentAsync()\` and \`componentProperties\` access. On failure the node still emits, only the optional component fields are dropped.

### 2. Surface skipped nodes (commit 2)

Silent skips would let users see "weird scores" with no signal *why*. Collect every skipped node (id, name, reason) on the sandbox side, forward via the result message, and render an amber banner above the report:

> ⚠ N node(s) skipped — their parent component sets have errors in Figma. Related rule scores may be incomplete.
> ▸ Show list

The list items are focus-node links so users can jump straight to the broken set in Figma to fix it. Telemetry: \`skippedCount\` added to the existing \`cic_analysis_completed\` event.

## Test plan
- [ ] \`pnpm lint\` ✓ (verified locally)
- [ ] \`pnpm build:plugin\` ✓ (verified locally — banner code present in built ui.html)
- [ ] In Figma, Import plugin from manifest → run **Analyze Selection** on a frame containing an instance whose component set has errors:
  - [ ] no UI error, report renders
  - [ ] amber banner above report shows count + list
  - [ ] clicking a list item focuses that node in Figma
- [ ] Re-run on a clean frame (no malformed sets): no banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)