### PR TITLE
fix: raw-value false positives — property-level variable bindings, plugin styles map, shadow bindings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ \"$DEVELOP_SUBAGENT\" = \"1\" ] && exit 0; OUT=$({ pnpm lint && pnpm build; } 2>&1); [ $? -eq 0 ] || { echo '[stop-hook] pnpm lint/build FAILED'; echo \"$OUT\"; exit 1; }"
+            "command": "[ \"$DEVELOP_SUBAGENT\" = \"1\" ] && exit 0; eval \"$(fnm env 2>/dev/null)\"; OUT=$({ pnpm lint && pnpm build; } 2>&1); [ $? -eq 0 ] || { echo '[stop-hook] pnpm lint/build FAILED' >&2; echo \"$OUT\" >&2; exit 1; }"
           },
           {
             "type": "command",

--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -298,6 +298,29 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
     }
   }
 
+  // Style references (fillStyleId/strokeStyleId/effectStyleId/textStyleId →
+  // REST-style `styles` map) so hasStyleReference() works in the plugin
+  // channel. figma.mixed is a symbol, so the typeof check skips mixed values;
+  // an empty string means no style is applied.
+  const styleRefs: Record<string, string> = {};
+  const STYLE_ID_KEYS: Array<[prop: string, key: string]> = [
+    ["fillStyleId", "fill"],
+    ["strokeStyleId", "stroke"],
+    ["effectStyleId", "effect"],
+    ["textStyleId", "text"],
+  ];
+  for (const [prop, key] of STYLE_ID_KEYS) {
+    if (prop in node) {
+      const styleId = (node as unknown as Record<string, unknown>)[prop];
+      if (typeof styleId === "string" && styleId !== "") {
+        styleRefs[key] = styleId;
+      }
+    }
+  }
+  if (Object.keys(styleRefs).length > 0) {
+    result.styles = styleRefs;
+  }
+
   // Fills, strokes, effects — serialize as plain arrays
   if (hasFills(node)) {
     const fills = node.fills;

--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -320,10 +320,32 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
     }
   }
   if (hasStrokes(node)) {
-    result.strokes = node.strokes.map((s) => ({ ...s }));
+    result.strokes = node.strokes.map((s) => {
+      const plain: Record<string, unknown> = { ...s };
+      const bv = (s as unknown as { boundVariables?: unknown }).boundVariables;
+      if (bv !== undefined) {
+        try {
+          plain["boundVariables"] = JSON.parse(JSON.stringify(bv));
+        } catch (e) {
+          console.warn("[canicode] stroke.boundVariables not serializable:", e);
+        }
+      }
+      return plain;
+    });
   }
   if (hasEffects(node)) {
-    result.effects = node.effects.map((e) => ({ ...e }));
+    result.effects = node.effects.map((e) => {
+      const plain: Record<string, unknown> = { ...e };
+      const bv = (e as unknown as { boundVariables?: unknown }).boundVariables;
+      if (bv !== undefined) {
+        try {
+          plain["boundVariables"] = JSON.parse(JSON.stringify(bv));
+        } catch (e) {
+          console.warn("[canicode] effect.boundVariables not serializable:", e);
+        }
+      }
+      return plain;
+    });
   }
 
   // Corner radius

