### PR TITLE
docs(readme): add Figma Community plugin badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/canicode"><img src="https://img.shields.io/npm/v/canicode.svg" alt="npm version"></a>
+  <a href="https://www.figma.com/community/plugin/1617144221046795292/can-i-code"><img src="https://img.shields.io/badge/Figma-Plugin-F24E1E?logo=figma&logoColor=white" alt="Figma Plugin"></a>
   <a href="https://github.com/let-sunny/canicode/actions/workflows/ci.yml"><img src="https://github.com/let-sunny/canicode/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/let-sunny/canicode/actions/workflows/release.yml"><img src="https://github.com/let-sunny/canicode/actions/workflows/release.yml/badge.svg" alt="Release"></a>
 </p>


### PR DESCRIPTION
## Summary
- Plugin was approved on the Figma Community (https://www.figma.com/community/plugin/1617144221046795292/can-i-code)
- Add a Figma-branded badge next to the npm badge in the README header so users discover the in-Figma entry point alongside the CLI

## Test plan
- [x] Badge renders with Figma orange (#F24E1E) and links to the Community page

🤖 Generated with [Claude Code](https://claude.com/claude-code)