### PR TITLE
fix(plugin): library variable bindings no longer flagged as raw-value

### DIFF
--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -302,7 +302,19 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
   if (hasFills(node)) {
     const fills = node.fills;
     if (Array.isArray(fills)) {
-      result.fills = fills.map((f) => ({ ...f }));
+      result.fills = fills.map((f) => {
+        const plain: Record<string, unknown> = { ...f };
+        // Figma Paint proxy objects expose boundVariables as a non-enumerable
+        // getter, so spread silently drops it. Copy it explicitly so that
+        // library variable bindings on individual fills survive serialization.
+        const fillBV = (f as unknown as { boundVariables?: unknown }).boundVariables;
+        if (fillBV !== undefined) {
+          try {
+            plain["boundVariables"] = JSON.parse(JSON.stringify(fillBV));
+          } catch { /* ignore if not serializable */ }
+        }
+        return plain;
+      });
     }
   }
   if (hasStrokes(node)) {
@@ -322,6 +334,21 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
     result.boundVariables = JSON.parse(
       JSON.stringify(node.boundVariables)
     ) as Record<string, unknown>;
+  }
+
+  // Plugin API may omit node.boundVariables["fills"] for library variables even
+  // when the individual fills have variable bindings. Synthesize the key from
+  // fill-level data so the rule engine sees a consistent REST-API-shaped object.
+  if (result.fills && result.fills.length > 0) {
+    const fillBVs = result.fills.map(
+      (f) => (f as Record<string, unknown>)["boundVariables"] as unknown
+    );
+    if (fillBVs.some(Boolean)) {
+      if (!result.boundVariables) result.boundVariables = {};
+      if (!("fills" in result.boundVariables)) {
+        result.boundVariables["fills"] = fillBVs;
+      }
+    }
   }
 
   // Text properties

--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -330,24 +330,38 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
   }
 
   // Bound variables (design tokens)
+  // JSON.stringify(node.boundVariables) silently drops library variable keys:
+  // Figma's proxy only enumerates local-file variables via ownKeys, but all
+  // variables (local + library) are accessible via direct property access (get).
+  // Extract each known key explicitly so library bindings survive serialization.
   if ("boundVariables" in node && node.boundVariables) {
-    result.boundVariables = JSON.parse(
-      JSON.stringify(node.boundVariables)
-    ) as Record<string, unknown>;
-  }
-
-  // Plugin API may omit node.boundVariables["fills"] for library variables even
-  // when the individual fills have variable bindings. Synthesize the key from
-  // fill-level data so the rule engine sees a consistent REST-API-shaped object.
-  if (result.fills && result.fills.length > 0) {
-    const fillBVs = result.fills.map(
-      (f) => (f as Record<string, unknown>)["boundVariables"] as unknown
-    );
-    if (fillBVs.some(Boolean)) {
-      if (!result.boundVariables) result.boundVariables = {};
-      if (!("fills" in result.boundVariables)) {
-        result.boundVariables["fills"] = fillBVs;
-      }
+    const bv = node.boundVariables as Record<string, unknown>;
+    const SCALAR_KEYS = [
+      "itemSpacing", "counterAxisSpacing",
+      "paddingLeft", "paddingRight", "paddingTop", "paddingBottom",
+      "opacity",
+      "topLeftRadius", "topRightRadius", "bottomLeftRadius", "bottomRightRadius",
+      "minWidth", "maxWidth", "minHeight", "maxHeight",
+      "strokeWeight", "strokeTopWeight", "strokeRightWeight", "strokeBottomWeight", "strokeLeftWeight",
+      "gridRowGap", "gridColumnGap",
+      "width", "height", "characters", "visible",
+    ] as const;
+    const ARRAY_KEYS = [
+      "fills", "strokes", "effects", "layoutGrids",
+      "fontFamily", "fontSize", "fontStyle", "fontWeight",
+      "letterSpacing", "lineHeight", "paragraphSpacing", "paragraphIndent",
+    ] as const;
+    const extracted: Record<string, unknown> = {};
+    for (const key of [...SCALAR_KEYS, ...ARRAY_KEYS]) {
+      try {
+        const val = bv[key];
+        if (val !== undefined) {
+          extracted[key] = JSON.parse(JSON.stringify(val));
+        }
+      } catch { /* skip unserializable values */ }
+    }
+    if (Object.keys(extracted).length > 0) {
+      result.boundVariables = extracted;
     }
   }
 

--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -311,7 +311,9 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
         if (fillBV !== undefined) {
           try {
             plain["boundVariables"] = JSON.parse(JSON.stringify(fillBV));
-          } catch { /* ignore if not serializable */ }
+          } catch (e) {
+            console.warn("[canicode] fill.boundVariables not serializable:", e);
+          }
         }
         return plain;
       });
