### PR TITLE
fix(adr-016): pre-compute groupMembers display counts in question payload

### DIFF
--- a/.claude/skills/canicode-roundtrip/SKILL.md
+++ b/.claude/skills/canicode-roundtrip/SKILL.md
@@ -263,10 +263,10 @@ Instance-child guard and per-rule prompts — **[Appendix Strategy B](https://gi
 
 ##### Strategy B group componentize — Phase 3 (`missing-component:structure-repetition`)
 
-When `applyStrategy === "structural-mod"` AND `question.ruleId === "missing-component"` AND `question.subType === "structure-repetition"` AND `question.groupMembers` is set, the question represents a fingerprint group of N FRAMEs the user can componentize-and-swap in one batch. The group spans both same-parent siblings and cross-parent matches found by the Stage 3 scope-wide pass (#557). Render the per-question prompt with the **group size** explicitly so the designer knows the scope before answering. Substitute `{nodeName}` with `question.nodeName` and `{others}` with `question.groupMembers.length - 1` (the count excluding the first member that becomes the new component); render in the user's session language:
+When `applyStrategy === "structural-mod"` AND `question.ruleId === "missing-component"` AND `question.subType === "structure-repetition"` AND `question.groupMembers` is set, the question represents a fingerprint group of N FRAMEs the user can componentize-and-swap in one batch. The group spans both same-parent siblings and cross-parent matches found by the Stage 3 scope-wide pass (#557). Render the per-question prompt with the **group size** explicitly so the designer knows the scope before answering. Substitute `{nodeName}` with `question.nodeName`, `{others}` with `question.othersCount`, and `{total}` with `question.totalCount`; render in the user's session language:
 
-- Korean: `> "{nodeName}" 외에 동일한 구조의 frame이 {others}개 더 있습니다 (총 {others + 1}개). 모두 컴포넌트화 할까요? (yes/no)`
-- English: `> "{nodeName}" and {others} other frame(s) share the same structure ({others + 1} total). Componentize the whole group? (yes/no)`
+- Korean: `> "{nodeName}" 외에 동일한 구조의 frame이 {others}개 더 있습니다 (총 {total}개). 모두 컴포넌트화 할까요? (yes/no)`
+- English: `> "{nodeName}" and {others} other frame(s) share the same structure ({total} total). Componentize the whole group? (yes/no)`
 
 On `yes`, compute the file-wide existing component name set once (decision C uses this for the suffix), then call the group orchestrator. On `no` / `skip`, drop the question without writing anything; the gotcha state is captured in the SKILL's section markdown either way.
 

--- a/src/core/contracts/gotcha-survey.ts
+++ b/src/core/contracts/gotcha-survey.ts
@@ -106,6 +106,11 @@ export const GotchaSurveyQuestionSchema = z.object({
   // = 2). A future rule emitting `[]` or `[oneId]` is a programming error,
   // not a runtime case to handle gracefully.
   groupMembers: z.array(z.string()).min(2).optional(),
+  // Pre-computed scalars derived from `groupMembers` (ADR-016: no arithmetic
+  // in SKILL.md prose). Only present when `groupMembers` is set.
+  // othersCount = groupMembers.length - 1 (≥1), totalCount = groupMembers.length (≥2).
+  othersCount: z.number().int().min(1).optional(),
+  totalCount: z.number().int().min(2).optional(),
 });
 
 export type GotchaSurveyQuestion = z.infer<typeof GotchaSurveyQuestionSchema>;

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -1536,6 +1536,28 @@ describe("generateGotchaSurvey", () => {
       expect(parsed.success).toBe(true);
     });
 
+    it("computes othersCount/totalCount correctly for minimum 2-member group", () => {
+      const issues = [
+        makeIssue({
+          ruleId: "missing-component",
+          category: "code-quality",
+          severity: "risk",
+          nodeId: "fA",
+          nodePath: "Root > A",
+          subType: "structure-repetition",
+          groupMembers: ["fA", "fB"],
+        }),
+      ];
+      const survey = generateGotchaSurvey(
+        makeResult(issues),
+        makeScoreReport("C"),
+      );
+      expect(survey.questions).toHaveLength(1);
+      expect(survey.questions[0]?.othersCount).toBe(1); // 2 members → 1 other
+      expect(survey.questions[0]?.totalCount).toBe(2);  // 2 members total
+      expect(GotchaSurveySchema.safeParse(survey).success).toBe(true);
+    });
+
     it("omits groupMembers when the violation does not carry one (non-group rules)", () => {
       const issues = [
         makeIssue({

--- a/src/core/gotcha/survey-generator.test.ts
+++ b/src/core/gotcha/survey-generator.test.ts
@@ -1528,6 +1528,9 @@ describe("generateGotchaSurvey", () => {
       );
       expect(survey.questions).toHaveLength(1);
       expect(survey.questions[0]?.groupMembers).toEqual(["fA", "fB", "fC"]);
+      // ADR-016: pre-computed scalars derived from groupMembers
+      expect(survey.questions[0]?.othersCount).toBe(2); // 3 members → 2 others
+      expect(survey.questions[0]?.totalCount).toBe(3);  // 3 members total
       // Schema validation — `groupMembers: z.array(z.string()).optional()`
       const parsed = GotchaSurveySchema.safeParse(survey);
       expect(parsed.success).toBe(true);
@@ -1548,6 +1551,8 @@ describe("generateGotchaSurvey", () => {
       );
       expect(survey.questions).toHaveLength(1);
       expect(survey.questions[0]?.groupMembers).toBeUndefined();
+      expect(survey.questions[0]?.othersCount).toBeUndefined();
+      expect(survey.questions[0]?.totalCount).toBeUndefined();
     });
   });
 });

--- a/src/core/gotcha/survey-generator.ts
+++ b/src/core/gotcha/survey-generator.ts
@@ -229,8 +229,14 @@ function mapToQuestion(
     // #560 / Phase 3 delta 4a: thread groupMembers through from the
     // violation. Currently only populated by `missing-component`
     // Stage 3; non-group rules pass undefined and the field is omitted.
+    // ADR-016: pre-compute othersCount / totalCount so SKILL.md prose needs
+    // no arithmetic.
     ...(issue.violation.groupMembers !== undefined
-      ? { groupMembers: issue.violation.groupMembers }
+      ? {
+          groupMembers: issue.violation.groupMembers,
+          othersCount: issue.violation.groupMembers.length - 1,
+          totalCount: issue.violation.groupMembers.length,
+        }
       : {}),
   };
 }


### PR DESCRIPTION
## Summary

- Adds `othersCount` and `totalCount` pre-computed fields to `GotchaSurveyQuestion` Zod schema and TypeScript type
- Co-locates computation with `groupMembers` in the survey generator (single conditional spread), satisfying `exactOptionalPropertyTypes` via `.optional()` with `.min()` constraints
- Updates SKILL.md L266–269 to substitute `{others}` → `question.othersCount` and `{total}` → `question.totalCount`, removing the arithmetic prose (`groupMembers.length - 1`, `others + 1`) that ADR-016 prohibits
- Adds boundary test (2-member group: `othersCount===1`, `totalCount===2`) alongside the existing 3-member test

Closes #577

## Test plan

- [x] TypeScript type check (`tsc --noEmit`) — no errors
- [x] Full test suite (`vitest run`) — 82 files, 1291 tests, all passed
- [x] SKILL.md arithmetic prose replaced with pre-computed field references

🤖 Generated with [Claude Code](https://claude.com/claude-code)