### PR TITLE
fix(web): add fs/path shims before browser bundle to prevent CanICode undefined error

### DIFF
--- a/app/web/src/index.html
+++ b/app/web/src/index.html
@@ -211,6 +211,27 @@
 
   </main>
 
+  <!--
+    Node-builtin shims for the analysis engine bundle.
+    tsup wraps the IIFE with `(function(exports, fs$1, path){...})({}, fs$1, path);`
+    because rollup externalises `fs`/`path` regardless of the browser platform target.
+    Pre-declaring them here prevents a ReferenceError that would leave `CanICode` undefined.
+  -->
+  <script>
+    var fs$1 = {
+      existsSync: function () { return false; },
+      readFileSync: function () { return ''; },
+      statSync: function () { throw new Error('statSync not available in browser'); },
+      readdirSync: function () { return []; }
+    };
+    var path = {
+      sep: '/',
+      join: function () { return Array.prototype.filter.call(arguments, Boolean).join('/'); },
+      resolve: function () { return Array.prototype.filter.call(arguments, Boolean).join('/'); },
+      isAbsolute: function (p) { return typeof p === 'string' && p.charAt(0) === '/'; }
+    };
+  </script>
+
   <script src="browser.global.js"></script>
 
   <!-- Monitoring: PostHog analytics + Sentry error tracking -->


### PR DESCRIPTION
## Summary

- `browser.global.js` IIFE 번들이 `fs$1`, `path`를 전역 변수로 참조하는데 웹 앱 `index.html`에 shim이 없어서 `ReferenceError` 발생
- `CanICode` 글로벌이 미할당 상태로 남아 모든 웹 앱 동작이 실패 ("Cannot read properties of undefined (reading 'parseFigmaUrl')")

## Root cause

#571에서 플러그인 샌드박스의 동일한 문제를 고칠 때 `app/figma-plugin/src/ui.template.html`에만 shim을 추가하고 `app/web/src/index.html`은 빠뜨린 것이 원인.

## Changes

`app/web/src/index.html`에 `browser.global.js` 로드 전 `fs$1`/`path` stub 선언 추가 — 플러그인 템플릿과 동일한 패턴.

Closes #581

## Test plan

- [x] 웹 앱에서 Figma URL 입력 후 분석 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)