### PR TITLE
fix: raw-value false positives — gap Auto (space-between) and library variable paint bindings

### DIFF
--- a/app/figma-plugin/src/main.ts
+++ b/app/figma-plugin/src/main.ts
@@ -61,6 +61,55 @@ function hasEffects(
   return "effects" in node;
 }
 
+// Bindable fields on Paint / Effect sub-objects (Path B bindings).
+const PAINT_BV_KEYS = ["color"] as const;
+const EFFECT_BV_KEYS = ["color", "radius", "spread", "offsetX", "offsetY"] as const;
+
+// Serialize a Paint/Effect proxy to a plain object, preserving boundVariables.
+// Two proxy quirks force the explicit handling (same root cause as the
+// node-level extraction below):
+// 1. boundVariables is a non-enumerable getter, so spread drops it.
+// 2. The boundVariables proxy only enumerates LOCAL variables via ownKeys —
+//    JSON.stringify silently drops library variable keys, so each known key
+//    must be read via direct property access.
+function serializeSubObject(
+  obj: unknown,
+  bvKeys: readonly string[],
+  label: string
+): Record<string, unknown> {
+  const plain: Record<string, unknown> = { ...(obj as object) };
+  const bv = (obj as { boundVariables?: unknown }).boundVariables;
+  if (bv !== undefined && bv !== null) {
+    const extracted: Record<string, unknown> = {};
+    for (const key of bvKeys) {
+      try {
+        const val = (bv as Record<string, unknown>)[key];
+        if (val !== undefined) {
+          extracted[key] = JSON.parse(JSON.stringify(val));
+        }
+      } catch (e) {
+        console.warn(`[canicode] ${label}.boundVariables["${key}"] not serializable:`, e);
+      }
+    }
+    // Catch any enumerable keys outside the known list (future-proofing)
+    try {
+      for (const key of Object.keys(bv as object)) {
+        if (extracted[key] !== undefined) continue;
+        const val = (bv as Record<string, unknown>)[key];
+        if (val !== undefined) {
+          extracted[key] = JSON.parse(JSON.stringify(val));
+        }
+      }
+    } catch (e) {
+      console.warn(`[canicode] ${label}.boundVariables enumeration failed:`, e);
+    }
+    if (Object.keys(extracted).length > 0) {
+      plain["boundVariables"] = extracted;
+    }
+  }
+  return plain;
+}
+
 // ---- AnalysisNode shape (matches src/contracts/figma-node.ts) ----
 
 interface AnalysisNode {
@@ -325,50 +374,14 @@ async function transformPluginNode(node: SceneNode): Promise<AnalysisNode> {
   if (hasFills(node)) {
     const fills = node.fills;
     if (Array.isArray(fills)) {
-      result.fills = fills.map((f) => {
-        const plain: Record<string, unknown> = { ...f };
-        // Figma Paint proxy objects expose boundVariables as a non-enumerable
-        // getter, so spread silently drops it. Copy it explicitly so that
-        // library variable bindings on individual fills survive serialization.
-        const fillBV = (f as unknown as { boundVariables?: unknown }).boundVariables;
-        if (fillBV !== undefined) {
-          try {
-            plain["boundVariables"] = JSON.parse(JSON.stringify(fillBV));
-          } catch (e) {
-            console.warn("[canicode] fill.boundVariables not serializable:", e);
-          }
-        }
-        return plain;
-      });
+      result.fills = fills.map((f) => serializeSubObject(f, PAINT_BV_KEYS, "fill"));
     }
   }
   if (hasStrokes(node)) {
-    result.strokes = node.strokes.map((s) => {
-      const plain: Record<string, unknown> = { ...s };
-      const bv = (s as unknown as { boundVariables?: unknown }).boundVariables;
-      if (bv !== undefined) {
-        try {
-          plain["boundVariables"] = JSON.parse(JSON.stringify(bv));
-        } catch (e) {
-          console.warn("[canicode] stroke.boundVariables not serializable:", e);
-        }
-      }
-      return plain;
-    });
+    result.strokes = node.strokes.map((s) => serializeSubObject(s, PAINT_BV_KEYS, "stroke"));
   }
   if (hasEffects(node)) {
-    result.effects = node.effects.map((effect) => {
-      const plain: Record<string, unknown> = { ...effect };
-      const bv = (effect as unknown as { boundVariables?: unknown }).boundVariables;
-      if (bv !== undefined) {
-        try {
-          plain["boundVariables"] = JSON.parse(JSON.stringify(bv));
-        } catch (e) {
-          console.warn("[canicode] effect.boundVariables not serializable:", e);
-        }
-      }
-      return plain;
-    });
+    result.effects = node.effects.map((effect) => serializeSubObject(effect, EFFECT_BV_KEYS, "effect"));
   }
 
   // Corner radius

--- a/src/core/rules/token/index.test.ts
+++ b/src/core/rules/token/index.test.ts
@@ -132,6 +132,43 @@ describe("raw-value", () => {
       expect(rawValue.check(node, makeContext())).toBeNull();
     });
   });
