### PR TITLE
chore: release v0.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canicode",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "mcpName": "io.github.let-sunny/canicode",
   "description": "Lint Figma designs for AI code-gen and roundtrip the answers back into the file. CLI + MCP server.",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/let-sunny/canicode",
     "source": "github"
   },
-  "version": "0.12.3",
+  "version": "0.12.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "canicode",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Version bump for the raw-value false-positive fix release.

Included since v0.12.3:
- #584 — raw-value false positives: property-level (Path B) variable bindings, plugin `styles` map serialization, shadow variable bindings
- #585 — gap "Auto" (space-between) stale itemSpacing skip, library variable paint-level serialization

## Release steps

- [x] Version bump 0.12.3 → 0.12.4
- [ ] Merge to main
- [ ] Tag `v0.12.4` on the merged commit → CI publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)