--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -334,9 +334,9 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
     });
   }
   if (hasEffects(node)) {
-    result.effects = node.effects.map((e) => {
-      const plain: Record<string, unknown> = { ...e };
-      const bv = (e as unknown as { boundVariables?: unknown }).boundVariables;
+    result.effects = node.effects.map((effect) => {
+      const plain: Record<string, unknown> = { ...effect };
+      const bv = (effect as unknown as { boundVariables?: unknown }).boundVariables;
       if (bv !== undefined) {
         try {
           plain["boundVariables"] = JSON.parse(JSON.stringify(bv));

--- a/scripts/develop.ts
+++ b/scripts/develop.ts
@@ -40,6 +40,18 @@ import { createDevelopRunDir } from "../src/agents/run-directory.js";
 import { conventionalizeTitle } from "./conventional-title.js";
 
 // ---------------------------------------------------------------------------
+// Bootstrap: inject fnm-managed pnpm into PATH if not already present
+// ---------------------------------------------------------------------------
+
+try {
+  if (!execSync("which pnpm 2>/dev/null || true", { encoding: "utf-8", shell: "/bin/zsh" }).trim()) {
+    const fnmOut = execSync("fnm env 2>/dev/null || true", { encoding: "utf-8", shell: "/bin/zsh" });
+    const match = fnmOut.match(/export PATH="([^"]+)"/);
+    if (match) process.env["PATH"] = `${match[1]}:${process.env["PATH"] ?? ""}`;
+  }
+} catch { /* non-fatal */ }
+
+// ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 

--- a/scripts/develop.ts
+++ b/scripts/develop.ts
@@ -161,8 +161,10 @@ function markFailed(index: DevelopRunIndex, name: string, error: string): void {
 
 function runCli(command: string, label: string): string {
   console.log(`  [cli] ${label}`);
+  const shell = process.env["SHELL"] ?? "/bin/zsh";
+  const wrapped = `eval "$(fnm env 2>/dev/null)"; ${command}`;
   try {
-    return execSync(command, { encoding: "utf-8", maxBuffer: 50 * 1024 * 1024, cwd: PROJECT_ROOT });
+    return execSync(wrapped, { encoding: "utf-8", maxBuffer: 50 * 1024 * 1024, cwd: PROJECT_ROOT, shell });
   } catch (err) {
     const execErr = err as SpawnSyncReturns<string>;
     const stderr = execErr.stderr ?? "";

--- a/src/core/rules/token/index.test.ts
+++ b/src/core/rules/token/index.test.ts
@@ -47,6 +47,90 @@ describe("raw-value", () => {
       expect(result?.ruleId).toBe("raw-value");
       expect(result?.subType).toBe("opacity");
     });
+
+    it("flags a raw SOLID fill sitting next to a variable-bound fill", () => {
+      const node = makeNode({
+        type: "FRAME",
+        fills: [
+          {
+            type: "SOLID",
+            color: { r: 0, g: 0, b: 1 },
+            boundVariables: { color: { type: "VARIABLE_ALIAS", id: "VariableID:1:1" } },
+          },
+          { type: "SOLID", color: { r: 1, g: 0, b: 0 } },
+        ],
+      });
+      const result = rawValue.check(node, makeContext());
+      expect(result?.ruleId).toBe("raw-value");
+      expect(result?.subType).toBe("color");
+    });
+  });
+
+  describe("style references (plugin styles map)", () => {
+    it("does not flag a fill backed by a fill style", () => {
+      const node = makeNode({
+        type: "FRAME",
+        styles: { fill: "S:abc123" },
+        fills: [{ type: "SOLID", color: { r: 1, g: 0, b: 0 } }],
+      });
+      expect(rawValue.check(node, makeContext())).toBeNull();
+    });
+
+    it("does not flag a TEXT node backed by a text style", () => {
+      const node = makeNode({
+        type: "TEXT",
+        styles: { text: "S:txt456" },
+        style: { fontFamily: "Inter", fontSize: 16, fontWeight: 400 },
+      });
+      expect(rawValue.check(node, makeContext())).toBeNull();
+    });
+  });
+
+  describe("shadow variable bindings", () => {
+    const dropShadow = {
+      type: "DROP_SHADOW",
+      color: { r: 0, g: 0, b: 0, a: 0.25 },
+      offset: { x: 0, y: 4 },
+      radius: 8,
+    };
+
+    it("does not flag a shadow when effects are bound at node level (Path A)", () => {
+      const node = makeNode({
+        type: "FRAME",
+        effects: [dropShadow],
+        boundVariables: { effects: [{ type: "VARIABLE_ALIAS", id: "VariableID:2:1" }] },
+      });
+      expect(rawValue.check(node, makeContext())).toBeNull();
+    });
+
+    it("does not flag a shadow whose effect object carries its own binding (Path B)", () => {
+      const node = makeNode({
+        type: "FRAME",
+        effects: [
+          { ...dropShadow, boundVariables: { color: { type: "VARIABLE_ALIAS", id: "VariableID:2:2" } } },
+        ],
+      });
+      expect(rawValue.check(node, makeContext())).toBeNull();
+    });
+
+    it("flags a shadow with an empty boundVariables on the effect object", () => {
+      const node = makeNode({
+        type: "FRAME",
+        effects: [{ ...dropShadow, boundVariables: {} }],
+      });
+      const result = rawValue.check(node, makeContext());
+      expect(result?.ruleId).toBe("raw-value");
+      expect(result?.subType).toBe("shadow");
+    });
+
+    it("does not flag a shadow backed by an effect style", () => {
+      const node = makeNode({
+        type: "FRAME",
+        styles: { effect: "S:eff789" },
+        effects: [dropShadow],
+      });
+      expect(rawValue.check(node, makeContext())).toBeNull();
+    });
   });
 });
 

--- a/src/core/rules/token/index.test.ts
+++ b/src/core/rules/token/index.test.ts
@@ -36,6 +36,17 @@ describe("raw-value", () => {
       expect(result?.ruleId).toBe("raw-value");
       expect(result?.subType).toBe("color");
     });
+
+    it("still flags raw opacity when fill has a Path B binding", () => {
+      const node = makeNode({
+        type: "FRAME",
+        fills: [{ type: "SOLID", color: { r: 1, g: 0, b: 0 }, boundVariables: { color: { type: "VARIABLE_ALIAS", id: "VariableID:1:1" } } }],
+        opacity: 0.5,
+      });
+      const result = rawValue.check(node, makeContext());
+      expect(result?.ruleId).toBe("raw-value");
+      expect(result?.subType).toBe("opacity");
+    });
   });
 });
 

--- a/src/core/rules/token/index.test.ts
+++ b/src/core/rules/token/index.test.ts
@@ -1,5 +1,43 @@
 import { makeNode, makeContext } from "../test-helpers.js";
-import { irregularSpacing } from "./index.js";
+import { rawValue, irregularSpacing } from "./index.js";
+
+describe("raw-value", () => {
+  describe("fill color Path B — fills[i].boundVariables", () => {
+    it("does not flag a SOLID fill whose fill object carries a color variable binding", () => {
+      const node = makeNode({
+        type: "FRAME",
+        fills: [
+          {
+            type: "SOLID",
+            color: { r: 1, g: 0, b: 0 },
+            boundVariables: { color: { type: "VARIABLE_ALIAS", id: "VariableID:1:1" } },
+          },
+        ],
+      });
+      expect(rawValue.check(node, makeContext())).toBeNull();
+    });
+
+    it("flags a SOLID fill whose fill object carries an empty boundVariables", () => {
+      const node = makeNode({
+        type: "FRAME",
+        fills: [{ type: "SOLID", color: { r: 1, g: 0, b: 0 }, boundVariables: {} }],
+      });
+      const result = rawValue.check(node, makeContext());
+      expect(result?.ruleId).toBe("raw-value");
+      expect(result?.subType).toBe("color");
+    });
+
+    it("flags a SOLID fill with no boundVariables on the fill object", () => {
+      const node = makeNode({
+        type: "FRAME",
+        fills: [{ type: "SOLID", color: { r: 1, g: 0, b: 0 } }],
+      });
+      const result = rawValue.check(node, makeContext());
+      expect(result?.ruleId).toBe("raw-value");
+      expect(result?.subType).toBe("color");
+    });
+  });
+});
 
 describe("irregular-spacing", () => {
   describe("off-grid spacing without variable binding", () => {

--- a/src/core/rules/token/index.ts
+++ b/src/core/rules/token/index.ts
@@ -27,6 +27,12 @@ const rawValueCheck: RuleCheckFn = (node, context) => {
   // Check 1: Raw fill color
   if (node.fills && Array.isArray(node.fills) && node.fills.length > 0) {
     if (!hasStyleReference(node, "fill") && !hasBoundVariable(node, "fills")) {
+      // Path B: variable bound directly on a fill's own boundVariables (e.g. fills[i].boundVariables.color)
+      const hasFillColorVar = node.fills.some((f) => {
+        const bv = (f as Record<string, unknown>)["boundVariables"];
+        return bv !== undefined && Object.keys(bv as object).length > 0;
+      });
+      if (hasFillColorVar) return null;
       for (const fill of node.fills) {
         const fillObj = fill as Record<string, unknown>;
         if (fillObj["type"] === "SOLID" && fillObj["color"]) {

--- a/src/core/rules/token/index.ts
+++ b/src/core/rules/token/index.ts
@@ -8,6 +8,12 @@ function isOnGrid(value: number, gridBase: number): boolean {
   return value % gridBase === 0;
 }
 
+/** Path B variable binding: a sub-object (fill/stroke/effect) carrying its own boundVariables */
+function hasOwnBoundVariables(obj: Record<string, unknown>): boolean {
+  const bv = obj["boundVariables"];
+  return bv !== undefined && bv !== null && Object.keys(bv as object).length > 0;
+}
+
 // ============================================
 // raw-value (merged: raw-color + raw-font + raw-shadow + raw-opacity + raw-spacing)
 // ============================================
@@ -27,25 +33,22 @@ const rawValueCheck: RuleCheckFn = (node, context) => {
   // Check 1: Raw fill color
   if (node.fills && Array.isArray(node.fills) && node.fills.length > 0) {
     if (!hasStyleReference(node, "fill") && !hasBoundVariable(node, "fills")) {
-      // Path B: variable bound directly on a fill's own boundVariables (e.g. fills[i].boundVariables.color)
-      const hasFillColorVar = node.fills.some((f) => {
-        const bv = (f as Record<string, unknown>)["boundVariables"];
-        return bv !== undefined && Object.keys(bv as object).length > 0;
-      });
-      if (!hasFillColorVar) {
-        for (const fill of node.fills) {
-          const fillObj = fill as Record<string, unknown>;
-          if (fillObj["type"] === "SOLID" && fillObj["color"]) {
-            const c = fillObj["color"] as Record<string, number>;
-            const hex = `#${Math.round((c["r"] ?? 0) * 255).toString(16).padStart(2, "0")}${Math.round((c["g"] ?? 0) * 255).toString(16).padStart(2, "0")}${Math.round((c["b"] ?? 0) * 255).toString(16).padStart(2, "0")}`.toUpperCase();
-            return {
-              ruleId: rawValueDef.id,
-              subType: "color" as const,
-              nodeId: node.id,
-              nodePath,
-              ...rawValueMsg.color(node.name, hex),
-            };
-          }
+      for (const fill of node.fills) {
+        const fillObj = fill as Record<string, unknown>;
+        // Path B: variable bound directly on this fill's own boundVariables
+        // (e.g. fills[i].boundVariables.color) — checked per fill so a raw
+        // fill next to a bound one is still flagged
+        if (hasOwnBoundVariables(fillObj)) continue;
+        if (fillObj["type"] === "SOLID" && fillObj["color"]) {
+          const c = fillObj["color"] as Record<string, number>;
+          const hex = `#${Math.round((c["r"] ?? 0) * 255).toString(16).padStart(2, "0")}${Math.round((c["g"] ?? 0) * 255).toString(16).padStart(2, "0")}${Math.round((c["b"] ?? 0) * 255).toString(16).padStart(2, "0")}`.toUpperCase();
+          return {
+            ruleId: rawValueDef.id,
+            subType: "color" as const,
+            nodeId: node.id,
+            nodePath,
+            ...rawValueMsg.color(node.name, hex),
+          };
         }
       }
     }
@@ -75,11 +78,13 @@ const rawValueCheck: RuleCheckFn = (node, context) => {
     }
   }
 
-  // Check 3: Raw shadow (effects without effect style)
+  // Check 3: Raw shadow (effects without effect style or variable binding)
   if (node.effects && Array.isArray(node.effects) && node.effects.length > 0) {
-    if (!hasStyleReference(node, "effect")) {
+    if (!hasStyleReference(node, "effect") && !hasBoundVariable(node, "effects")) {
       for (const effect of node.effects) {
         const effectObj = effect as Record<string, unknown>;
+        // Path B: variable bound directly on this effect (effects[i].boundVariables)
+        if (hasOwnBoundVariables(effectObj)) continue;
         if (effectObj["type"] === "DROP_SHADOW" || effectObj["type"] === "INNER_SHADOW") {
           const shadowType = effectObj["type"] === "DROP_SHADOW" ? "drop shadow" : "inner shadow";
           const offset = effectObj["offset"] as Record<string, number> | undefined;

--- a/src/core/rules/token/index.ts
+++ b/src/core/rules/token/index.ts
@@ -32,19 +32,20 @@ const rawValueCheck: RuleCheckFn = (node, context) => {
         const bv = (f as Record<string, unknown>)["boundVariables"];
         return bv !== undefined && Object.keys(bv as object).length > 0;
       });
-      if (hasFillColorVar) return null;
-      for (const fill of node.fills) {
-        const fillObj = fill as Record<string, unknown>;
-        if (fillObj["type"] === "SOLID" && fillObj["color"]) {
-          const c = fillObj["color"] as Record<string, number>;
-          const hex = `#${Math.round((c["r"] ?? 0) * 255).toString(16).padStart(2, "0")}${Math.round((c["g"] ?? 0) * 255).toString(16).padStart(2, "0")}${Math.round((c["b"] ?? 0) * 255).toString(16).padStart(2, "0")}`.toUpperCase();
-          return {
-            ruleId: rawValueDef.id,
-            subType: "color" as const,
-            nodeId: node.id,
-            nodePath,
-            ...rawValueMsg.color(node.name, hex),
-          };
+      if (!hasFillColorVar) {
+        for (const fill of node.fills) {
+          const fillObj = fill as Record<string, unknown>;
+          if (fillObj["type"] === "SOLID" && fillObj["color"]) {
+            const c = fillObj["color"] as Record<string, number>;
+            const hex = `#${Math.round((c["r"] ?? 0) * 255).toString(16).padStart(2, "0")}${Math.round((c["g"] ?? 0) * 255).toString(16).padStart(2, "0")}${Math.round((c["b"] ?? 0) * 255).toString(16).padStart(2, "0")}`.toUpperCase();
+            return {
+              ruleId: rawValueDef.id,
+              subType: "color" as const,
+              nodeId: node.id,
+              nodePath,
+              ...rawValueMsg.color(node.name, hex),
+            };
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Closes the full set of raw-value false-positive paths reported in #583:

1. **Path B fill bindings** — `rawValueCheck` now recognizes variables bound directly on a fill (`fills[i].boundVariables.color`), not just node-level `node.boundVariables.fills`. Checked per fill, so a raw fill next to a bound one is still flagged.
2. **Plugin `styles` map missing (root cause of the reported TEXT font false positive)** — the plugin never serialized `fillStyleId`/`strokeStyleId`/`effectStyleId`/`textStyleId`, so `hasStyleReference()` was always false in the plugin channel and every style-backed fill/text/effect was flagged as raw. The plugin now emits a REST-style `node.styles` map.
3. **Shadow bindings ignored** — the shadow check now respects `node.boundVariables.effects` (Path A) and per-effect `boundVariables` (Path B). Effect `boundVariables` serialization was added in the plugin to feed this.
4. **Plugin proxy serialization** — `boundVariables` on fill/stroke/effect objects is a non-enumerable getter on Figma proxy objects, so spread drops it; it is now copied explicitly (same pattern as PR #580).

Also includes develop-pipeline infra fixes (fnm-resolved pnpm in non-interactive shells).

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (1313 tests)
- [x] `pnpm build` passes
- [x] `scripts/build-plugin.sh` builds; `tsc --noEmit` clean in `app/figma-plugin`

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)