+
+  describe("gap Auto (space-between)", () => {
+    it("does not flag the stale itemSpacing when gap is Auto", () => {
+      const node = makeNode({
+        type: "INSTANCE",
+        layoutMode: "HORIZONTAL",
+        primaryAxisAlignItems: "SPACE_BETWEEN",
+        itemSpacing: 24,
+      });
+      expect(rawValue.check(node, makeContext())).toBeNull();
+    });
+
+    it("still flags a raw itemSpacing when gap is a fixed number", () => {
+      const node = makeNode({
+        type: "FRAME",
+        layoutMode: "HORIZONTAL",
+        primaryAxisAlignItems: "MIN",
+        itemSpacing: 24,
+      });
+      const result = rawValue.check(node, makeContext());
+      expect(result?.ruleId).toBe("raw-value");
+      expect(result?.subType).toBe("spacing");
+    });
+
+    it("still flags raw padding on a gap-Auto node", () => {
+      const node = makeNode({
+        type: "FRAME",
+        layoutMode: "HORIZONTAL",
+        primaryAxisAlignItems: "SPACE_BETWEEN",
+        itemSpacing: 24,
+        paddingLeft: 12,
+      });
+      const result = rawValue.check(node, makeContext());
+      expect(result?.ruleId).toBe("raw-value");
+      expect(result?.subType).toBe("spacing");
+    });
+  });
 });
 
 describe("irregular-spacing", () => {
@@ -142,6 +179,11 @@ describe("irregular-spacing", () => {
       expect(result).not.toBeNull();
       expect(result?.ruleId).toBe("irregular-spacing");
       expect(result?.subType).toBe("padding");
+    });
+
+    it("does not flag off-grid itemSpacing when gap is Auto (space-between)", () => {
+      const node = makeNode({ itemSpacing: 7, primaryAxisAlignItems: "SPACE_BETWEEN" });
+      expect(irregularSpacing.check(node, makeContext())).toBeNull();
     });
 
     it("flags off-grid itemSpacing", () => {

--- a/src/core/rules/token/index.ts
+++ b/src/core/rules/token/index.ts
@@ -119,6 +119,9 @@ const rawValueCheck: RuleCheckFn = (node, context) => {
   // Check 5: Raw spacing (padding/gap without variable binding)
   const spacingKeys = ["paddingLeft", "paddingRight", "paddingTop", "paddingBottom", "itemSpacing"] as const;
   for (const key of spacingKeys) {
+    // Gap set to "Auto" (space-between): Figma keeps the stale itemSpacing
+    // number in the API but the layout engine ignores it — not a raw value
+    if (key === "itemSpacing" && node.primaryAxisAlignItems === "SPACE_BETWEEN") continue;
     const value = node[key];
     if (value !== undefined && value > 0 && !hasBoundVariable(node, key)) {
       const label = key === "itemSpacing" ? "gap" : key.replace("padding", "padding-").toLowerCase();
@@ -162,7 +165,8 @@ const irregularSpacingCheck: RuleCheckFn = (node, context, options) => {
     const v = node[key];
     if (v !== undefined && v > 0) spacingEntries.push({ key, value: v, subType: "padding" });
   }
-  if (node.itemSpacing !== undefined && node.itemSpacing > 0) {
+  // Gap "Auto" (space-between) leaves a stale itemSpacing value the layout ignores
+  if (node.itemSpacing !== undefined && node.itemSpacing > 0 && node.primaryAxisAlignItems !== "SPACE_BETWEEN") {
     spacingEntries.push({ key: "itemSpacing", value: node.itemSpacing, subType: "gap" });
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #584. Two remaining raw-value false-positive sources found while debugging the production report:

### 1. Gap "Auto" (space-between) flagged as raw gap — rules, all channels

When a designer sets gap to **Auto**, Figma keeps the stale numeric `itemSpacing` in the API (`itemSpacing: 24`) while the layout engine ignores it (`primaryAxisAlignItems: "SPACE_BETWEEN"`). Both `raw-value` (Check 5) and `irregular-spacing` flagged that stale number.

Confirmed on the production node (`GNB` instance: `itemSpacing 24`, `SPACE_BETWEEN`, no binding — panel shows "Auto"). Both rules now skip `itemSpacing` when `primaryAxisAlignItems === "SPACE_BETWEEN"`; padding checks unchanged.

### 2. Library variable bindings dropped at paint level — plugin channel

The `boundVariables` proxy only enumerates **local** variables via `ownKeys`, so `JSON.parse(JSON.stringify(...))` silently dropped **library** variable bindings on `fills[i]`/`strokes[i]`/`effects[i]` (same root cause as #580, which fixed node-level only). Paint/effect `boundVariables` are now extracted via explicit key access (`color` for paints; `color/radius/spread/offsetX/offsetY` for effects) with an enumeration fallback for unknown keys.

### Verification

- Live reproduction built via Figma MCP: library file with a slot component (gap + fill bound to published library variables) consumed as an instance in a second file — analyzed clean with the real plugin build, while deliberately-raw fills in the same fixture were still flagged (true positives preserved).
- Slot scenarios (component slot, instance mirror, freeform edit, variable override, instance-in-slot) all verified clean — slots themselves were not a factor.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test:run` passes (1317 tests, 4 new)
- [x] `scripts/build-plugin.sh` builds; new serializer verified in dist output
- [x] Production file re-analysis confirms GNB gap warning resolved (user-verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)