@@ -358,7 +360,9 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
         if (val !== undefined) {
           extracted[key] = JSON.parse(JSON.stringify(val));
         }
-      } catch { /* skip unserializable values */ }
+      } catch (e) {
+        console.warn(`[canicode] boundVariables["${key}"] not serializable:`, e);
+      }
     }
     if (Object.keys(extracted).length > 0) {
       result.boundVariables = extracted;

--- a/src/core/rules/token/index.test.ts
+++ b/src/core/rules/token/index.test.ts
@@ -1,0 +1,101 @@
+import { makeNode, makeContext } from "../test-helpers.js";
+import { irregularSpacing } from "./index.js";
+
+describe("irregular-spacing", () => {
+  describe("off-grid spacing without variable binding", () => {
+    it("flags off-grid paddingLeft", () => {
+      const node = makeNode({ paddingLeft: 7 });
+      const result = irregularSpacing.check(node, makeContext());
+      expect(result).not.toBeNull();
+      expect(result?.ruleId).toBe("irregular-spacing");
+      expect(result?.subType).toBe("padding");
+    });
+
+    it("flags off-grid itemSpacing", () => {
+      const node = makeNode({ itemSpacing: 7 });
+      const result = irregularSpacing.check(node, makeContext());
+      expect(result).not.toBeNull();
+      expect(result?.subType).toBe("gap");
+    });
+  });
+
+  describe("off-grid spacing bound to a variable", () => {
+    it("skips off-grid paddingLeft bound to a local variable", () => {
+      const node = makeNode({
+        paddingLeft: 7,
+        boundVariables: { paddingLeft: { type: "VARIABLE_ALIAS", id: "VariableID:1:1" } },
+      });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
+    });
+
+    it("skips off-grid paddingRight bound to a variable", () => {
+      const node = makeNode({
+        paddingRight: 7,
+        boundVariables: { paddingRight: { type: "VARIABLE_ALIAS", id: "VariableID:1:1" } },
+      });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
+    });
+
+    it("skips off-grid paddingTop bound to a variable", () => {
+      const node = makeNode({
+        paddingTop: 7,
+        boundVariables: { paddingTop: { type: "VARIABLE_ALIAS", id: "VariableID:1:1" } },
+      });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
+    });
+
+    it("skips off-grid paddingBottom bound to a variable", () => {
+      const node = makeNode({
+        paddingBottom: 7,
+        boundVariables: { paddingBottom: { type: "VARIABLE_ALIAS", id: "VariableID:1:1" } },
+      });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
+    });
+
+    it("skips off-grid itemSpacing bound to a variable", () => {
+      const node = makeNode({
+        itemSpacing: 7,
+        boundVariables: { itemSpacing: { type: "VARIABLE_ALIAS", id: "VariableID:1:1" } },
+      });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
+    });
+
+    it("skips off-grid itemSpacing bound to a library variable", () => {
+      const node = makeNode({
+        itemSpacing: 13,
+        boundVariables: {
+          itemSpacing: { type: "VARIABLE_ALIAS", id: "VariableID:library:42" },
+        },
+      });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
+    });
+
+    it("flags unbound off-grid padding even when another key is bound", () => {
+      const node = makeNode({
+        paddingLeft: 7,
+        paddingRight: 8,
+        boundVariables: { paddingRight: { type: "VARIABLE_ALIAS", id: "VariableID:1:1" } },
+      });
+      const result = irregularSpacing.check(node, makeContext());
+      expect(result).not.toBeNull();
+      expect(result?.subType).toBe("padding");
+    });
+  });
+
+  describe("on-grid and exempt values", () => {
+    it("returns null for on-grid padding (multiple of 4)", () => {
+      const node = makeNode({ paddingLeft: 8, paddingRight: 16, itemSpacing: 4 });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
+    });
+
+    it("returns null for common exempt values (1, 2)", () => {
+      const node = makeNode({ paddingLeft: 1, itemSpacing: 2 });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
+    });
+
+    it("returns null for node with no spacing properties", () => {
+      const node = makeNode({ type: "TEXT" });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
+    });
+  });
+});

--- a/src/core/rules/token/index.ts
+++ b/src/core/rules/token/index.ts
@@ -145,13 +145,13 @@ const irregularSpacingCheck: RuleCheckFn = (node, context, options) => {
   const configuredGridBase = (options?.["gridBase"] as number) ?? getRuleOption("irregular-spacing", "gridBase", 4);
   const gridBase = Number.isFinite(configuredGridBase) && configuredGridBase > 0 ? configuredGridBase : 4;
 
-  const spacingEntries: Array<{ value: number; subType: "padding" | "gap" }> = [];
+  const spacingEntries: Array<{ key: string; value: number; subType: "padding" | "gap" }> = [];
   for (const key of ["paddingLeft", "paddingRight", "paddingTop", "paddingBottom"] as const) {
     const v = node[key];
-    if (v !== undefined && v > 0) spacingEntries.push({ value: v, subType: "padding" });
+    if (v !== undefined && v > 0) spacingEntries.push({ key, value: v, subType: "padding" });
   }
   if (node.itemSpacing !== undefined && node.itemSpacing > 0) {
-    spacingEntries.push({ value: node.itemSpacing, subType: "gap" });
+    spacingEntries.push({ key: "itemSpacing", value: node.itemSpacing, subType: "gap" });
   }
 
   // Allow small intentional values
@@ -159,6 +159,8 @@ const irregularSpacingCheck: RuleCheckFn = (node, context, options) => {
 
   for (const entry of spacingEntries) {
     if (commonValues.includes(entry.value)) continue;
+    // Skip entries bound to a design token — off-grid is intentional for library variables
+    if (hasBoundVariable(node, entry.key)) continue;
     if (!isOnGrid(entry.value, gridBase)) {
       return {
         ruleId: irregularSpacingDef.id,


### PR DESCRIPTION
## Summary

Closes #578

배포된 라이브러리 변수로 fill 컬러, gap, padding, opacity, font 등을 설정해도 `raw-value`/`irregular-spacing`으로 플래그되는 버그를 수정합니다.

## Root cause

Figma Plugin API의 `node.boundVariables`는 프록시 객체입니다.

- `console.log(node.boundVariables)` → 로컬 + 라이브러리 변수 모두 표시 (get trap)
- `JSON.stringify(node.boundVariables)` → **라이브러리 변수 키 누락** (ownKeys trap이 로컬 파일 변수만 열거)

기존 코드가 `JSON.parse(JSON.stringify(node.boundVariables))`로 직렬화하여 `result.boundVariables = {}`가 되고, 이후 `hasBoundVariable()` 체크가 전부 `false`를 반환하여 모든 라이브러리 변수가 raw value로 잡혔습니다.

## Changes

### `app/figma-plugin/src/main.ts`

**boundVariables 직렬화 방식 변경**

`JSON.stringify` 대신 Figma Plugin API 타이핑 기준 알려진 키(`VariableBindableNodeField`, `VariableBindableTextField`, array keys)를 하나씩 직접 접근하여 추출합니다. 직접 프로퍼티 접근은 get trap을 통해 로컬 + 라이브러리 변수 모두 반환합니다.

```ts
// Before (broken for library variables)
result.boundVariables = JSON.parse(JSON.stringify(node.boundVariables));

// After
const SCALAR_KEYS = ["itemSpacing", "paddingLeft", ..., "opacity", ...];
const ARRAY_KEYS = ["fills", "strokes", "fontFamily", "fontSize", ...];
for (const key of [...SCALAR_KEYS, ...ARRAY_KEYS]) {
  const val = bv[key]; // get trap — returns library vars too
  if (val !== undefined) extracted[key] = JSON.parse(JSON.stringify(val));
}
result.boundVariables = extracted;
```

**fills 직렬화 수정**

Paint 프록시 객체의 `boundVariables`도 non-enumerable이라 spread에서 소실됩니다. 명시적으로 복사하여 design-tree의 `/* var:... */` 주석이 라이브러리 fill 변수에도 표시되도록 수정합니다.

### `src/core/rules/token/index.ts`

**`irregular-spacing` 룰에 variable binding 체크 추가**

기존 `irregular-spacing`은 `hasBoundVariable` 체크 없이 off-grid 값을 무조건 플래그했습니다. 라이브러리 spacing 토큰이 그리드에 맞지 않더라도 의도된 디자인이므로 건너뜁니다.

## Test plan

- [ ] 퍼블리시된 라이브러리의 COLOR 변수를 fill에 적용한 노드 → `raw-value (color)` 미발생
- [ ] 퍼블리시된 라이브러리의 NUMBER 변수를 gap/padding에 적용한 노드 → `raw-value (spacing)` 미발생
- [ ] 퍼블리시된 라이브러리의 NUMBER 변수를 off-grid 값으로 gap에 적용 → `irregular-spacing` 미발생
- [ ] 로컬 변수 동작 기존과 동일한지 확인
- [ ] 변수 없는 raw value는 여전히 플래그되는지 확인


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hxd2k9yUubs6rMvCKBuqho)_