### PR TITLE
feat(plugin): copy-as-prompt button — deterministic fix prompt for Figma AI agent

### DIFF
--- a/.claude/docs/ARCHITECTURE.md
+++ b/.claude/docs/ARCHITECTURE.md
@@ -47,6 +47,9 @@
 - Source: `app/figma-plugin/src/`
 - Build: `pnpm build:plugin` → `app/figma-plugin/dist/` (gitignored)
 - Shared UI from `app/shared/` inlined at build time
+- Copy-as-prompt (#587): "Copy fix prompt" button on the report opens a modal with a deterministic fix prompt built by `buildFixPrompt` (`src/core/fix-prompt/`, pure templating — no LLM call). Flow: analyze → copy prompt → paste into Figma's native AI agent (which applies fixes / asks gotcha questions and records answers as canicode-format annotations) → re-analyze to verify. This is the no-MCP-access counterpart of `/canicode-roundtrip`; fix execution is owned by the host agent per ADR-013.
+- The prompt always contains the entire current report — stateless, no chunking; re-analysis regenerates the remaining prompt. A selection-size warning (node count ≥ `SELECTION_NODE_WARNING_THRESHOLD`, 1000, in `src/core/ui-constants.ts`) shows inline in the modal but never blocks.
+- The prompt's annotation-format section mirrors the roundtrip read/write contract (`labelMarkdown` body ending with the `— *<ruleId>*` footer, category `canicode:gotcha`) so annotated gotchas are recognized on re-analysis; plugin-side annotation readback is a follow-up issue.
 
 ### CLI Commands (User-Facing)
 

--- a/app/figma-plugin/src/ui.template.html
+++ b/app/figma-plugin/src/ui.template.html
@@ -33,6 +33,23 @@
 
   </div>
 
+  <!-- Fix prompt modal (#587) — read-only textarea doubles as a manual
+       select-copy fallback for Figma's plugin-iframe clipboard restrictions -->
+  <div id="fixprompt-overlay" class="fixprompt-overlay" style="display:none" onclick="if (event.target === this) closeFixPromptModal()">
+    <div class="fixprompt-panel">
+      <div class="fixprompt-header">
+        <strong>Fix prompt for Figma's AI agent</strong>
+        <button class="fixprompt-close" onclick="closeFixPromptModal()" aria-label="Close">&times;</button>
+      </div>
+      <p class="fixprompt-hint">Paste this into Figma's AI agent, let it apply the fixes, then re-run Analyze Selection to verify.</p>
+      <div id="fixprompt-warning" class="fixprompt-warning" style="display:none"></div>
+      <textarea id="fixprompt-text" class="fixprompt-text" readonly></textarea>
+      <div class="fixprompt-actions">
+        <button class="btn btn-primary" id="fixprompt-copy" onclick="copyFixPrompt()">Copy</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Monitoring: lightweight inline PostHog + Sentry via fetch -->
   <script>
     (function() {
@@ -130,13 +147,26 @@
     }
 
     // ---- Render results via shared renderReportBody() ----
+    // Latest analysis kept for the fix-prompt modal. Stateless across
+    // analyses — each result fully replaces the previous one (#587).
+    var _lastFile = null;
+    var _lastResult = null;
+
     function showResults(file, result, scores, skipped) {
       document.getElementById('empty-state').style.display = 'none';
       document.getElementById('loading').style.display = 'none';
       document.getElementById('error').style.display = 'none';
 
+      _lastFile = file;
+      _lastResult = result;
+
       var el = document.getElementById('results');
       var bannerHtml = renderSkippedBanner(skipped);
+      if (result.issues.length > 0) {
+        bannerHtml = '<div class="fixprompt-toolbar">' +
+          '<button class="btn" onclick="openFixPromptModal()">Copy fix prompt</button>' +
+          '</div>' + bannerHtml;
+      }
       el.innerHTML = bannerHtml + CanICode.renderReportBody({
         fileName: file.name,
         fileKey: file.fileKey,
@@ -163,6 +193,57 @@
         '<strong>' + skipped.length + ' node(s) skipped</strong> — their parent component sets have errors in Figma. Related rule scores may be incomplete.' +
         '<details><summary>Show list</summary><ul>' + items + '</ul></details>' +
         '</div>';
+    }
+
+    // ---- Fix prompt modal (#587) ----
+    function openFixPromptModal() {
+      if (!_lastResult || !_lastFile) return;
+
+      var warningEl = document.getElementById('fixprompt-warning');
+      var nodeCount = _lastResult.nodeCount || 0;
+      if (nodeCount >= CanICode.SELECTION_NODE_WARNING_THRESHOLD) {
+        warningEl.textContent = 'Large selection (' + nodeCount + ' nodes) — the agent works better on one section at a time; consider re-running on a smaller selection.';
+        warningEl.style.display = 'block';
+      } else {
+        warningEl.style.display = 'none';
+      }
+
+      document.getElementById('fixprompt-text').value =
+        CanICode.buildFixPrompt(_lastResult.issues, { fileName: _lastFile.name });
+      var copyBtn = document.getElementById('fixprompt-copy');
+      copyBtn.textContent = 'Copy';
+      document.getElementById('fixprompt-overlay').style.display = 'flex';
+    }
+
+    function closeFixPromptModal() {
+      document.getElementById('fixprompt-overlay').style.display = 'none';
+    }
+
+    function copyFixPrompt() {
+      var textarea = document.getElementById('fixprompt-text');
+      var onCopied = function() {
+        var copyBtn = document.getElementById('fixprompt-copy');
+        copyBtn.textContent = 'Copied';
+        setTimeout(function() { copyBtn.textContent = 'Copy'; }, 1500);
+        window._trackEvent('cic_fix_prompt_copied', {
+          issueCount: _lastResult ? _lastResult.issues.length : 0,
+          nodeCount: _lastResult ? _lastResult.nodeCount : 0
+        });
+      };
+      // Clipboard API may reject inside Figma's plugin iframe — fall back to
+      // select + execCommand; the read-only textarea remains a manual fallback.
+      var fallbackCopy = function() {
+        textarea.focus();
+        textarea.select();
+        try {
+          if (document.execCommand('copy')) onCopied();
+        } catch (e) {}
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(textarea.value).then(onCopied, fallbackCopy);
+      } else {
+        fallbackCopy();
+      }
     }
 
     // ---- Focus node in Figma — intercept all [data-node-id] clicks ----

--- a/app/shared/styles.css
+++ b/app/shared/styles.css
@@ -702,6 +702,84 @@ body {
   text-decoration: underline;
 }
 
+/* ---- Fix prompt modal (fixprompt-*) — Figma plugin only (#587) ---- */
+.fixprompt-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16px;
+}
+.fixprompt-toolbar .btn { flex: 0 0 auto; }
+.fixprompt-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  z-index: 100;
+}
+.fixprompt-panel {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+  padding: 16px;
+  width: 100%;
+  max-width: 480px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.fixprompt-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+}
+.fixprompt-close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  line-height: 1;
+  color: var(--fg-muted);
+  cursor: pointer;
+  padding: 2px 6px;
+}
+.fixprompt-close:hover { color: var(--fg); }
+.fixprompt-hint {
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.fixprompt-warning {
+  background: var(--amber-bg);
+  color: #92400e;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  border: 1px solid rgba(245,158,11,0.2);
+}
+.fixprompt-text {
+  width: 100%;
+  min-height: 200px;
+  flex: 1;
+  resize: vertical;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--fg);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px;
+}
+.fixprompt-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+.fixprompt-actions .btn { flex: 0 0 auto; padding: 8px 16px; }
+
 /* ---- Results visibility ---- */
 #results { display: none; }
 #results.visible { display: block; }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -22,6 +22,7 @@ export {
   GAUGE_C,
   CATEGORY_DESCRIPTIONS,
   SEVERITY_ORDER,
+  SELECTION_NODE_WARNING_THRESHOLD,
 } from "./core/ui-constants.js";
 export {
   gaugeColor,
@@ -36,6 +37,10 @@ export {
 // Report rendering (shared with web/plugin)
 export { renderReportBody, initReportInteractions } from "./core/report-html/render.js";
 export type { ReportData } from "./core/report-html/render.js";
+
+// Fix prompt for the host design agent (#587, plugin copy-as-prompt)
+export { buildFixPrompt, ANNOTATION_FORMAT_SPEC } from "./core/fix-prompt/build-fix-prompt.js";
+export type { BuildFixPromptOptions } from "./core/fix-prompt/build-fix-prompt.js";
 
 // Import rules to register them with the global registry
 import "./core/rules/index.js";

--- a/src/core/fix-prompt/build-fix-prompt.test.ts
+++ b/src/core/fix-prompt/build-fix-prompt.test.ts
@@ -1,0 +1,120 @@
+import type { Category } from "../contracts/category.js";
+import type { RuleId, RuleViolation } from "../contracts/rule.js";
+import type { AnalysisIssue } from "../engine/rule-engine.js";
+import { RULE_ID_CATEGORY } from "../rules/rule-config.js";
+import { ANNOTATION_FORMAT_SPEC, buildFixPrompt } from "./build-fix-prompt.js";
+
+function makeIssue(
+  ruleId: string,
+  overrides: Partial<AnalysisIssue> & { violation?: Partial<RuleViolation> } = {}
+): AnalysisIssue {
+  const category: Category = RULE_ID_CATEGORY[ruleId as RuleId] ?? "semantic";
+  const { violation: violationOverrides, ...issueOverrides } = overrides;
+  return {
+    violation: {
+      ruleId,
+      nodeId: "12:34",
+      nodePath: `Page 1 > Section > Node-${ruleId}`,
+      message: `"Node-${ruleId}" violates ${ruleId}`,
+      suggestion: `Fix ${ruleId}`,
+      ...violationOverrides,
+    },
+    rule: {
+      definition: {
+        id: ruleId,
+        name: ruleId,
+        category,
+        why: "test",
+        impact: "test",
+        fix: "test",
+      },
+      check: () => null,
+    },
+    config: { severity: "risk", score: -4, enabled: true },
+    depth: 1,
+    maxDepth: 3,
+    calculatedScore: -4,
+    ...issueOverrides,
+  };
+}
+
+describe("buildFixPrompt", () => {
+  it("returns an empty string for no issues", () => {
+    expect(buildFixPrompt([])).toBe("");
+  });
+
+  it("omits the gotcha section and annotation spec when only violations exist", () => {
+    const prompt = buildFixPrompt([makeIssue("no-auto-layout")]);
+    expect(prompt).toContain("## Fixes to apply");
+    expect(prompt).not.toContain("## Missing context");
+    expect(prompt).not.toContain("## Annotation format");
+  });
+
+  it("includes the annotation spec when gotcha issues exist", () => {
+    const prompt = buildFixPrompt([makeIssue("missing-interaction-state")]);
+    expect(prompt).toContain("## Missing context — ask the user");
+    expect(prompt).toContain(ANNOTATION_FORMAT_SPEC);
+    expect(prompt).not.toContain("## Fixes to apply");
+  });
+
+  it("filters acknowledged issues", () => {
+    const prompt = buildFixPrompt([
+      makeIssue("missing-interaction-state", { acknowledged: true }),
+      makeIssue("no-auto-layout"),
+    ]);
+    expect(prompt).not.toContain("missing-interaction-state");
+    expect(prompt).toContain("## Fixes to apply");
+    expect(prompt).not.toContain("## Annotation format");
+  });
+
+  it("returns an empty string when every issue is acknowledged", () => {
+    const prompt = buildFixPrompt([
+      makeIssue("no-auto-layout", { acknowledged: true }),
+    ]);
+    expect(prompt).toBe("");
+  });
+
+  it("sorts structural fixes first regardless of input order", () => {
+    const prompt = buildFixPrompt([
+      makeIssue("raw-value"),
+      makeIssue("no-auto-layout"),
+    ]);
+    const structuralIndex = prompt.indexOf("no-auto-layout");
+    const tokenIndex = prompt.indexOf("raw-value");
+    expect(structuralIndex).toBeGreaterThan(-1);
+    expect(tokenIndex).toBeGreaterThan(-1);
+    expect(structuralIndex).toBeLessThan(tokenIndex);
+  });
+
+  it("keeps document order within the same rule", () => {
+    const prompt = buildFixPrompt([
+      makeIssue("no-auto-layout", { violation: { nodeId: "1:1", message: "first node" } }),
+      makeIssue("no-auto-layout", { violation: { nodeId: "2:2", message: "second node" } }),
+    ]);
+    expect(prompt.indexOf("first node")).toBeLessThan(prompt.indexOf("second node"));
+  });
+
+  it("includes the file name when provided", () => {
+    const prompt = buildFixPrompt([makeIssue("no-auto-layout")], {
+      fileName: "My Design",
+    });
+    expect(prompt).toContain('"My Design"');
+  });
+
+  it("gotcha items carry the rule id for the annotation footer", () => {
+    const prompt = buildFixPrompt([makeIssue("missing-prototype")]);
+    expect(prompt).toContain("(rule id: missing-prototype)");
+  });
+});
+
+describe("ANNOTATION_FORMAT_SPEC", () => {
+  // These literals are the roundtrip read/write contract — keep in sync with
+  // upsertCanicodeAnnotation (annotations.ts) and FOOTER_RE
+  // (read-acknowledgments.ts).
+  it("specifies the footer convention and gotcha category", () => {
+    expect(ANNOTATION_FORMAT_SPEC).toContain("— *");
+    expect(ANNOTATION_FORMAT_SPEC).toContain("canicode:gotcha");
+    expect(ANNOTATION_FORMAT_SPEC).toContain("labelMarkdown");
+    expect(ANNOTATION_FORMAT_SPEC).toContain("addAnnotationCategoryAsync");
+  });
+});

--- a/src/core/fix-prompt/build-fix-prompt.ts
+++ b/src/core/fix-prompt/build-fix-prompt.ts
@@ -1,0 +1,126 @@
+/**
+ * Deterministic fix-prompt builder (#587).
+ *
+ * Assembles the full "paste into the host design agent" prompt from a
+ * report's issues — pure templating, no LLM call, no Node/DOM dependencies
+ * (this module is exported through src/browser.ts and runs inside the Figma
+ * plugin iframe). The prompt always contains the entire current report:
+ * the plugin stays stateless, and re-analysis after the agent's fixes
+ * naturally regenerates the remaining prompt.
+ *
+ * Per ADR-013 the prompt only directs the host agent; canicode does not
+ * execute fixes.
+ */
+
+import { CATEGORIES, type Category } from "../contracts/category.js";
+import type { RuleId } from "../contracts/rule.js";
+import type { AnalysisIssue } from "../engine/rule-engine.js";
+import { getFixPromptLine } from "../rules/fix-prompt-templates.js";
+import { getRulePurpose, RULE_ID_CATEGORY } from "../rules/rule-config.js";
+
+/**
+ * Annotation convention the agent must follow when recording gotcha answers.
+ * This block is the load-bearing piece of the verify loop: it must mirror
+ * EXACTLY what upsertCanicodeAnnotation writes and
+ * extractAcknowledgmentsFromNode reads (src/core/roundtrip/annotations.ts,
+ * read-acknowledgments.ts) — otherwise re-analysis cannot detect the gotcha
+ * as resolved. Exported so tests can assert the footer/category literals
+ * stay in sync with the roundtrip contract.
+ */
+export const ANNOTATION_FORMAT_SPEC = `## Annotation format
+
+When recording an answer, add a Figma annotation to the node (\`node.annotations\`) following this exact convention — CanICode re-analysis reads it to mark the issue as resolved:
+
+- One annotation entry per answer, with the body set via \`labelMarkdown\` ONLY — never set both \`label\` and \`labelMarkdown\`.
+- The body MUST end with the footer \`— *<rule-id>*\` (em-dash, space, rule id in italics) on its own line, e.g. \`— *missing-interaction-state*\`. Use the rule id given in parentheses for each item above.
+- Set the entry's \`categoryId\` to the annotation category labeled \`canicode:gotcha\`. If that category does not exist yet, create it once with \`figma.annotations.addAnnotationCategoryAsync({ label: "canicode:gotcha", color: "blue" })\`. If you cannot create or assign categories, keep the footer anyway — footer-only annotations are still recognized.
+- If the node already has an annotation whose body ends with the same \`— *<rule-id>*\` footer, REPLACE that entry instead of adding a duplicate.`;
+
+export interface BuildFixPromptOptions {
+  fileName?: string;
+}
+
+/**
+ * Deterministic sort for fix instructions: structural fixes first.
+ * CATEGORIES order puts pixel-critical (no-auto-layout etc.) ahead of
+ * everything else — structural changes can invalidate other findings, so
+ * the agent should apply them first. Ties break by rule id, then by the
+ * original (document) order. No new config knob.
+ */
+function violationSortKey(issue: AnalysisIssue): [number, string] {
+  const category: Category | undefined =
+    RULE_ID_CATEGORY[issue.violation.ruleId as RuleId];
+  const categoryIndex = category ? CATEGORIES.indexOf(category) : CATEGORIES.length;
+  return [categoryIndex, issue.violation.ruleId];
+}
+
+function numbered(lines: string[]): string {
+  return lines.map((line, i) => `${i + 1}. ${line}`).join("\n");
+}
+
+/**
+ * Build the full fix prompt from a report's issues.
+ *
+ * - Acknowledged issues (already annotated, flagged by the rule engine) are
+ *   dropped so regenerated prompts shrink as the agent works.
+ * - Issues split by rule purpose (ADR-017): violations become imperative fix
+ *   instructions, info-collection rules become ask-the-user instructions.
+ * - The annotation-format spec is included only when gotcha items exist.
+ *
+ * Returns an empty string when there is nothing to do.
+ */
+export function buildFixPrompt(
+  issues: AnalysisIssue[],
+  opts: BuildFixPromptOptions = {}
+): string {
+  const active = issues.filter((issue) => issue.acknowledged !== true);
+
+  const violations = active
+    .map((issue, index) => ({ issue, index }))
+    .filter(({ issue }) => getRulePurpose(issue.violation.ruleId) === "violation")
+    .sort((a, b) => {
+      const [catA, ruleA] = violationSortKey(a.issue);
+      const [catB, ruleB] = violationSortKey(b.issue);
+      if (catA !== catB) return catA - catB;
+      if (ruleA !== ruleB) return ruleA < ruleB ? -1 : 1;
+      return a.index - b.index;
+    })
+    .map(({ issue }) => issue);
+
+  const gotchas = active.filter(
+    (issue) => getRulePurpose(issue.violation.ruleId) === "info-collection"
+  );
+
+  if (violations.length === 0 && gotchas.length === 0) return "";
+
+  const fileRef = opts.fileName ? ` "${opts.fileName}"` : "";
+  const sections: string[] = [
+    `You are operating on the currently open Figma file${fileRef}. The CanICode plugin analyzed the current selection and found the items below. Apply the fixes and collect the missing context exactly as instructed. Node ids are given in parentheses — use them to locate each node.`,
+  ];
+
+  if (violations.length > 0) {
+    sections.push(
+      `## Fixes to apply\n\n${numbered(
+        violations.map((issue) => getFixPromptLine(issue.violation))
+      )}`
+    );
+  }
+
+  if (gotchas.length > 0) {
+    sections.push(
+      `## Missing context — ask the user\n\n${numbered(
+        gotchas.map(
+          (issue) =>
+            `${getFixPromptLine(issue.violation)} (rule id: ${issue.violation.ruleId})`
+        )
+      )}`
+    );
+    sections.push(ANNOTATION_FORMAT_SPEC);
+  }
+
+  sections.push(
+    "When you are done, the user will re-run the CanICode plugin analysis on the same selection to verify the fixes."
+  );
+
+  return sections.join("\n\n");
+}

--- a/src/core/fix-prompt/build-fix-prompt.ts
+++ b/src/core/fix-prompt/build-fix-prompt.ts
@@ -33,7 +33,7 @@ When recording an answer, add a Figma annotation to the node (\`node.annotations
 
 - One annotation entry per answer, with the body set via \`labelMarkdown\` ONLY — never set both \`label\` and \`labelMarkdown\`.
 - The body MUST end with the footer \`— *<rule-id>*\` (em-dash, space, rule id in italics) on its own line, e.g. \`— *missing-interaction-state*\`. Use the rule id given in parentheses for each item above.
-- Set the entry's \`categoryId\` to the annotation category labeled \`canicode:gotcha\`. If that category does not exist yet, create it once with \`figma.annotations.addAnnotationCategoryAsync({ label: "canicode:gotcha", color: "blue" })\`. If you cannot create or assign categories, keep the footer anyway — footer-only annotations are still recognized.
+- Set the entry's \`categoryId\` to the annotation category labeled \`canicode:gotcha\`. If that category does not exist yet, create it once with \`figma.annotations.addAnnotationCategoryAsync({ label: "canicode:gotcha", color: "blue" })\`. If you cannot create or assign categories, keep the footer anyway — the footer is what ties the annotation to the rule.
 - If the node already has an annotation whose body ends with the same \`— *<rule-id>*\` footer, REPLACE that entry instead of adding a duplicate.`;
 
 export interface BuildFixPromptOptions {

--- a/src/core/rules/fix-prompt-templates.test.ts
+++ b/src/core/rules/fix-prompt-templates.test.ts
@@ -1,0 +1,78 @@
+import type { RuleId, RuleViolation } from "../contracts/rule.js";
+import {
+  FIX_PROMPT_TEMPLATES,
+  fallbackFixPromptLine,
+  getFixPromptLine,
+  violationNodeName,
+} from "./fix-prompt-templates.js";
+import { RULE_PURPOSE } from "./rule-config.js";
+
+function makeViolation(ruleId: string): RuleViolation {
+  return {
+    ruleId,
+    nodeId: "12:34",
+    nodePath: "Page 1 > Section > Card",
+    message: `"Card" has a problem detected by ${ruleId}`,
+    suggestion: "Fix the problem",
+  };
+}
+
+describe("getFixPromptLine", () => {
+  const allRuleIds = Object.keys(RULE_PURPOSE) as RuleId[];
+
+  it("produces a non-empty line for every rule id", () => {
+    for (const ruleId of allRuleIds) {
+      const line = getFixPromptLine(makeViolation(ruleId));
+      expect(line.length, ruleId).toBeGreaterThan(0);
+      expect(line, ruleId).toContain("12:34");
+    }
+  });
+
+  it("has a registry template for every rule id", () => {
+    for (const ruleId of allRuleIds) {
+      expect(FIX_PROMPT_TEMPLATES[ruleId], ruleId).toBeTypeOf("function");
+    }
+  });
+
+  it("info-collection rules instruct the agent to ask the user and annotate", () => {
+    const gotchaRuleIds = allRuleIds.filter(
+      (id) => RULE_PURPOSE[id] === "info-collection"
+    );
+    expect(gotchaRuleIds.length).toBeGreaterThan(0);
+    for (const ruleId of gotchaRuleIds) {
+      const line = getFixPromptLine(makeViolation(ruleId));
+      expect(line, ruleId).toContain("Ask the user");
+      expect(line, ruleId).toContain("annotation");
+      // The agent phrases the question itself — no authored question text.
+      expect(line, ruleId).not.toContain("?");
+    }
+  });
+
+  it("violation rules produce an imperative fix line with message and suggestion", () => {
+    const v = makeViolation("no-auto-layout");
+    const line = getFixPromptLine(v);
+    expect(line).toContain(v.message);
+    expect(line).toContain(v.suggestion);
+    expect(line).not.toContain("Ask the user");
+  });
+
+  it("falls back for unknown rule ids without crashing", () => {
+    const v = makeViolation("some-future-rule");
+    const line = getFixPromptLine(v);
+    expect(line).toBe(fallbackFixPromptLine(v));
+    expect(line).toContain(v.message);
+    expect(line).toContain(v.suggestion);
+    expect(line).toContain("(node 12:34)");
+  });
+});
+
+describe("violationNodeName", () => {
+  it("derives the name from the last nodePath segment", () => {
+    expect(violationNodeName(makeViolation("raw-value"))).toBe("Card");
+  });
+
+  it("falls back to nodeId when nodePath is empty", () => {
+    const v = { ...makeViolation("raw-value"), nodePath: "" };
+    expect(violationNodeName(v)).toBe("12:34");
+  });
+});

--- a/src/core/rules/fix-prompt-templates.ts
+++ b/src/core/rules/fix-prompt-templates.ts
@@ -1,0 +1,105 @@
+/**
+ * Per-rule fix-prompt templates (#587).
+ *
+ * Turns one RuleViolation into one deterministic instruction line for the
+ * copy-as-prompt feature. The lines are pasted into the host design agent
+ * (e.g. Figma's native AI agent) which executes the fixes — canicode only
+ * directs the fix, it never executes (ADR-013).
+ *
+ * Two line shapes, mirroring the rule purpose split (ADR-017):
+ * - violation rules → imperative fix instruction. The centralized
+ *   message/suggestion strings (rule-messages.ts) are already node-specific
+ *   and imperative, so most templates re-frame them with the node id appended.
+ * - info-collection (gotcha) rules → "ask the user" instruction. The agent
+ *   phrases the question itself in designer-friendly words — we deliberately
+ *   do NOT author question text — then records the answer as a canicode
+ *   annotation so re-analysis can detect the gotcha as resolved.
+ */
+
+import type { RuleId, RuleViolation } from "../contracts/rule.js";
+
+/**
+ * Display name for a violation's node. RuleViolation has no nodeName field;
+ * nodePath is the " > "-joined name chain whose last segment is the node's
+ * own name (rule-engine builds it as [...path, node.name]).
+ */
+export function violationNodeName(v: RuleViolation): string {
+  const segments = v.nodePath.split(" > ");
+  const last = segments[segments.length - 1];
+  const trimmed = last?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : v.nodeId;
+}
+
+/**
+ * Generic fallback — covers unknown/future rule ids so the prompt builder
+ * never crashes. message and suggestion are already node-specific.
+ */
+export function fallbackFixPromptLine(v: RuleViolation): string {
+  return `${v.message} — ${v.suggestion} (node ${v.nodeId})`;
+}
+
+/** Imperative fix line for violation rules: message + suggestion + node id. */
+function imperativeFix(v: RuleViolation): string {
+  return `${v.message}. ${v.suggestion} (node ${v.nodeId}).`;
+}
+
+/**
+ * Ask-the-user line for info-collection rules. `missingContext` describes
+ * WHAT is unknown — never an authored question — so the agent phrases the
+ * question itself. The trailing annotation instruction is what closes the
+ * verify loop: re-analysis reads the annotation back (read-acknowledgments.ts).
+ */
+function askUser(v: RuleViolation, missingContext: string): string {
+  return (
+    `${v.message} (node ${v.nodeId}). Ask the user, in your own designer-friendly words, ` +
+    `${missingContext}, then record the answer as an annotation on this node ` +
+    `(see "Annotation format" below).`
+  );
+}
+
+/**
+ * Registry of per-rule template functions. Violation rules share the
+ * imperative shape; info-collection rules (RULE_PURPOSE in rule-config.ts)
+ * get rule-specific missing-context descriptions. Rules absent here fall
+ * back to fallbackFixPromptLine via getFixPromptLine.
+ */
+export const FIX_PROMPT_TEMPLATES: Partial<
+  Record<RuleId, (v: RuleViolation) => string>
+> = {
+  // ── Violation rules — imperative fix instructions ──
+  "no-auto-layout": imperativeFix,
+  "absolute-position-in-auto-layout": imperativeFix,
+  "non-layout-container": imperativeFix,
+  "fixed-size-in-auto-layout": imperativeFix,
+  "missing-component": imperativeFix,
+  "detached-instance": imperativeFix,
+  "variant-structure-mismatch": imperativeFix,
+  "deep-nesting": imperativeFix,
+  "raw-value": imperativeFix,
+  "irregular-spacing": imperativeFix,
+  "non-standard-naming": imperativeFix,
+  "non-semantic-name": imperativeFix,
+  "inconsistent-naming-convention": imperativeFix,
+
+  // ── Info-collection (gotcha) rules — ask the user, then annotate ──
+  "missing-size-constraint": (v) =>
+    askUser(
+      v,
+      "how this element should behave when the screen size changes — stretch with the layout, stay fixed, or respect min/max bounds"
+    ),
+  "missing-interaction-state": (v) =>
+    askUser(v, "what this element should look like in that interaction state"),
+  "missing-prototype": (v) =>
+    askUser(v, "what should happen when the user interacts with this element"),
+  "unmapped-component": (v) =>
+    askUser(
+      v,
+      "whether this component should be mapped to an existing code component, and if so which one"
+    ),
+};
+
+/** Resolve a violation to its prompt line — registry entry or fallback. */
+export function getFixPromptLine(v: RuleViolation): string {
+  const template = FIX_PROMPT_TEMPLATES[v.ruleId as RuleId];
+  return template ? template(v) : fallbackFixPromptLine(v);
+}

--- a/src/core/ui-constants.ts
+++ b/src/core/ui-constants.ts
@@ -33,3 +33,9 @@ export const SEVERITY_ORDER: Severity[] = [
   "suggestion",
   "note",
 ];
+
+// #587: selection size above which the plugin's copy-as-prompt modal shows an
+// inline "scope too big" warning. Keyed on node count, NOT issue count — real
+// designs produce dozens of issues even at proper section scope. Warning only;
+// never blocks.
+export const SELECTION_NODE_WARNING_THRESHOLD = 1000;


### PR DESCRIPTION
## Summary

Add a 'Copy fix prompt' button to the Figma plugin report that opens a modal with a deterministic, fully-templated fix prompt the user pastes into Figma's native AI agent. The prompt is built by a new pure prompt-builder in src/core (so web/CLI can reuse it later): violation-rule issues become imperative fix instructions (structural fixes sorted first), info-collection (gotcha) issues become 'ask the user, then record the answer as an annotation' instructions, plus a single annotation-format spec block that mirrors the exact convention canicode's re-analysis reads (labelMarkdown footer '— *<ruleId>*', category 'canicode:gotcha') so the verify loop can close. A selection-size warning (node count >= 1000, constant in ui-constants.ts) is shown inline; it never blocks. The plugin stays stateless — re-analysis regenerates the remaining prompt. Per ADR-013 the prompt only directs the host agent; canicode does not execute fixes.

## Tasks

- Per-rule fix-prompt template registry
- Prompt builder module + browser exports + threshold constant
- Plugin UI: copy button, prompt modal, selection-size warning
- Document the copy-as-prompt flow in ARCHITECTURE.md

## Self-review

Solid, plan-faithful implementation. The annotation-spec literals were verified against the actual roundtrip read/write code and all match (footer regex, category label/color, labelMarkdown-only, replace-by-footer). The builder is pure, browser-safe, deterministic, and well tested; the plugin UI is template-only and stateless as required. Findings are non-blocking: one overstated claim inside the prompt's annotation spec about footer-only recognition, the documented ARCHITECTURE.md permission-gate bypass that needs human sign-off, and two minor UX suggestions. The PR must stay draft until the manual Figma clipboard/modal check from the test strategy is performed (implementer agrees in knownRisks).
- Verdict: approve
- Errors: 0, Warnings: 2, Total: 5

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm test:run` passes
- [ ] `pnpm build` passes

Closes #587

---
Generated by `scripts/develop.ts` ([#247](https://github.com/let-sunny/canicode/issues/247))